### PR TITLE
Fix viewport in ReflowableSetup

### DIFF
--- a/navigator-html-injectables/src/modules/setup/ReflowableSetup.ts
+++ b/navigator-html-injectables/src/modules/setup/ReflowableSetup.ts
@@ -11,7 +11,7 @@ export class ReflowableSetup extends Setup {
     onViewportWidthChanged(event: Event) {
         const wnd = event.target as Window;
         // const pageWidth = wnd.innerWidth / wnd.devicePixelRatio;
-        setProperty(wnd, "--RS__viewportWidth", `calc(${wnd.innerWidth}px / ${wnd.devicePixelRatio})`);
+        setProperty(wnd, "--RS__viewportWidth", `${wnd.innerWidth}px`);
     }
 
     mount(wnd: Window, comms: Comms): boolean {


### PR DESCRIPTION
Not sure I’m missing something – there’s nothing obvious while blaming the file – but the following created an issue when switching to devices with a pixel density that is more than `1` in Readium Playground. 

https://github.com/readium/ts-toolkit/blob/bb3a594f5e7f78fbd4aa444cbf283475c4b34ce4/navigator-html-injectables/src/modules/setup/ReflowableSetup.ts#L11-L15

Switched to an actual Android device to make sure it was not a software issue of sorts and this is what I would get:

![Multiple columns instead of 1.](https://github.com/user-attachments/assets/49c98b16-fa1d-448c-88fd-82627f4269e3)

![The columns are cut off and not perfectly aligned.](https://github.com/user-attachments/assets/e7fb772d-1180-44d9-bc12-f42fb5ef5a42)

Note I used the desktop version so that it’s a little bit clearer what happens, otherwise columns are like a few characters wide. But I can guarantee the problem applies w/o using the desktop version – as well as software emulation e.g. Safari’s responsive debug, etc.

While this is the expected result:

![A single column](https://github.com/user-attachments/assets/9b07b8c2-aae6-45b6-a89c-40fb69ac9e81)

It’s working as expected when removing the `devicePixelRatio` but again, maybe I’m missing something cos’ I can’t explain why it was used in the first place so maybe it solves an issue.