### PR TITLE
Fix target of intercepted events in reader frame

### DIFF
--- a/navigator-html-injectables/src/helpers/dom.ts
+++ b/navigator-html-injectables/src/helpers/dom.ts
@@ -3,7 +3,7 @@
 import { Locator, LocatorLocations, LocatorText } from "@readium/shared/src/publication";
 import type { getCssSelector } from "css-selector-generator";
 
-type BlockedEventData = [0, Function, any[], any[]] | [1, Event];
+type BlockedEventData = [0, Function, any[], any[]] | [1, Event, EventTarget];
 
 // This is what is injected into the HTML documents
 export interface ReadiumWindow extends Window {

--- a/navigator-html-injectables/src/modules/setup/Setup.ts
+++ b/navigator-html-injectables/src/modules/setup/Setup.ts
@@ -24,13 +24,13 @@ export abstract class Setup extends Module {
                     break;
                 case 1:
                     const ev = x[1];
+                    const evTarget = x[2];
                     wnd.removeEventListener(ev.type, wnd._readium_eventBlocker, true);
                     const evt = new Event(ev.type, {
                         bubbles: ev.bubbles,
                         cancelable: ev.cancelable
                     });
-                    if(ev.currentTarget) ev.currentTarget.dispatchEvent(evt)
-                    else if(ev.target) ev.target.dispatchEvent(evt)
+                    if(evTarget) evTarget.dispatchEvent(evt);
                     else wnd.dispatchEvent(evt);
                     break;
             }

--- a/navigator/src/epub/frame/FrameBlobBuilder.ts
+++ b/navigator/src/epub/frame/FrameBlobBuilder.ts
@@ -55,7 +55,7 @@ const rBefore = (doc: Document) => scriptify(doc, cached("JS-Before", () => blob
         e.preventDefault();
         e.stopImmediatePropagation();
         _readium_blockedEvents.push([
-            1, e
+            1, e, e.currentTarget || e.target
         ]);
     };
     window.addEventListener("DOMContentLoaded", window._readium_eventBlocker, true);


### PR DESCRIPTION
Addresses differences in preservation of `event.currentTarget` outside the event handler in Chrome vs. FF & Safari. This fixes certain events not being dispatched in those browsers.