### PR TITLE
Fix workspace in navigator-html-injectable

### DIFF
--- a/navigator-html-injectables/package.json
+++ b/navigator-html-injectables/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@juggle/resize-observer": "^3.4.0",
-    "@readium/shared": "workspace:1.2.0",
+    "@readium/shared": "workspace:*",
     "css-selector-generator": "^3.6.4",
     "tslib": "^2.6.1",
     "typescript": "^5.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,7 +60,7 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0
       '@readium/shared':
-        specifier: workspace:1.2.0
+        specifier: workspace:*
         version: link:../shared
       css-selector-generator:
         specifier: ^3.6.4


### PR DESCRIPTION
Otherwise it fails to `pnpm install/add` with error:

```
ERR_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE  In navigator-html-injectables: No matching version found for @readium/shared@workspace:1.2.0 inside the workspace
```