### PR TITLE
Deselection of text when moving/changing resources

### DIFF
--- a/navigator-html-injectables/src/helpers/dom.ts
+++ b/navigator-html-injectables/src/helpers/dom.ts
@@ -15,6 +15,10 @@ export interface ReadiumWindow extends Window {
     };
 }
 
+export function deselect(wnd: Window) {
+    const currentSelection = wnd.getSelection();
+    if(currentSelection) currentSelection.removeAllRanges();
+}
 
 const interactiveTags = [
     "a",

--- a/navigator-html-injectables/src/modules/snapper/ColumnSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ColumnSnapper.ts
@@ -36,9 +36,6 @@ export class ColumnSnapper extends Snapper {
 
     snapOffset(offset: number) {
         const value = offset + (isRTL(this.wnd) ? -1 : 1);
-        /*console.log(this.wnd.document.head.getElementsByTagName("base").item(0)?.href?.split("OPS/")[1])
-        console.log(value, "%", this.wnd.innerWidth, "=", value % this.wnd.innerWidth)
-        console.log("Snap", value, "-", value % this.wnd.innerWidth, "=", value - (value % this.wnd.innerWidth));*/
         return value - (value % this.wnd.innerWidth);
     }
 

--- a/navigator-html-injectables/src/modules/snapper/ColumnSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ColumnSnapper.ts
@@ -6,7 +6,7 @@ import { easeInOutQuad } from "../../helpers/animation";
 import { ModuleName } from "../ModuleLibrary";
 import { Locator, LocatorText } from "@readium/shared/src/publication";
 import { rangeFromLocator } from "../../helpers/locator";
-import { ReadiumWindow, findFirstVisibleLocator } from "../../helpers/dom";
+import { ReadiumWindow, deselect, findFirstVisibleLocator } from "../../helpers/dom";
 
 const COLUMN_SNAPPER_STYLE_ID = "readium-column-snapper-style";
 const SNAP_DURATION = 200; // Milliseconds
@@ -36,6 +36,9 @@ export class ColumnSnapper extends Snapper {
 
     snapOffset(offset: number) {
         const value = offset + (isRTL(this.wnd) ? -1 : 1);
+        /*console.log(this.wnd.document.head.getElementsByTagName("base").item(0)?.href?.split("OPS/")[1])
+        console.log(value, "%", this.wnd.innerWidth, "=", value % this.wnd.innerWidth)
+        console.log("Snap", value, "-", value % this.wnd.innerWidth, "=", value - (value % this.wnd.innerWidth));*/
         return value - (value % this.wnd.innerWidth);
     }
 
@@ -202,8 +205,10 @@ export class ColumnSnapper extends Snapper {
 
     onTouchMove(e: TouchEvent) {
         if(this.touchState === ScrollTouchState.END) return;
-        if(this.touchState === ScrollTouchState.START)
+        if(this.touchState === ScrollTouchState.START) {
             this.touchState = ScrollTouchState.MOVE;
+            deselect(this.wnd);
+        }
         this.endingX = e.touches[0].clientX;
 
         const dro = this.dragOffset();
@@ -308,6 +313,7 @@ export class ColumnSnapper extends Snapper {
                 const offset = documentWidth * position * factor;
                 this.doc().scrollLeft = this.snapOffset(offset);
                 this.reportProgress();
+                deselect(this.wnd);
                 ack(true);
             });
         })
@@ -321,6 +327,7 @@ export class ColumnSnapper extends Snapper {
             this.wnd.requestAnimationFrame(() => {
                 this.doc().scrollLeft = this.snapOffset(element.getBoundingClientRect().left + wnd.scrollX);
                 this.reportProgress();
+                deselect(this.wnd);
                 ack(true);
             });
         });
@@ -339,6 +346,7 @@ export class ColumnSnapper extends Snapper {
             this.wnd.requestAnimationFrame(() => {
                 this.doc().scrollLeft = this.snapOffset(r.getBoundingClientRect().left + wnd.scrollX);
                 this.reportProgress();
+                deselect(this.wnd);
                 ack(true);
             });
         });
@@ -351,6 +359,7 @@ export class ColumnSnapper extends Snapper {
                 if(this.doc().scrollLeft === final) return ack(false);
                 this.doc().scrollLeft = this.snapOffset(final);
                 this.reportProgress();
+                deselect(this.wnd);
                 ack(true);
             });
         })
@@ -360,6 +369,7 @@ export class ColumnSnapper extends Snapper {
                 if(this.doc().scrollLeft === 0) return ack(false);
                 this.doc().scrollLeft = 0;
                 this.reportProgress();
+                deselect(this.wnd);
                 ack(true);
             });
         })
@@ -369,7 +379,10 @@ export class ColumnSnapper extends Snapper {
                 const offset = wnd.scrollX - wnd.innerWidth;
                 const minOffset = isRTL(wnd) ? - (this.cachedScrollWidth - wnd.innerWidth) : 0;
                 const change = scrollToOffset(Math.max(offset, minOffset));
-                if(change) this.reportProgress();
+                if(change) {
+                    this.reportProgress();
+                    deselect(this.wnd);
+                }
                 ack(change);
             });
         });
@@ -379,13 +392,17 @@ export class ColumnSnapper extends Snapper {
                 const offset = wnd.scrollX + wnd.innerWidth;
                 const maxOffset = isRTL(wnd) ? 0 : this.cachedScrollWidth - wnd.innerWidth;
                 const change = scrollToOffset(Math.min(offset, maxOffset));
-                if(change) this.reportProgress();
+                if(change) {
+                    this.reportProgress();
+                    deselect(this.wnd);
+                }
                 ack(change);
             });
         });
 
         comms.register("unfocus", ColumnSnapper.moduleName, (_, ack) => {
             this.snappingCancelled = true;
+            deselect(this.wnd);
             ack(true);
         });
 

--- a/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
@@ -128,6 +128,7 @@ export class ScrollSnapper extends Snapper {
         });
 
         comms.register("unfocus", ScrollSnapper.moduleName, (_, ack) => {
+            deselect(this.wnd);
             ack(true);
         });
 

--- a/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
@@ -1,6 +1,6 @@
 import { Locator, LocatorText } from "@readium/shared/src/publication";
 import { Comms } from "../../comms";
-import { ReadiumWindow, findFirstVisibleLocator } from "../../helpers/dom";
+import { ReadiumWindow, deselect, findFirstVisibleLocator } from "../../helpers/dom";
 import { AnchorObserver, helperCreateAnchorElements, helperRemoveAnchorElements } from '../../helpers/scrollSnapperHelper';
 import { ModuleName } from "../ModuleLibrary";
 import { Snapper } from "./Snapper";
@@ -67,6 +67,7 @@ export class ScrollSnapper extends Snapper {
             this.wnd.requestAnimationFrame(() => {
               this.doc().scrollTop = this.doc().offsetHeight * position;
               this.reportProgress(position);
+              deselect(this.wnd);
               ack(true);
           });
         });
@@ -80,6 +81,7 @@ export class ScrollSnapper extends Snapper {
             this.wnd.requestAnimationFrame(() => {
                 this.doc().scrollTop = element.getBoundingClientRect().top + wnd.scrollY - wnd.innerHeight / 2;
                 this.reportProgress(this.doc().scrollTop / this.doc().offsetHeight);
+                deselect(this.wnd);
                 ack(true);
             });
         });
@@ -98,6 +100,7 @@ export class ScrollSnapper extends Snapper {
             this.wnd.requestAnimationFrame(() => {
                 this.doc().scrollTop = r.getBoundingClientRect().top + wnd.scrollY - wnd.innerHeight / 2;
                 this.reportProgress(this.doc().scrollTop / this.doc().offsetHeight);
+                deselect(this.wnd);
                 ack(true);
             });
         });

--- a/navigator/src/epub/fxl/FXLFrameManager.ts
+++ b/navigator/src/epub/fxl/FXLFrameManager.ts
@@ -151,6 +151,7 @@ export default class FXLFrameManager {
 
     async unload() {
         if(!this.loaded) return;
+        this.deselect();
         this.frame.style.visibility = "hidden";
         this.frame.style.pointerEvents = "none";
         this.frame.classList.add("blank");
@@ -172,8 +173,13 @@ export default class FXLFrameManager {
         });
     }
 
+    deselect() {
+        this.frame.contentWindow?.getSelection()?.removeAllRanges();
+    }
+
     async hide(): Promise<void> {
         if(this.frame.parentElement) {
+            this.deselect();
             if(this.comms === undefined) return;
             return new Promise((res, _) => {
                 this.comms?.send("unfocus", undefined, (ok: boolean) => {

--- a/navigator/src/epub/fxl/FXLFramePoolManager.ts
+++ b/navigator/src/epub/fxl/FXLFramePoolManager.ts
@@ -280,7 +280,7 @@ export default class FramePoolManager {
                     if(this.spineElement.style.transform === newTransform) return;
                     this.transform = newTransform;
                     this.updateSpineStyle(true, fast);
-                    this.currentFrames?.forEach(f => f?.deselect());
+                    this.deselect();
                 });
             });
         } else {
@@ -288,7 +288,7 @@ export default class FramePoolManager {
             if(this.spineElement.style.transform === newTransform) return;
             this.transform = newTransform;
             this.updateSpineStyle(false);
-            this.currentFrames?.forEach(f => f?.deselect());
+            this.deselect();
         }
     }
 
@@ -597,5 +597,9 @@ export default class FramePoolManager {
         }
         const spread = this.spreader.currentSpread(this.currentSlide, this.perPage);
         return spread[0].properties?.otherProperties["number"];
+    }
+
+    deselect() {
+        this.currentFrames?.forEach(f => f?.deselect());
     }
 }

--- a/navigator/src/epub/fxl/FXLFramePoolManager.ts
+++ b/navigator/src/epub/fxl/FXLFramePoolManager.ts
@@ -280,6 +280,7 @@ export default class FramePoolManager {
                     if(this.spineElement.style.transform === newTransform) return;
                     this.transform = newTransform;
                     this.updateSpineStyle(true, fast);
+                    this.currentFrames?.forEach(f => f?.deselect());
                 });
             });
         } else {
@@ -287,6 +288,7 @@ export default class FramePoolManager {
             if(this.spineElement.style.transform === newTransform) return;
             this.transform = newTransform;
             this.updateSpineStyle(false);
+            this.currentFrames?.forEach(f => f?.deselect());
         }
     }
 

--- a/navigator/src/epub/fxl/FXLPeripherals.ts
+++ b/navigator/src/epub/fxl/FXLPeripherals.ts
@@ -343,8 +343,10 @@ export default class FXLPeripherals {
         e.stopPropagation();
         const coords = this.coordinator.getBibiEventCoord(e);
 
-        if ((Math.abs(this.pan.startY - coords.Y) + Math.abs(this.pan.startX - coords.X)) > 5 && this.dragState < 1)
+        if ((Math.abs(this.pan.startY - coords.Y) + Math.abs(this.pan.startX - coords.X)) > 5 && this.dragState < 1) {
+            this.manager.currentFrames?.forEach(f => f.deselect());
             this.dragState = 1;
+        }
 
         const currentDistance = this.coordinator?.getTouchDistance(e);
 

--- a/navigator/src/epub/fxl/FXLPeripherals.ts
+++ b/navigator/src/epub/fxl/FXLPeripherals.ts
@@ -344,7 +344,7 @@ export default class FXLPeripherals {
         const coords = this.coordinator.getBibiEventCoord(e);
 
         if ((Math.abs(this.pan.startY - coords.Y) + Math.abs(this.pan.startX - coords.X)) > 5 && this.dragState < 1) {
-            this.manager.currentFrames?.forEach(f => f.deselect());
+            this.manager.currentFrames?.forEach(f => f?.deselect());
             this.dragState = 1;
         }
 

--- a/navigator/src/epub/fxl/FXLPeripherals.ts
+++ b/navigator/src/epub/fxl/FXLPeripherals.ts
@@ -41,6 +41,7 @@ export default class FXLPeripherals {
     private readonly coordinator: FXLCoordinator;
 
     public dragState = 0;
+    private minimumMoved = false;
     public pan: PanTracker = {
         startX: 0,
         endX: 0,
@@ -285,6 +286,7 @@ export default class FXLPeripherals {
                 this.updateAfterDrag();
             }
             this.dragState = 0;
+            this.minimumMoved = false;
             this.clearPinch();
             if(this.debugger?.show) {
                 this.debugger.DOM.center.style.display = "none";
@@ -343,9 +345,12 @@ export default class FXLPeripherals {
         e.stopPropagation();
         const coords = this.coordinator.getBibiEventCoord(e);
 
-        if ((Math.abs(this.pan.startY - coords.Y) + Math.abs(this.pan.startX - coords.X)) > 5 && this.dragState < 1) {
-            this.manager.currentFrames?.forEach(f => f?.deselect());
-            this.dragState = 1;
+        if ((Math.abs(this.pan.startY - coords.Y) + Math.abs(this.pan.startX - coords.X)) > 5) {
+            if(!this.minimumMoved) {
+                this.manager.deselect();
+                this.minimumMoved = true;
+            }
+            if(this.dragState < 1) this.dragState = 1;
         }
 
         const currentDistance = this.coordinator?.getTouchDistance(e);


### PR DESCRIPTION
As discussed in today's Readium call, this implements deselection of any selection in the iframes of the FXL and reflowable EPUBs when it is aesthetically unpleasing to keep them displaying, such as when swiping to a previous/next resource in the horizontal reader.
This feature is already implemented to some extent in the mobile toolkits.