### PR TITLE
Implement media element play/pause logging and pausing on unfocus

### DIFF
--- a/navigator-html-injectables/src/comms/keys.ts
+++ b/navigator-html-injectables/src/comms/keys.ts
@@ -14,7 +14,9 @@ export type CommsEventKey =
     "swipe" |
     "progress" |
     "first_visible_locator" |
-    "text_selected";
+    "text_selected" |
+    "media_play" |
+    "media_pause";
 ;
 
 export type CommsCommandKey =

--- a/navigator-html-injectables/src/modules/ModuleLibrary.ts
+++ b/navigator-html-injectables/src/modules/ModuleLibrary.ts
@@ -8,6 +8,7 @@ import { Decorator } from "./Decorator";
 
 // All the module names. TODO: Come up with a better way of collecting these in a way TS will recognize
 export type ModuleName =
+    "setup" |
     "snapper" |
     "column_snapper" |
     "scroll_snapper" |

--- a/navigator-html-injectables/src/modules/setup/FixedSetup.ts
+++ b/navigator-html-injectables/src/modules/setup/FixedSetup.ts
@@ -2,7 +2,7 @@ import { Comms } from "../../comms/comms";
 import { Setup } from "./Setup";
 import { removeProperty, setProperty } from "../../helpers/css";
 import { ModuleName } from "../ModuleLibrary";
-import { ReadiumWindow } from "../../helpers/dom";
+import { ReadiumWindow, deselect } from "../../helpers/dom";
 
 const FIXED_STYLE_ID = "readium-fixed-style";
 
@@ -42,8 +42,13 @@ export class FixedSetup extends Setup {
 
         comms.register("first_visible_locator", FixedSetup.moduleName, (_, ack) => ack(false))
 
+        comms.register("unfocus", FixedSetup.moduleName, (_, ack) => {
+            deselect(wnd);
+            ack(true);
+        });
+
         comms.register([
-            "focus", "unfocus", "go_next", "go_prev",
+            "focus", "go_next", "go_prev",
             "go_id", "go_end", "go_start", "go_text",
             "go_progression"
         ], FixedSetup.moduleName, (_, ack) => ack(true));

--- a/navigator/src/epub/fxl/FXLFrameManager.ts
+++ b/navigator/src/epub/fxl/FXLFrameManager.ts
@@ -179,7 +179,6 @@ export class FXLFrameManager {
 
     async hide(): Promise<void> {
         if(this.frame.parentElement) {
-            this.deselect();
             if(this.comms === undefined) return;
             return new Promise((res, _) => {
                 this.comms?.send("unfocus", undefined, (_: boolean) => {

--- a/navigator/src/epub/fxl/FXLFrameManager.ts
+++ b/navigator/src/epub/fxl/FXLFrameManager.ts
@@ -144,7 +144,7 @@ export class FXLFrameManager {
     }
 
     async destroy() {
-        await this.hide();
+        await this.unfocus();
         this.loader?.destroy();
         this.wrapper.remove();
     }
@@ -177,7 +177,7 @@ export class FXLFrameManager {
         this.frame.contentWindow?.getSelection()?.removeAllRanges();
     }
 
-    async hide(): Promise<void> {
+    async unfocus(): Promise<void> {
         if(this.frame.parentElement) {
             if(this.comms === undefined) return;
             return new Promise((res, _) => {


### PR DESCRIPTION
There are quite a few FXL and reflowable publications in the wild with embedded audio and video. Sometimes it's a simple `<video>` element, sometimes it's a more advanced JS-based interactive experience with audio playback triggered by buttons on the page. Regardless, every single publication doing so (though technically there are other ways) uses an [`HTMLMediaElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement).
This PR adds:
- The ability to track the playing and pausing of such elements, in the form of two new `comms` messages
- The automatic pausing of all audio and video when a document is "unfocused", that means if it's hidden from view because the page has changed (FXL) or the resource has been changed (reflow), the `.pause()` function will be called on all `<audio>` and `<video>`
- Improved FXL unfocusing to support this change