### PR TITLE
Improve line-length helper

### DIFF
--- a/navigator/docs/epub/ConfiguringEpubNavigator.md
+++ b/navigator/docs/epub/ConfiguringEpubNavigator.md
@@ -98,10 +98,10 @@ EPUB comes in two very different flavors: reflowable which allows a lot of custo
 | Preference               | Reflowable | Fixed Layout |
 | ------------------------ | ---------- | ------------ |
 | backgroundColor          | ✅         |              |
-| blendFilter              | ✅         | ✅           |
-| constraint               | ✅         | ✅           |
+| blendFilter              | ✅         | WIP          |
+| constraint               | ✅         | WIP          |
 | columnCount              | ✅         | (TMP)        |
-| darkenFilter             | ✅         | ✅           |
+| darkenFilter             | ✅         | WIP          |
 | deprecatedFontSize       | ✅         |              |
 | fontFamily               | ✅         |              |
 | fontSize                 | ✅         |              |
@@ -110,14 +110,13 @@ EPUB comes in two very different flavors: reflowable which allows a lot of custo
 | fontWeight               | ✅         |              |
 | fontWidth                | ✅         |              |
 | hyphens                  | ✅         |              |
-| invertFilter             | ✅         | ✅           |
-| invertGaijiFilter        | ✅         | ✅           |
+| invertFilter             | ✅         | WIP          |
+| invertGaijiFilter        | ✅         |              |
 | iPadOSPatch              | ✅         |              |
 | layoutStrategy           | ✅         |              |
 | letterSpacing            | ✅         |              |
 | ligatures                | ✅         |              |
 | lineHeight               | ✅         |              |
-| lineLength               | ✅         |              |
 | linkColor                | ✅         |              |
 | maximalLineLength        | ✅         |              |
 | minimalLineLength        | ✅         |              |
@@ -135,10 +134,17 @@ EPUB comes in two very different flavors: reflowable which allows a lot of custo
 | theme                    | ✅         |              |
 | visitedColor             | ✅         |              |
 | wordSpacing              | ✅         |              |
+| zoom                     |            | WIP          |
 
 ### Layout Strategy
 
 Layout strategy `columns` is not available in scroll mode (`scroll = true`) or when `columnCount` is not `null`.
+
+### Line length
+
+There is no `lineLength` preference because the effective line length is calculated based on the `optimalLineLength`, `minimalLineLength` and `maximalLineLength` preferences. 
+
+If you prefer to set a line length yourself, you can set `optimalLineLength` to the desired value (`ch|ic` unit) with `layoutStrategy` set to `margins`.
 
 ### Scroll vs paginated
 

--- a/navigator/package.json
+++ b/navigator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "type": "module",
   "description": "Next generation SDK for publications in Web Apps",
   "author": "readium",

--- a/navigator/src/epub/css/ReadiumCSS.ts
+++ b/navigator/src/epub/css/ReadiumCSS.ts
@@ -1,12 +1,8 @@
-import { ILineLengthsConfig, LineLengths } from "../../helpers";
+import { LineLengths } from "../../helpers";
 import { getContentWidth } from "../../helpers/dimensions";
 import { LayoutStrategy } from "../../preferences";
 import { EpubSettings } from "../preferences/EpubSettings";
 import { IUserProperties, RSProperties, UserProperties } from "./Properties";
-
-type ILineLengthsProps = {
-  [K in Exclude<keyof ILineLengthsConfig, "fontSize" | "sample" | "isCJK" | "getRelative">]?: ILineLengthsConfig[K]
-};
 
 export interface IReadiumCSS {
   rsProperties: RSProperties;
@@ -55,13 +51,12 @@ export class ReadiumCSS {
 
     // This has to be updated before pagination
     // otherwise the metrics won’t be correct for line length
-    this.updateLineLengths({
+    this.lineLengths.update({
       fontFace: settings.fontFamily,
       letterSpacing: settings.letterSpacing,
       pageGutter: settings.pageGutter,
       wordSpacing: settings.wordSpacing,
       optimalChars: settings.optimalLineLength,
-      userChars: settings.lineLength,
       minChars: settings.minimalLineLength,
       maxChars: settings.maximalLineLength
     });
@@ -131,17 +126,6 @@ export class ReadiumCSS {
     this.userProperties = new UserProperties(updated);
   }
 
-  private updateLineLengths(props: ILineLengthsProps) {
-    if (props.fontFace !== undefined) this.lineLengths.fontFace = props.fontFace;
-    if (props.letterSpacing !== undefined) this.lineLengths.letterSpacing = props.letterSpacing || 0;
-    if (props.pageGutter !== undefined) this.lineLengths.pageGutter = props.pageGutter || 0;
-    if (props.wordSpacing !== undefined) this.lineLengths.wordSpacing = props.wordSpacing || 0;
-    if (props.optimalChars) this.lineLengths.optimalChars = props.optimalChars;
-    if (props.userChars !== undefined) this.lineLengths.userChars = props.userChars;
-    if (props.minChars !== undefined) this.lineLengths.minChars = props.minChars;
-    if (props.maxChars !== undefined) this.lineLengths.maxChars = props.maxChars;
-  }
-
   private updateLayout(scale: number | null, deprecatedImplem: boolean | null, scroll: boolean | null, colCount?: number | null) {
     const isScroll = scroll ?? this.userProperties.view === "scroll";
 
@@ -165,7 +149,7 @@ export class ReadiumCSS {
     return {
       zoomFactor: zoomFactor,
       zoomCompensation: zoomCompensation,
-      optimal: Math.round(this.lineLengths.userLineLength || this.lineLengths.optimalLineLength) * zoomFactor,
+      optimal: Math.round(this.lineLengths.optimalLineLength) * zoomFactor,
       minimal: this.lineLengths.minimalLineLength !== null 
         ? Math.round(this.lineLengths.minimalLineLength * zoomFactor) 
         : null,

--- a/navigator/src/epub/preferences/EpubDefaults.ts
+++ b/navigator/src/epub/preferences/EpubDefaults.ts
@@ -43,7 +43,6 @@ export interface IEpubDefaults {
   letterSpacing?: number | null,
   ligatures?: boolean | null,
   lineHeight?: number | null,
-  lineLength?: number | null,
   linkColor?: string | null,
   maximalLineLength?: number | null,
   minimalLineLength?: number | null,
@@ -85,7 +84,6 @@ export class EpubDefaults {
   letterSpacing: number | null;
   ligatures: boolean | null;
   lineHeight: number | null;
-  lineLength: number | null;
   linkColor: string | null;
   maximalLineLength: number | null;
   minimalLineLength: number | null;
@@ -146,9 +144,8 @@ export class EpubDefaults {
     this.visitedColor = ensureString(defaults.visitedColor) || null;
     this.wordSpacing = ensureNonNegative(defaults.wordSpacing) || null;
 
-    this.lineLength = ensureNonNegative(defaults.lineLength) || null;
     this.optimalLineLength = ensureNonNegative(defaults.optimalLineLength) || 65;
-    this.maximalLineLength = withFallback(ensureMoreThanOrEqual(defaults.maximalLineLength, this.lineLength || this.optimalLineLength), 80);
-    this.minimalLineLength = withFallback(ensureLessThanOrEqual(defaults.minimalLineLength, this.lineLength || this.optimalLineLength), 40);
+    this.maximalLineLength = withFallback(ensureMoreThanOrEqual(defaults.maximalLineLength, this.optimalLineLength), 80);
+    this.minimalLineLength = withFallback(ensureLessThanOrEqual(defaults.minimalLineLength, this.optimalLineLength), 40);
   }
 }

--- a/navigator/src/epub/preferences/EpubPreferences.ts
+++ b/navigator/src/epub/preferences/EpubPreferences.ts
@@ -40,7 +40,6 @@ export interface IEpubPreferences {
   letterSpacing?: number | null,
   ligatures?: boolean | null,
   lineHeight?: number | null,
-  lineLength?: number | null,
   linkColor?: string | null,
   maximalLineLength?: number | null,
   minimalLineLength?: number | null,
@@ -82,7 +81,6 @@ export class EpubPreferences implements ConfigurablePreferences {
   letterSpacing?: number | null;
   ligatures?: boolean | null;
   lineHeight?: number | null;
-  lineLength?: number | null;
   linkColor?: string | null;
   maximalLineLength?: number | null;
   minimalLineLength?: number | null;
@@ -138,7 +136,6 @@ export class EpubPreferences implements ConfigurablePreferences {
     this.visitedColor = ensureString(preferences.visitedColor);
     this.wordSpacing = ensureNonNegative(preferences.wordSpacing);
 
-    this.lineLength = ensureNonNegative(preferences.lineLength);
     this.optimalLineLength = ensureNonNegative(preferences.optimalLineLength);
     this.maximalLineLength = ensureNonNegative(preferences.maximalLineLength);
     this.minimalLineLength = ensureNonNegative(preferences.minimalLineLength);
@@ -167,12 +164,12 @@ export class EpubPreferences implements ConfigurablePreferences {
         (
           key !== "maximalLineLength" ||
           other[key] === null ||
-          (other[key] >= (other.lineLength ?? merged.lineLength ?? other.optimalLineLength ?? merged.optimalLineLength ?? 65))
+          (other[key] >= (other.optimalLineLength ?? merged.optimalLineLength ?? 65))
         ) &&
         (
           key !== "minimalLineLength" ||
           other[key] === null || 
-          (other[key] <= (other.lineLength ?? merged.lineLength ?? other.optimalLineLength ?? merged.optimalLineLength ?? 65))
+          (other[key] <= (other.optimalLineLength ?? merged.optimalLineLength ?? 65))
         )
       ) {
         merged[key] = other[key];

--- a/navigator/src/epub/preferences/EpubPreferencesEditor.ts
+++ b/navigator/src/epub/preferences/EpubPreferencesEditor.ts
@@ -285,19 +285,6 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
     });
   }
 
-  get lineLength(): RangePreference<number> {
-    return new RangePreference<number>({
-      initialValue: this.preferences.lineLength,
-      effectiveValue: this.settings.lineLength || this.settings.optimalLineLength,
-      isEffective: this.layout === EPUBLayout.reflowable && this.preferences.lineLength !== null,
-      onChange: (newValue: number | null | undefined) => {
-        this.updatePreference("lineLength", newValue || null);
-      },
-      supportedRange: [20, 100],
-      step: 1
-    });
-  }
-
   get linkColor(): Preference<string> {
     return new Preference<string>({
       initialValue: this.preferences.linkColor,
@@ -350,7 +337,7 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
     return new RangePreference<number>({
       initialValue: this.preferences.optimalLineLength,
       effectiveValue: this.settings.optimalLineLength,
-      isEffective: this.layout === EPUBLayout.reflowable && !this.settings.lineLength,
+      isEffective: this.layout === EPUBLayout.reflowable,
       onChange: (newValue: number | null | undefined) => {
         this.updatePreference("optimalLineLength", newValue as number);
       },

--- a/navigator/src/epub/preferences/EpubSettings.ts
+++ b/navigator/src/epub/preferences/EpubSettings.ts
@@ -27,7 +27,6 @@ export interface IEpubSettings {
   letterSpacing?: number | null,
   ligatures?: boolean | null,
   lineHeight?: number | null,
-  lineLength?: number | null,
   linkColor?: string | null,
   maximalLineLength?: number | null,
   minimalLineLength?: number | null,
@@ -69,7 +68,6 @@ export class EpubSettings implements ConfigurableSettings {
   letterSpacing: number | null;
   ligatures: boolean | null;
   lineHeight: number | null;
-  lineLength: number | null;
   linkColor: string | null;
   maximalLineLength: number | null;
   minimalLineLength: number | null;
@@ -159,11 +157,6 @@ export class EpubSettings implements ConfigurableSettings {
       ? preferences.lineHeight 
       : defaults.lineHeight !== undefined 
         ? defaults.lineHeight 
-        : null;
-    this.lineLength = preferences.lineLength !== undefined 
-      ? preferences.lineLength 
-      : defaults.lineLength !== undefined 
-        ? defaults.lineLength 
         : null;
     this.linkColor = preferences.linkColor || defaults.linkColor || null;
     this.maximalLineLength = preferences.maximalLineLength === null 

--- a/navigator/src/helpers/lineLength.ts
+++ b/navigator/src/helpers/lineLength.ts
@@ -9,7 +9,6 @@ export interface ILineLengthsConfig {
   optimalChars: number;
   minChars?: number | null;
   maxChars?: number | null;
-  userChars?: number | null;
   baseFontSize?: number | null;
   sample?: string | null;
   pageGutter?: number | null;
@@ -22,7 +21,6 @@ export interface ILineLengthsConfig {
 
 export interface ILineLengths {
   min: number | null;
-  user: number | null;
   max: number | null;
   optimal: number;
   baseFontSize: number;
@@ -41,7 +39,7 @@ const DEFAULT_FONT_FACE = fontStacks.RS__oldStyleTf;
 // offset on the y-axis (using fillText), and getting the total height.
 // If you don’t need high accuracy, it’s acceptable to use the one returned with isCJK.
 //
-// Instead of measuring text for min, user, and optimal each, we define multipliers
+// Instead of measuring text for min and maximal, we define multipliers
 // at the end, with optimalLineLength as a ref, before returning the lineLengths object.
 
 export class LineLengths {
@@ -50,7 +48,6 @@ export class LineLengths {
   private _optimalChars: number;
   private _minChars?: number | null;
   private _maxChars?: number | null;
-  private _userChars: number | null;
   private _baseFontSize: number;
   private _fontFace: string | ICustomFontFace;
   private _sample: string | null;
@@ -62,7 +59,6 @@ export class LineLengths {
   
   private _padding: number;
   private _minDivider: number | null;
-  private _userMultiplier: number | null;
   private _maxMultiplier: number | null;
   private _approximatedWordSpaces: number;
 
@@ -73,7 +69,6 @@ export class LineLengths {
     this._optimalChars = config.optimalChars;
     this._minChars = config.minChars;
     this._maxChars = config.maxChars;
-    this._userChars = config.userChars || null;
     this._baseFontSize = config.baseFontSize || DEFAULT_FONT_SIZE;
     this._fontFace = config.fontFace || DEFAULT_FONT_FACE;
     this._sample = config.sample || null;
@@ -92,9 +87,6 @@ export class LineLengths {
       : this._minChars === null 
         ? null
         : 1;
-    this._userMultiplier = this._userChars 
-      ? this._userChars / this._optimalChars 
-      : null;
     this._maxMultiplier = this._maxChars && this._maxChars > this._optimalChars
       ? this._maxChars / this._optimalChars 
       : this._maxChars === null 
@@ -103,25 +95,13 @@ export class LineLengths {
     this._approximatedWordSpaces = LineLengths.approximateWordSpaces(this._optimalChars, this._sample);
   }
 
-  set minChars(n: number | null) {
-    if (n === this._minChars) return;
-    this._minChars = n;
+  private updateMultipliers() {
     this._minDivider = this._minChars && this._minChars < this._optimalChars 
       ? this._optimalChars / this._minChars 
       : this._minChars === null 
         ? null
         : 1;
-  }
 
-  set optimalChars(n: number) {
-    if (n === this._optimalChars) return;
-    this._optimalChars = n;
-    this._optimalLineLength = this.getOptimalLineLength();
-  }
-
-  set maxChars(n: number | null) {
-    if (n === this._maxChars) return;
-    this._maxChars = n;
     this._maxMultiplier = this._maxChars && this._maxChars > this._optimalChars 
       ? this._maxChars / this._optimalChars 
       : this._maxChars === null 
@@ -129,50 +109,28 @@ export class LineLengths {
         : 1;
   }
 
-  set userChars(n: number | null) {
-    if (n === this._userChars) return;
-    this._userChars = n;
-    this._userMultiplier = this._userChars ? this._userChars / this._optimalChars : null;
-  }
+  // Batch update to guarantee up-to-date values
+  // Not filtering because pretty much everything can
+  // trigger a recomputation anyway.
+  update(props: Partial<ILineLengthsConfig>) {
+    if (props.optimalChars) this._optimalChars = props.optimalChars;
+    if (props.minChars !== undefined) this._minChars = props.minChars;
+    if (props.maxChars !== undefined) this._maxChars = props.maxChars;
+    if (props.baseFontSize) this._baseFontSize = props.baseFontSize;
+    if (props.fontFace !== undefined) this._fontFace = props.fontFace || DEFAULT_FONT_FACE;
+    if (props.letterSpacing) this._letterSpacing = props.letterSpacing;
+    if (props.wordSpacing) this._wordSpacing = props.wordSpacing;
+    if (props.isCJK != null) this._isCJK = props.isCJK;
+    if (props.pageGutter) this._pageGutter = props.pageGutter;
+    if (props.getRelative) this._getRelative = props.getRelative;
 
-  set letterSpacing(n: number) {
-    if (n === this._letterSpacing) return;
-    this._letterSpacing = Math.round(n * this._baseFontSize);
+    if (props.sample) {
+      this._sample = props.sample;
+      this._approximatedWordSpaces = LineLengths.approximateWordSpaces(this._optimalChars, this._sample);
+    }
+
+    this.updateMultipliers();
     this._optimalLineLength = this.getOptimalLineLength();
-  }
-  
-  set wordSpacing(n: number) {
-    if (n === this._wordSpacing) return;
-    this._wordSpacing = Math.round(n * this._baseFontSize);
-    this._optimalLineLength = this.getOptimalLineLength();
-  }
-
-  set baseFontSize(n: number) {
-    this._baseFontSize = n;
-    this._optimalLineLength = this.getOptimalLineLength();
-  }
-
-  set fontFace(f: string | ICustomFontFace | null) {
-    this._fontFace = f || DEFAULT_FONT_FACE;
-    this._optimalLineLength = this.getOptimalLineLength();
-  }
-
-  set sample(s: string) {
-    if (s === this._sample) return;
-    this._sample = s;
-    this._approximatedWordSpaces = LineLengths.approximateWordSpaces(this._optimalChars, this._sample);
-  }
-
-  set pageGutter(n: number) {
-    if (n === this._pageGutter) return;
-    this._pageGutter = n;
-    this._padding = this._pageGutter * 2;
-    this._optimalLineLength = this.getOptimalLineLength();
-  }
-
-  set relativeGetters(b: boolean) {
-    if (b === this._getRelative) return;
-    this._getRelative = b;
   }
 
   get baseFontSize() {
@@ -185,15 +143,6 @@ export class LineLengths {
     }
     return this._minDivider !== null 
       ? Math.round((this._optimalLineLength / this._minDivider) + this._padding) / (this._getRelative ? this._baseFontSize : 1) 
-      : null;
-  }
-
-  get userLineLength(): number | null {
-    if (!this._optimalLineLength) {
-      this._optimalLineLength = this.getOptimalLineLength();
-    }
-    return this._userMultiplier !== null 
-      ? Math.round((this._optimalLineLength * this._userMultiplier) + this._padding) / (this._getRelative ? this._baseFontSize : 1) 
       : null;
   }
 
@@ -219,7 +168,6 @@ export class LineLengths {
     }
     return {
       min: this.minimalLineLength,
-      user: this.userLineLength,
       max: this.maximalLineLength,
       optimal: this.optimalLineLength,
       baseFontSize: this._baseFontSize


### PR DESCRIPTION
This provides a new `update` method to batch changes to the lineLength helper config, replacing setters for all properties, in order to guarantee values won’t go stale and you don’t have to care about the order, etc. It should fix bugs that were observable in playground.readium.org’s Layout Strategy settings (in the overflow menu), excluding incorrect values at instantiation, which are the responsibility of Thorium Web – currently they are not passed to EPUBNavigator on load. 

It also removes property `lineLength`, which was not used and added complexity for no reason. 

This removed property could eventually become a way to set the line-length directly into pixels (through ReadiumCSS custom property), bypassing the lineLength helper entirely if there is such requirement, but this should be done as a specific PR anyways, given the entire logic should be rewritten in that case. 