### PR TITLE
Add CSS selector to tap/click events

### DIFF
--- a/navigator-html-injectables/src/Loader.ts
+++ b/navigator-html-injectables/src/Loader.ts
@@ -1,4 +1,5 @@
 import { Comms } from "./comms/comms";
+import { ReadiumWindow } from "./helpers/dom";
 import { Module, ModuleDerived, ModuleLibrary, ModuleName } from "./modules";
 
 /**
@@ -7,14 +8,14 @@ import { Module, ModuleDerived, ModuleLibrary, ModuleName } from "./modules";
  */
 export class Loader<T extends string = ModuleName> {
     private loadedModules: Module[] = [];
-    private readonly wnd: Window;
+    private readonly wnd: ReadiumWindow;
     private readonly comms: Comms;
 
     /**
      * @param wnd Window instance to operate on
      * @param initialModules List of initial modules to load
      */
-    constructor(wnd: Window = window, initialModules: string[] = []) {
+    constructor(wnd: ReadiumWindow = window as Window as ReadiumWindow, initialModules: string[] = []) {
         this.wnd = wnd; // Window instance
         this.comms = new Comms(wnd);
 

--- a/navigator-html-injectables/src/comms/comms.ts
+++ b/navigator-html-injectables/src/comms/comms.ts
@@ -1,3 +1,4 @@
+import { ReadiumWindow } from "../helpers/dom";
 import { CommsEventKey, CommsCommandKey } from "./keys";
 import { mid } from "./mid";
 
@@ -24,13 +25,13 @@ export type CommsCallback = (data: unknown, ack: CommsAck) => void; // TODO: may
  * adds structure to the messages and lets modules register callbacks.
  */
 export class Comms {
-    private readonly wnd: Window;
-    private destination: Window | null = null;
+    private readonly wnd: ReadiumWindow;
+    private destination: ReadiumWindow | null = null;
     private registrar = new Map<CommsCommandKey, Registrant[]>();
     private origin: string = "";
     private channelId: string = "";
 
-    constructor(wnd: Window) {
+    constructor(wnd: ReadiumWindow) {
         this.wnd = wnd;
         wnd.addEventListener("message", this.receiver);
     }
@@ -43,7 +44,7 @@ export class Comms {
         if(data.key === "_ping") {
             // The "ping" gives us a destination we bind to for posting events
             if(!this.destination) {
-                this.destination = event.source as Window;
+                this.destination = event.source as Window as ReadiumWindow;
                 this.origin = event.origin;
                 this.channelId = data._channel;
 

--- a/navigator-html-injectables/src/helpers/css.ts
+++ b/navigator-html-injectables/src/helpers/css.ts
@@ -1,14 +1,16 @@
+import { ReadiumWindow } from "./dom";
+
 // Easy way to get a CSS property
-export function getProperty(wnd: Window, key: string) {
+export function getProperty(wnd: ReadiumWindow, key: string) {
     return wnd.document.documentElement.style.getPropertyValue(key);
 }
 
 // Easy way to set a CSS property
-export function setProperty(wnd: Window, key: string, value: string) {
+export function setProperty(wnd: ReadiumWindow, key: string, value: string) {
     wnd.document.documentElement.style.setProperty(key, value);
 }
 
 // Easy way to remove a CSS property
-export function removeProperty(wnd: Window, key: string) {
+export function removeProperty(wnd: ReadiumWindow, key: string) {
     wnd.document.documentElement.style.removeProperty(key);
 }

--- a/navigator-html-injectables/src/helpers/document.ts
+++ b/navigator-html-injectables/src/helpers/document.ts
@@ -1,9 +1,10 @@
+import { ReadiumWindow } from "./dom";
 
-export function isRTL(wnd: Window): boolean {
+export function isRTL(wnd: ReadiumWindow): boolean {
     return wnd.document.body.dir.toLowerCase() === "rtl";
 }
 
-export function getColumnCountPerScreen(wnd: Window) {
+export function getColumnCountPerScreen(wnd: ReadiumWindow) {
     return parseInt(
         wnd.getComputedStyle(
             wnd.document.documentElement
@@ -15,7 +16,7 @@ export function getColumnCountPerScreen(wnd: Window) {
  * Having an odd number of columns when displaying two columns per screen causes snapping and page
  * turning issues. To fix this, we insert a blank virtual column at the end of the resource.
  */
-export function appendVirtualColumnIfNeeded(wnd: Window) {
+export function appendVirtualColumnIfNeeded(wnd: ReadiumWindow) {
     const id = "readium-virtual-page";
     let virtualCol = wnd.document.getElementById(id);
     if (getColumnCountPerScreen(wnd) !== 2) {

--- a/navigator-html-injectables/src/helpers/dom.ts
+++ b/navigator-html-injectables/src/helpers/dom.ts
@@ -15,7 +15,7 @@ export interface ReadiumWindow extends Window {
     };
 }
 
-export function deselect(wnd: Window) {
+export function deselect(wnd: ReadiumWindow) {
     const currentSelection = wnd.getSelection();
     if(currentSelection) currentSelection.removeAllRanges();
 }

--- a/navigator-html-injectables/src/modules/Decorator.ts
+++ b/navigator-html-injectables/src/modules/Decorator.ts
@@ -6,6 +6,7 @@ import { ModuleName } from "./ModuleLibrary";
 import { Rect, getClientRectsNoOverlap } from "../helpers/rect";
 import { ResizeObserver as Polyfill } from '@juggle/resize-observer';
 import { getProperty } from "../helpers/css";
+import { ReadiumWindow } from "../helpers/dom";
 
 // Necessary for iOS 13 and below
 const ResizeObserver = window.ResizeObserver || Polyfill;
@@ -68,7 +69,7 @@ class DecorationGroup {
      * @param name Human-readable name of the group
      */
     constructor(
-        private readonly wnd: Window,
+        private readonly wnd: ReadiumWindow,
         private readonly comms: Comms,
         private readonly id: string,
         private readonly name: string
@@ -377,7 +378,7 @@ class DecorationGroup {
 export class Decorator extends Module {
     static readonly moduleName: ModuleName = "decorator";
     private resizeObserver!: ResizeObserver;
-    private wnd!: Window;
+    private wnd!: ReadiumWindow;
     /*private readonly lastSize = {
         width: 0,
         height: 0
@@ -403,7 +404,7 @@ export class Decorator extends Module {
     }
     private readonly handleResizer = this.handleResize.bind(this);
 
-    mount(wnd: Window, comms: Comms): boolean {
+    mount(wnd: ReadiumWindow, comms: Comms): boolean {
         this.wnd = wnd;
 
         comms.register("decorate", Decorator.moduleName, (data, ack) => {
@@ -447,7 +448,7 @@ export class Decorator extends Module {
         return true;
     }
 
-    unmount(wnd: Window, comms: Comms): boolean {
+    unmount(wnd: ReadiumWindow, comms: Comms): boolean {
         wnd.removeEventListener("orientationchange", this.handleResizer);
         wnd.removeEventListener("resize", this.handleResizer);
 

--- a/navigator-html-injectables/src/modules/Module.ts
+++ b/navigator-html-injectables/src/modules/Module.ts
@@ -1,4 +1,5 @@
 import { Comms } from "../comms";
+import { ReadiumWindow } from "../helpers/dom";
 import { ModuleName } from "./ModuleLibrary";
 
 export abstract class Module {
@@ -9,14 +10,14 @@ export abstract class Module {
     // to using comms.register, and send any commands using comms.send. Modules
     // must be designed to not use comms.send before the communication handshake
     // has finished (so not during the mount function).
-    abstract mount(wnd: Window, comms: Comms): boolean;
+    abstract mount(wnd: ReadiumWindow, comms: Comms): boolean;
 
     // Unmounting should completely clean up any event listeners or
     // active modification of the HTML content, and cease all activity. This is
     // because an implementer should be able to mount and unmount Modules at any
     // time, to, for example, switch reading modes. There should be no difference
     // in behavior after mounting and unmounting a Module repeatedly.
-    abstract unmount(wnd: Window, comms: Comms): boolean;
+    abstract unmount(wnd: ReadiumWindow, comms: Comms): boolean;
 }
 
 export type ModuleDerived = {new (): Module} & typeof Module;

--- a/navigator-html-injectables/src/modules/ModuleLibrary.ts
+++ b/navigator-html-injectables/src/modules/ModuleLibrary.ts
@@ -1,7 +1,7 @@
 import { ModuleDerived } from "./Module";
 import { ColumnSnapper } from "./snapper/ColumnSnapper";
 import { ScrollSnapper } from "./snapper/ScrollSnapper";
-import { ReflowablePeripherals } from "./ReflowablePeripherals";
+import { Peripherals } from "./Peripherals";
 import { ReflowableSetup } from "./setup/ReflowableSetup";
 import { FixedSetup } from "./setup/FixedSetup";
 import { Decorator } from "./Decorator";
@@ -15,20 +15,20 @@ export type ModuleName =
     "fixed_setup" |
     "decorator" |
     "reflowable_setup" |
-    "reflowable_peripherals";
+    "peripherals";
 
 // Modules that are valid for FXL publications
 export const FXLModules: ModuleName[] = [
     "fixed_setup",
     "decorator",
-    "reflowable_peripherals"
+    "peripherals"
 ];
 
 // Modules that are valid for reflowable publications
 export const ReflowableModules: ModuleName[] = [
     "reflowable_setup",
     "decorator",
-    "reflowable_peripherals",
+    "peripherals",
     "column_snapper",
     "scroll_snapper"
 ];
@@ -37,7 +37,7 @@ export const ModuleLibrary = new Map<string, ModuleDerived>([
     // All modules go here
     FixedSetup,
     ReflowableSetup,
-    ReflowablePeripherals,
+    Peripherals,
     Decorator,
     ColumnSnapper,
     ScrollSnapper,

--- a/navigator-html-injectables/src/modules/Peripherals.ts
+++ b/navigator-html-injectables/src/modules/Peripherals.ts
@@ -1,11 +1,12 @@
 import { Comms } from "../comms/comms";
 import { Module } from "./Module";
-import { nearestInteractiveElement } from "../helpers/dom";
+import { ReadiumWindow, nearestInteractiveElement } from "../helpers/dom";
 
 export interface FrameClickEvent {
     defaultPrevented: boolean;
     doNotDisturb: boolean;
     interactiveElement: string | undefined;
+    cssSelector: string | undefined;
     targetElement: string;
     targetFrameSrc: string;
     x: number;
@@ -21,9 +22,9 @@ export interface BasicTextSelection {
     targetFrameSrc: string;
 }
 
-export class ReflowablePeripherals extends Module {
-    static readonly moduleName = "reflowable_peripherals";
-    private wnd!: Window;
+export class Peripherals extends Module {
+    static readonly moduleName = "peripherals";
+    private wnd!: ReadiumWindow;
     private comms!: Comms;
 
     private pointerMoved = false;
@@ -69,7 +70,8 @@ export class ReflowablePeripherals extends Module {
             y: event.clientY * pixelRatio,
             targetFrameSrc: this.wnd.location.href,
             targetElement: (event.target as Element).outerHTML,
-            interactiveElement: nearestInteractiveElement(event.target as Element)?.outerHTML
+            interactiveElement: nearestInteractiveElement(event.target as Element)?.outerHTML,
+            cssSelector: this.wnd._readium_cssSelectorGenerator.getCssSelector(event.target),
         } as FrameClickEvent);
 
         this.pointerMoved = false;
@@ -120,7 +122,7 @@ export class ReflowablePeripherals extends Module {
     }
     private readonly onClicker = this.onClick.bind(this);
 
-    mount(wnd: Window, comms: Comms): boolean {
+    mount(wnd: ReadiumWindow, comms: Comms): boolean {
         this.wnd = wnd;
         this.comms = comms;
         wnd.document.addEventListener("pointerdown", this.onPointerDown);
@@ -129,18 +131,18 @@ export class ReflowablePeripherals extends Module {
         wnd.document.addEventListener("pointermove", this.onPointerMove);
         wnd.document.addEventListener("click", this.onClicker);
 
-        comms.log("ReflowablePeripherals Mounted");
+        comms.log("Peripherals Mounted");
         return true;
     }
 
-    unmount(wnd: Window, comms: Comms): boolean {
+    unmount(wnd: ReadiumWindow, comms: Comms): boolean {
         wnd.document.removeEventListener("pointerdown", this.onPointerDown);
         wnd.document.removeEventListener("pointerup", this.onPointerUp);
         wnd.document.removeEventListener("contextmenu", this.onContextMenu);
         wnd.document.removeEventListener("pointermove", this.onPointerMove);
         wnd.document.removeEventListener("click", this.onClicker);
 
-        comms.log("ReflowablePeripherals Unmounted");
+        comms.log("Peripherals Unmounted");
         return true;
     }
 }

--- a/navigator-html-injectables/src/modules/index.ts
+++ b/navigator-html-injectables/src/modules/index.ts
@@ -1,3 +1,3 @@
 export * from './Module';
 export * from './ModuleLibrary';
-export * from './ReflowablePeripherals';
+export * from './Peripherals';

--- a/navigator-html-injectables/src/modules/setup/FixedSetup.ts
+++ b/navigator-html-injectables/src/modules/setup/FixedSetup.ts
@@ -9,7 +9,7 @@ const FIXED_STYLE_ID = "readium-fixed-style";
 export class FixedSetup extends Setup {
     static readonly moduleName: ModuleName = "fixed_setup";
 
-    mount(wnd: Window, comms: Comms): boolean {
+    mount(wnd: ReadiumWindow, comms: Comms): boolean {
         if(!super.mount(wnd, comms)) return false;
 
         const style = wnd.document.createElement("style");
@@ -62,7 +62,7 @@ export class FixedSetup extends Setup {
         return true;
     }
 
-    unmount(wnd: Window, comms: Comms): boolean {
+    unmount(wnd: ReadiumWindow, comms: Comms): boolean {
         comms.unregisterAll(FixedSetup.moduleName);
 
         wnd.document.getElementById(FIXED_STYLE_ID)?.remove();

--- a/navigator-html-injectables/src/modules/setup/ReflowableSetup.ts
+++ b/navigator-html-injectables/src/modules/setup/ReflowableSetup.ts
@@ -9,12 +9,12 @@ export class ReflowableSetup extends Setup {
     static readonly moduleName = "reflowable_setup";
 
     onViewportWidthChanged(event: Event) {
-        const wnd = event.target as Window;
+        const wnd = event.target as ReadiumWindow;
         // const pageWidth = wnd.innerWidth / wnd.devicePixelRatio;
         setProperty(wnd, "--RS__viewportWidth", `${wnd.innerWidth}px`);
     }
 
-    mount(wnd: Window, comms: Comms): boolean {
+    mount(wnd: ReadiumWindow, comms: Comms): boolean {
         if(!super.mount(wnd, comms)) return false;
 
         // Add viewport tag
@@ -54,7 +54,7 @@ export class ReflowableSetup extends Setup {
         return true;
     }
 
-    unmount(wnd: Window, comms: Comms): boolean {
+    unmount(wnd: ReadiumWindow, comms: Comms): boolean {
         comms.unregisterAll(ReflowableSetup.moduleName);
         wnd.document.head.querySelector(`#${VIEWPORT_META_TAG_ID}`)?.remove();
         wnd.removeEventListener("orientationchange", this.onViewportWidthChanged);

--- a/navigator-html-injectables/src/modules/setup/Setup.ts
+++ b/navigator-html-injectables/src/modules/setup/Setup.ts
@@ -7,7 +7,6 @@ export abstract class Setup extends Module {
     static readonly moduleName: ModuleName = "setup";
 
     private comms!: Comms;
-    private wnd!: ReadiumWindow;
 
     wndOnErr(event: ErrorEvent) {
         this.comms?.send("error", {
@@ -54,16 +53,17 @@ export abstract class Setup extends Module {
         this.comms?.send("media_pause", this.mediaPlayingCount);
     }
 
-    private pauseAllMedia() {
-        const avEls = this.wnd.document.querySelectorAll("audio,video");
+    private pauseAllMedia(wnd: ReadiumWindow) {
+        const avEls = wnd.document.querySelectorAll("audio,video");
         for (let i = 0; i < avEls.length; i++) {
             (avEls[i] as HTMLMediaElement).pause();
         }
     }
 
+    private allAnimations = new Set<Animation>();
+
     mount(wnd: ReadiumWindow, comms: Comms): boolean {
         this.comms = comms;
-        this.wnd = wnd;
 
         // Track all window errors
         wnd.addEventListener(
@@ -72,12 +72,35 @@ export abstract class Setup extends Module {
             false
         );
 
-        comms.register("unfocus", Setup.moduleName, (_, ack) => {
-            // When a document is unfocused, all media is paused
-            this.pauseAllMedia();
+        // Add all currently active animations and cancel them
+        if("getAnimations" in wnd.document) {
+            wnd.document.getAnimations().forEach((a) => {
+                a.cancel();
+                this.allAnimations.add(a);
+            });
+        }
+
+        comms.register("activate", Setup.moduleName, (_, ack) => {
+            // Restart all animations
+            this.allAnimations.forEach(a => {
+                a.cancel();
+                a.play();
+            });
+
             ack(true);
         });
 
+        comms.register("unfocus", Setup.moduleName, (_, ack) => {
+            // When a document is unfocused, all media is paused
+            this.pauseAllMedia(wnd);
+
+            // ... and all animations are cancelled
+            this.allAnimations.forEach(a => a.pause());
+
+            ack(true);
+        });
+
+        // Track play/pause of all <audio> and <video> elements
         const avEls = wnd.document.querySelectorAll("audio,video");
         for (let i = 0; i < avEls.length; i++) {
             const e = avEls[i] as HTMLAudioElement | HTMLVideoElement;
@@ -97,6 +120,9 @@ export abstract class Setup extends Module {
         wnd.removeEventListener("error", this.wndOnErr);
         wnd.removeEventListener("play", this.onMediaPlayEvent);
         wnd.removeEventListener("pause", this.onMediaPauseEvent);
+
+        this.allAnimations.forEach(a => a.cancel());
+        this.allAnimations.clear();
 
         comms.log("Setup Unmounted");
         return true;

--- a/navigator-html-injectables/src/modules/setup/Setup.ts
+++ b/navigator-html-injectables/src/modules/setup/Setup.ts
@@ -7,7 +7,7 @@ export abstract class Setup extends Module {
     static readonly moduleName: ModuleName = "setup";
 
     private comms!: Comms;
-    private wnd!: Window;
+    private wnd!: ReadiumWindow;
 
     wndOnErr(event: ErrorEvent) {
         this.comms?.send("error", {
@@ -61,7 +61,7 @@ export abstract class Setup extends Module {
         }
     }
 
-    mount(wnd: Window, comms: Comms): boolean {
+    mount(wnd: ReadiumWindow, comms: Comms): boolean {
         this.comms = comms;
         this.wnd = wnd;
 
@@ -93,7 +93,7 @@ export abstract class Setup extends Module {
         return true;
     }
 
-    unmount(wnd: Window, comms: Comms): boolean {
+    unmount(wnd: ReadiumWindow, comms: Comms): boolean {
         wnd.removeEventListener("error", this.wndOnErr);
         wnd.removeEventListener("play", this.onMediaPlayEvent);
         wnd.removeEventListener("pause", this.onMediaPauseEvent);

--- a/navigator-html-injectables/src/modules/snapper/ColumnSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ColumnSnapper.ts
@@ -24,7 +24,7 @@ export class ColumnSnapper extends Snapper {
     static readonly moduleName: ModuleName = "column_snapper";
     private resizeObserver!: ResizeObserver;
     private mutationObserver!: MutationObserver;
-    private wnd!: Window;
+    private wnd!: ReadiumWindow;
     private comms!: Comms;
     private doc() { return this.wnd.document.scrollingElement as HTMLElement; }
     private scrollOffset() {
@@ -224,7 +224,7 @@ export class ColumnSnapper extends Snapper {
     }
     private readonly onTouchMover = this.onTouchMove.bind(this);
 
-    mount(wnd: Window, comms: Comms): boolean {
+    mount(wnd: ReadiumWindow, comms: Comms): boolean {
         this.wnd = wnd;
         this.comms = comms;
         if(!super.mount(wnd, comms)) return false;
@@ -271,7 +271,7 @@ export class ColumnSnapper extends Snapper {
         wnd.document.head.appendChild(d);
 
         // Necessary for iOS 13 and below
-        const ResizeObserver = (wnd as Window & typeof globalThis).ResizeObserver || Polyfill;
+        const ResizeObserver = (wnd as ReadiumWindow & typeof globalThis).ResizeObserver || Polyfill;
 
         this.resizeObserver = new ResizeObserver(() => wnd.requestAnimationFrame(() => {
             wnd && appendVirtualColumnIfNeeded(wnd);
@@ -447,7 +447,7 @@ export class ColumnSnapper extends Snapper {
         return true;
     }
 
-    unmount(wnd: Window, comms: Comms): boolean {
+    unmount(wnd: ReadiumWindow, comms: Comms): boolean {
         this.snappingCancelled = true;
         comms.unregisterAll(ColumnSnapper.moduleName);
         this.resizeObserver.disconnect();

--- a/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
@@ -10,7 +10,7 @@ const SCROLL_SNAPPER_STYLE_ID = "readium-scroll-snapper-style";
 
 export class ScrollSnapper extends Snapper {
     static readonly moduleName: ModuleName = "scroll_snapper";
-    private wnd!: Window;
+    private wnd!: ReadiumWindow;
     private comms!: Comms;
 
     private doc() {
@@ -34,7 +34,7 @@ export class ScrollSnapper extends Snapper {
         this.comms.send("progress", progress);
     }
 
-    mount(wnd: Window, comms: Comms): boolean {
+    mount(wnd: ReadiumWindow, comms: Comms): boolean {
         this.wnd = wnd;
         this.comms = comms;
 
@@ -158,7 +158,7 @@ export class ScrollSnapper extends Snapper {
         return true;
     }
 
-    unmount(wnd: Window, comms: Comms): boolean {
+    unmount(wnd: ReadiumWindow, comms: Comms): boolean {
         comms.unregisterAll(ScrollSnapper.moduleName);
         this.removeAnchorElements();
         wnd.document.getElementById(SCROLL_SNAPPER_STYLE_ID)?.remove();

--- a/navigator-html-injectables/src/modules/snapper/Snapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/Snapper.ts
@@ -1,4 +1,5 @@
 import { Comms } from "../../comms";
+import { ReadiumWindow } from "../../helpers/dom";
 import { Module } from "../Module";
 import { ModuleName } from "../ModuleLibrary";
 
@@ -17,7 +18,7 @@ export abstract class Snapper extends Module {
         }`;
     }
 
-    mount(wnd: Window, comms: Comms): boolean {
+    mount(wnd: ReadiumWindow, comms: Comms): boolean {
         const d = wnd.document.createElement("style");
         d.dataset.readium = "true";
         d.id = SNAPPER_STYLE_ID;
@@ -39,7 +40,7 @@ export abstract class Snapper extends Module {
         return true;
     }
 
-    unmount(wnd: Window, comms: Comms): boolean {
+    unmount(wnd: ReadiumWindow, comms: Comms): boolean {
         wnd.document.getElementById(SNAPPER_STYLE_ID)?.remove();
 
         comms.log("Snapper Unmounted");

--- a/navigator/src/epub/frame/FrameManager.ts
+++ b/navigator/src/epub/frame/FrameManager.ts
@@ -1,5 +1,6 @@
 import { Loader, ModuleName } from "@readium/navigator-html-injectables";
 import { FrameComms } from "./FrameComms";
+import { ReadiumWindow } from "../../../../navigator-html-injectables/types/src/helpers/dom";
 
 
 export class FrameManager {
@@ -32,7 +33,7 @@ export class FrameManager {
                 }
                 this.comms?.halt();
                 this.loader.destroy();
-                this.loader = new Loader(wnd, modules);
+                this.loader = new Loader(wnd as ReadiumWindow, modules);
                 this.currModules = modules;
                 this.comms = undefined;
                 try { res(wnd); } catch (error) {}
@@ -40,7 +41,7 @@ export class FrameManager {
             }
             this.frame.onload = () => {
                 const wnd = this.frame.contentWindow!;
-                this.loader = new Loader(wnd, modules);
+                this.loader = new Loader(wnd as ReadiumWindow, modules);
                 this.currModules = modules;
                 try { res(wnd); } catch (error) {}
             };

--- a/navigator/src/epub/fxl/FXLFrameManager.ts
+++ b/navigator/src/epub/fxl/FXLFrameManager.ts
@@ -2,6 +2,7 @@ import { Loader, ModuleName } from "@readium/navigator-html-injectables";
 import { Page, ReadingProgression } from "@readium/shared";
 import { FrameComms } from "../frame/FrameComms";
 import { FXLPeripherals } from "./FXLPeripherals";
+import { ReadiumWindow } from "../../../../navigator-html-injectables/types/src/helpers/dom";
 
 export class FXLFrameManager {
     private frame: HTMLIFrameElement;
@@ -65,7 +66,7 @@ export class FXLFrameManager {
                 // TODO
                 this.comms?.halt();
                 this.loader.destroy();
-                this.loader = new Loader(wnd, modules);
+                this.loader = new Loader(wnd as ReadiumWindow, modules);
                 this.currModules = modules;
                 this.comms = undefined;
                 try { res(wnd); this.loadPromise = undefined; } catch (error) {}
@@ -73,7 +74,7 @@ export class FXLFrameManager {
             }
             this.frame.addEventListener("load", () => {
                 const wnd = this.frame.contentWindow!;
-                this.loader = new Loader(wnd, modules);
+                this.loader = new Loader(wnd as ReadiumWindow, modules);
                 this.currModules = modules;
                 this.peripherals.observe(this.wrapper);
                 this.peripherals.observe(wnd);


### PR DESCRIPTION
This PR adds the CSS selector to the `FrameClickEvent` interface, which as proven useful for implementer purposes.
I also standardized the usage of the `ReadiumWindow` type across the navigator-html-injectables package, and renamed `ReflowablePeripherals` to `Peripherals` since it's actually used in FXL EPUBs as well