### PR TITLE
First visible locator (EPUBS) improvements

### DIFF
--- a/navigator-html-injectables/package.json
+++ b/navigator-html-injectables/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@juggle/resize-observer": "^3.4.0",
     "@readium/shared": "workspace:*",
-    "css-selector-generator": "^3.6.4",
+    "css-selector-generator": "^3.6.9",
     "tslib": "^2.6.1",
     "typescript": "^5.4.5",
     "vite": "^4.5.5"

--- a/navigator-html-injectables/src/helpers/dom.ts
+++ b/navigator-html-injectables/src/helpers/dom.ts
@@ -69,31 +69,12 @@ export function nearestInteractiveElement(element: Element): Element | null {
 /// the screen.
 export function findFirstVisibleLocator(wnd: ReadiumWindow, scrolling: boolean) {
     const element = findElement(wnd, wnd.document.body, scrolling) as HTMLElement;
-    const removedAttributes = new Map<HTMLElement, Attr[]>();
-    if (element) {
-        // remove all the properties other than class, id or style to avoid breaking the cssSelector
-        for (let i = 0; i < element.attributes?.length; i++) {
-            const attr = element.attributes[i];
-            if (attr.name !== "class" && attr.name !== "id" && attr.name !== "style") {
-                if(!removedAttributes.has(element)) {
-                    removedAttributes.set(element, [attr])
-                } else {
-                    removedAttributes.set(element, removedAttributes.get(element)!.concat([attr]))
-                }
-                element.removeAttribute(attr.name);
-            }
-        }
-    }
     
-    const cssSelector = wnd._readium_cssSelectorGenerator.getCssSelector(element);
-    // Now that the cssSelector is generated, we can put back the removed attributes
-    if (removedAttributes.size > 0) {
-        removedAttributes.forEach((attrs, elem) => {
-            attrs.forEach(attr => {
-                elem.setAttribute(attr.name, attr.value);
-            });
-        });
-    }
+    // Use only the allowed selectors to generate the cssSelector and avoid a crash
+    const cssSelector = wnd._readium_cssSelectorGenerator.getCssSelector(element, { 
+        selectors: ["tag", "id", "class", "nthchild", "nthoftype", "attribute"] 
+    });
+
     return new Locator({
         href: "#",
         type: "application/xhtml+xml",

--- a/navigator-html-injectables/src/modules/Peripherals.ts
+++ b/navigator-html-injectables/src/modules/Peripherals.ts
@@ -71,7 +71,7 @@ export class Peripherals extends Module {
             targetFrameSrc: this.wnd.location.href,
             targetElement: (event.target as Element).outerHTML,
             interactiveElement: nearestInteractiveElement(event.target as Element)?.outerHTML,
-            cssSelector: this.wnd._readium_cssSelectorGenerator.getCssSelector(event.target),
+            cssSelector: this.wnd._readium_cssSelectorGenerator.getCssSelector(event.target as Element),
         } as FrameClickEvent);
 
         this.pointerMoved = false;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       css-selector-generator:
-        specifier: ^3.6.4
-        version: 3.6.4
+        specifier: ^3.6.9
+        version: 3.6.9
       tslib:
         specifier: ^2.6.1
         version: 2.6.1


### PR DESCRIPTION
We have detected some different publications where the first visible locator is not working as expected. Doing an investigation, most of the cases are related to a crash in the usage of "cssSelectorGenerator" method. Additionally, there is another case covered here, when a publication has a list which is long enough to be shown entirely in the current pages.

Cases explanation:

In the first case, I've detected that, when using TTS for some publications in which the elements have custom properties (eg. xml:lang), the css selector process will crash, so the first visible locator will not be in the actual current page, but in the page in which the latest known element is.
<img width="1504" alt="Screenshot 2025-01-10 at 3 04 01 PM" src="https://github.com/user-attachments/assets/dc9ce14c-f827-4f4d-a3f1-de59ecc179e3" />
________________________
1a- Current behavior in _Sept comme setteur_ publication: 
Notice that even if I try to start in the page 46, it will go back to the page 40 (the beginning of the current chapter).

https://github.com/user-attachments/assets/203f7bd0-3a13-4bf5-bde9-2118b88b20f1

1b- New behavior in _Sept comme setteur_ publication: 
As now the cssSelectorGenerator is not crashing, it's able to get the right element to start.

https://github.com/user-attachments/assets/ea4a8d70-38bd-441f-870b-50cfc47d11ff

__________________________

In the second case, the publication I found is a little bit special, most of the content is wrapped into an UL element. 
This situation make the whole list of elements to act as list items, and that's why the current `"display: block"` validation is not enough to detect the right element to be selected as the first visible element.
<img width="1584" alt="Screenshot 2025-01-10 at 3 09 26 PM" src="https://github.com/user-attachments/assets/62d1f355-4591-4c30-b51b-e1a0bb96d1f2" />

___________________________

2a- Current behavior in _CRAAV Therapy_ publication:
Notice that I'm starting in the page 72, but as most of the content is ignored, the "first visible locator" will be the beginning of the UL (in page 5)

https://github.com/user-attachments/assets/80b40da4-2e56-475e-818f-9babb8114857


2b- New behavior in _CRAAV Therapy_ publication:
As now the elements are not ignored, the first visible locator is actually getting the right one.

https://github.com/user-attachments/assets/facc5880-03cc-4091-af36-e2abfcad9c83


