### PR TITLE
Improve loading of resources with many images

### DIFF
--- a/navigator/src/epub/frame/FrameBlobBuilder.ts
+++ b/navigator/src/epub/frame/FrameBlobBuilder.ts
@@ -172,6 +172,17 @@ export default class FrameBlobBuider {
             // Readium CSS After
             doc.head.appendChild(styleify(doc, cached("ReadiumCSS-after", () => blobify(stripCSS(readiumCSSAfter), "text/css"))));
         }
+
+        // Set all <img> elements to high priority
+        // From what I understand, browser heuristics
+        // de-prioritize <iframe> resources. This causes the <img>
+        // elements to be loaded in sequence, which in documents
+        // with many images causes significant impact to rendering
+        // speed. When you increase the priority, the <img> data is
+        // loaded in parallel, greatly increasing overall speed.
+        doc.body.querySelectorAll("img").forEach((img) => {
+            img.setAttribute("fetchpriority", "high");
+        });
     
         if(base !== undefined) {
             // Set all URL bases. Very convenient!


### PR DESCRIPTION
In a reflowable reader, the document's resources must be fully loaded in order for the positioning to be correct. That means every single image must be fully loaded, so the height and width it takes in the document is determined, and the e.g. columnated layout is fully finished. The ts-toolkit does allow proceeding fowards/backwards to a document until it has fully loaded, so when a resource takes particularly long to load, the user is left waiting, and appears stuck in the reader.
The visual queues for this should be improved in a future version of the reflowable reading engine itself, but in the meantime there is a larger issue that has to be addressed - <iframe> documents with hundreds of images take a *long* time to load when streamed over the web, because, based on my understanding, the loading of the frames' subresources are deprioritized by browser heuristics.
Here is an example of the loading of a reader using the ts-toolkit, in Google Chrome, before this change:
![dev tools network requests](https://github.com/user-attachments/assets/aa45e802-2899-4dc3-8b43-a0497c2cd3e3)
As you can see, the priority of the requests is low, and they are performed sequentially.

After this optimization, the images all have high priority, and are loaded in parallel by the browser:
![dev tools network requests](https://github.com/user-attachments/assets/60a3621c-3104-4518-9a6b-f80d5356fa40)

While I'm not quite happy with the abuse of the fetchpriority attribute to fix this issue, and the further modification of the original document, I don't think there's any other choice.