### PR TITLE
fix for 'copyWithLocations is not a function' bug

### DIFF
--- a/navigator/src/epub/EpubNavigator.ts
+++ b/navigator/src/epub/EpubNavigator.ts
@@ -376,8 +376,14 @@ export class EpubNavigator extends VisualNavigator {
         return { first: first, last: last }
     }
 
+    private isFunctionOfObject(obj: any, key: string): boolean {
+        return typeof obj[key] === 'function';
+    }
+
     private async syncLocation(iframeProgress: { progress: number, reference: number }) {
         const nearestPositions = this.findNearestPositions(iframeProgress)
+        const hasCopyWithLocations = this.isFunctionOfObject(nearestPositions.first, "copyWithLocations");
+        if (!hasCopyWithLocations) return  
         this.currentLocation = nearestPositions.first.copyWithLocations({
             progression: iframeProgress.progress // Most accurate progression in resource
         });


### PR DESCRIPTION
There is a bug in EpubNavigator.ts in syncLocation where it calls `nearestPositions.first.copyWithLocations`.  On startup there are cases where the object nearestPositions.first exists but it has not had copyWithLocations added to it yet.  This draft PR adds a private function, isFunctionOfObject, that can be used to check if this object exists.  It then returns from syncLocation if the function doesn't exist.  You may want to deal with the case in a different way but this should at least help demonstrate the issue.
<img width="1128" alt="Screenshot 2025-03-02 at 1 28 57 PM" src="https://github.com/user-attachments/assets/624a5486-65a6-41f6-aaef-2650c245863e" />
  