### PR TITLE
Fix and protect ReadiumCSS v1 package

### DIFF
--- a/navigator/package.json
+++ b/navigator/package.json
@@ -53,7 +53,7 @@
     "@readium/shared": "workspace:1.2.0",
     "@types/path-browserify": "^1.0.0",
     "css-selector-generator": "^3.6.4",
-    "readium-css": "github:readium/readium-css#master",
+    "readium-css": "github:readium/readium-css#v.1.1.0",
     "tslib": "^2.5.2",
     "typescript": "^5.4.5",
     "typescript-plugin-css-modules": "^5.1.0",

--- a/navigator/package.json
+++ b/navigator/package.json
@@ -53,7 +53,7 @@
     "@readium/shared": "workspace:1.2.0",
     "@types/path-browserify": "^1.0.0",
     "css-selector-generator": "^3.6.4",
-    "readium-css": "github:readium/readium-css",
+    "readium-css": "github:readium/readium-css#master",
     "tslib": "^2.5.2",
     "typescript": "^5.4.5",
     "typescript-plugin-css-modules": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         specifier: ^3.6.4
         version: 3.6.4
       readium-css:
-        specifier: github:readium/readium-css#master
+        specifier: github:readium/readium-css#v.1.1.0
         version: https://codeload.github.com/readium/readium-css/tar.gz/5084cac302997da5f66b9ca2c2a7cc6652d9caa3
       tslib:
         specifier: ^2.5.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^3.6.4
         version: 3.6.4
       readium-css:
-        specifier: github:readium/readium-css
-        version: https://codeload.github.com/readium/readium-css/tar.gz/583011453612e6f695056ab6c086a2c4f4cac9c0
+        specifier: github:readium/readium-css#master
+        version: https://codeload.github.com/readium/readium-css/tar.gz/5084cac302997da5f66b9ca2c2a7cc6652d9caa3
       tslib:
         specifier: ^2.5.2
         version: 2.5.2
@@ -2170,6 +2170,10 @@ packages:
   readdirp@4.0.1:
     resolution: {integrity: sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==}
     engines: {node: '>= 14.16.0'}
+
+  readium-css@https://codeload.github.com/readium/readium-css/tar.gz/5084cac302997da5f66b9ca2c2a7cc6652d9caa3:
+    resolution: {tarball: https://codeload.github.com/readium/readium-css/tar.gz/5084cac302997da5f66b9ca2c2a7cc6652d9caa3}
+    version: 1.1.0
 
   readium-css@https://codeload.github.com/readium/readium-css/tar.gz/583011453612e6f695056ab6c086a2c4f4cac9c0:
     resolution: {tarball: https://codeload.github.com/readium/readium-css/tar.gz/583011453612e6f695056ab6c086a2c4f4cac9c0}
@@ -4981,6 +4985,8 @@ snapshots:
       picomatch: 2.3.1
 
   readdirp@4.0.1: {}
+
+  readium-css@https://codeload.github.com/readium/readium-css/tar.gz/5084cac302997da5f66b9ca2c2a7cc6652d9caa3: {}
 
   readium-css@https://codeload.github.com/readium/readium-css/tar.gz/583011453612e6f695056ab6c086a2c4f4cac9c0: {}
 


### PR DESCRIPTION
ReadiumCSS has breaking changes in v2, but install would download an older beta version of v1 (lock file). This PR attempts to protect existing apps from these breaking changes from any install/update/upgrade side-effect by explicitly pointing to the latest release (`v.1.1.0`) on `master` branch.

This kinda also creates an issue with Playground as it can’t use the npm package of navigator at the moment, considering it needs v2 of ReadiumCSS. 

Not sure what the best option is as we’ve been working with a submodule so far and can probably continue doing so until this problem is resolved, but I guess it should be discussed in a specific issue as picking between Navigator with ReadiumCSS v1 or ReadiumCSS v2 may be something others want to do, at least temporarily (migration).