### PR TITLE
Improve SSR import-ability of toolkit

### DIFF
--- a/navigator-html-injectables/package.json
+++ b/navigator-html-injectables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator-html-injectables",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "type": "module",
   "description": "An embeddable solution for connecting frames of HTML publications with a Readium Navigator",
   "author": "readium",

--- a/navigator-html-injectables/src/modules/Decorator.ts
+++ b/navigator-html-injectables/src/modules/Decorator.ts
@@ -49,7 +49,7 @@ interface DecorationItem {
     container: HTMLElement | undefined;
 }
 
-const canNativeHighlight = "Highlight" in window;
+const canNativeHighlight = () => ("Highlight" in window);
 const cannotNativeHighlight = ["IMG", "IMAGE", "AUDIO", "VIDEO", "SVG"];
 
 class DecorationGroup {
@@ -71,7 +71,7 @@ class DecorationGroup {
         private readonly id: string,
         private readonly name: string
     ) {
-        if (canNativeHighlight) {
+        if (canNativeHighlight()) {
             this.experimentalHighlights = true;
             this.notTextFlag = new Map<string, boolean>();
         }


### PR DESCRIPTION
An attempt was made to use the ts-toolkit (more specifically, thorium-web) in combination with Next.JS SSR. In the SSR context, the global `window` is not available. In the injectables, we check for highlighting support in the browser, which was done by having a global const `const canNativeHighlight = "Highlight" in window;`. This broke the SSR because `window` is undefined. So I've changed it to a function instead so it won't get executed on import.