### PR TITLE
Current numbers range for reflow EPUB

### DIFF
--- a/navigator-html-injectables/src/modules/snapper/ColumnSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ColumnSnapper.ts
@@ -40,7 +40,7 @@ export class ColumnSnapper extends Snapper {
     }
 
     reportProgress() {
-        this.comms.send("progress", this.wnd.scrollX / this.cachedScrollWidth);
+        this.comms.send("progress", { progress: this.wnd.scrollX / this.cachedScrollWidth, reference: this.wnd.innerWidth / this.doc().scrollWidth });
     }
 
     private shakeTimeout = 0;

--- a/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
@@ -30,8 +30,8 @@ export class ScrollSnapper extends Snapper {
             customElements.define("anchor-observer", AnchorObserver);
     }
 
-    private reportProgress(progress: number) {
-        this.comms.send("progress", progress);
+    private reportProgress(data: { progress: number, reference: number }) {
+        this.comms.send("progress", data);
     }
 
     mount(wnd: ReadiumWindow, comms: Comms): boolean {
@@ -66,7 +66,7 @@ export class ScrollSnapper extends Snapper {
 
             this.wnd.requestAnimationFrame(() => {
               this.doc().scrollTop = this.doc().offsetHeight * position;
-              this.reportProgress(position);
+              this.reportProgress({ progress: position, reference: this.wnd.innerHeight / this.doc().scrollHeight });
               deselect(this.wnd);
               ack(true);
           });
@@ -80,7 +80,8 @@ export class ScrollSnapper extends Snapper {
             }
             this.wnd.requestAnimationFrame(() => {
                 this.doc().scrollTop = element.getBoundingClientRect().top + wnd.scrollY - wnd.innerHeight / 2;
-                this.reportProgress(this.doc().scrollTop / this.doc().offsetHeight);
+                const progress = this.doc().scrollTop / this.doc().offsetHeight;
+                this.reportProgress({ progress: progress, reference: this.wnd.innerHeight / this.doc().scrollHeight });
                 deselect(this.wnd);
                 ack(true);
             });
@@ -111,7 +112,8 @@ export class ScrollSnapper extends Snapper {
             }
             this.wnd.requestAnimationFrame(() => {
                 this.doc().scrollTop = r.getBoundingClientRect().top + wnd.scrollY - wnd.innerHeight / 2;
-                this.reportProgress(this.doc().scrollTop / this.doc().offsetHeight);
+                const progress = this.doc().scrollTop / this.doc().offsetHeight
+                this.reportProgress({ progress: progress, reference: this.wnd.innerHeight / this.doc().scrollHeight });
                 deselect(this.wnd);
                 ack(true);
             });
@@ -120,14 +122,14 @@ export class ScrollSnapper extends Snapper {
         comms.register("go_start", ScrollSnapper.moduleName, (_, ack) => {
             if (this.doc().scrollTop === 0) return ack(false);
             this.doc().scrollTop = 0;
-            this.reportProgress(0);
+            this.reportProgress({ progress: 0, reference: this.wnd.innerHeight / this.doc().scrollHeight });
             ack(true);
         });
 
         comms.register("go_end", ScrollSnapper.moduleName, (_, ack) => {
             if (this.doc().scrollTop === 0) return ack(false);
             this.doc().scrollTop = 0;
-            this.reportProgress(0);
+            this.reportProgress({ progress: 0, reference: this.wnd.innerHeight / this.doc().scrollHeight });
             ack(true);
         })
 
@@ -142,7 +144,8 @@ export class ScrollSnapper extends Snapper {
         ], ScrollSnapper.moduleName, (_, ack) => ack(false));
 
         comms.register("focus", ScrollSnapper.moduleName, (_, ack) => {
-            this.reportProgress(this.doc().scrollTop / this.doc().offsetHeight);
+            const progress = this.doc().scrollTop / this.doc().offsetHeight
+            this.reportProgress({ progress: progress, reference: this.wnd.innerHeight / this.doc().scrollHeight });
             ack(true);
         });
 

--- a/navigator/src/epub/EpubNavigator.ts
+++ b/navigator/src/epub/EpubNavigator.ts
@@ -216,7 +216,7 @@ export class EpubNavigator extends VisualNavigator {
                 this.listeners.zoom(data as number);
                 break;
             case "progress":
-                this.syncLocation(data as number);
+                this.syncLocation(data as { progress: number, reference: number });
                 break;
             case "log":
                 console.log(this._cframes[0]?.source?.split("/")[3], ...(data as any[]));
@@ -336,7 +336,7 @@ export class EpubNavigator extends VisualNavigator {
         return true;
     }
 
-    private findNearestPosition(fromProgression: number): Locator {
+    private findNearestPosition(fromProgression: { progress: number, reference: number }): Locator {
         // TODO replace with locator service
         const potentialPositions = this.positions.filter(
             (p) => p.href === this.currentLocation.href
@@ -347,7 +347,7 @@ export class EpubNavigator extends VisualNavigator {
         // smaller than or equal to the requested progression.
         potentialPositions.some((p) => {
             const pr = p.locations.progression ?? 0;
-            if (fromProgression <= pr) {
+            if (fromProgression.progress <= pr) {
                 pos = p;
                 return true;
             }
@@ -356,9 +356,9 @@ export class EpubNavigator extends VisualNavigator {
         return pos;
     }
 
-    private async syncLocation(iframeProgress: number) {
+    private async syncLocation(iframeProgress: { progress: number, reference: number }) {
         this.currentLocation = this.findNearestPosition(iframeProgress).copyWithLocations({
-            progression: iframeProgress // Most accurate progression in resource
+            progression: iframeProgress.progress // Most accurate progression in resource
         });
         this.listeners.positionChanged(this.currentLocation);
         await this.framePool.update(this.pub, this.currentLocation, this.determineModules());


### PR DESCRIPTION
Snappers report the progression to EPUBNavigator so that it can find the nearest position, which results in an array with a single Locator position when getting `currentNumbers` in reflow EPUB. In FXL it reports `2` when spreads are displayed.

This PR aims to return the first and last locators’ position to be found in a range by having snappers report a reference progression – a.k.a. progression by a `ReadiumWindow` viewport – in addition to the current one. 

This reference can then be used in EPUBNavigator to build a range, and find the aforementioned positions. If there is no `last` found, then it will return only the first one, as it did previously.