### PR TITLE
Update Preferences API for Readium css beta14

### DIFF
--- a/navigator/package.json
+++ b/navigator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "type": "module",
   "description": "Next generation SDK for publications in Web Apps",
   "author": "readium",
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@laynezh/vite-plugin-lib-assets": "^0.5.25",
-    "@readium/css": ">=2.0.0-beta.13",
+    "@readium/css": ">=2.0.0-beta.14",
     "@readium/navigator-html-injectables": "workspace:*",
     "@readium/shared": "workspace:*",
     "@types/path-browserify": "^1.0.3",

--- a/navigator/src/epub/css/Properties.ts
+++ b/navigator/src/epub/css/Properties.ts
@@ -60,7 +60,6 @@ export interface IUserProperties {
   deprecatedFontSize?: boolean | null;
   fontFamily?: string | null;
   fontOpticalSizing?: FontOpticalSizing | null;
-  fontOverride?: boolean | null;
   fontSize?: number | null;
   fontSizeNormalize?: boolean | null;
   fontWeight?: number | null;
@@ -96,7 +95,6 @@ export class UserProperties extends Properties {
   deprecatedFontSize: boolean | null;
   fontFamily: string | null;
   fontOpticalSizing: FontOpticalSizing | null;
-  fontOverride: boolean | null;
   fontSize: number | null;
   fontSizeNormalize: boolean | null;
   fontWeight: number | null;
@@ -132,7 +130,6 @@ export class UserProperties extends Properties {
     this.deprecatedFontSize = props.deprecatedFontSize ?? null;
     this.fontFamily = props.fontFamily ?? null;
     this.fontOpticalSizing = props.fontOpticalSizing ?? null;
-    this.fontOverride = props.fontOverride ?? null;
     this.fontSize = props.fontSize ?? null;
     this.fontSizeNormalize = props.fontSizeNormalize ?? null;
     this.fontWeight = props.fontWeight ?? null;
@@ -174,7 +171,6 @@ export class UserProperties extends Properties {
     if (this.deprecatedFontSize) cssProperties["--USER__fontSizeImplementation"] = this.toFlag("deprecatedFontSize");
     if (this.fontFamily) cssProperties["--USER__fontFamily"] = this.fontFamily;
     if (this.fontOpticalSizing != null) cssProperties["--USER__fontOpticalSizing"] = this.fontOpticalSizing;
-    if (this.fontOverride) cssProperties["--USER__fontOverride"] = this.toFlag("font");
     if (this.fontSize != null) cssProperties["--USER__fontSize"] = this.toPercentage(this.fontSize, true);
     if (this.fontSizeNormalize) cssProperties["--USER__fontSizeNormalize"] = this.toFlag("normalize");
     if (this.fontWeight != null) cssProperties["--USER__fontWeight"] = this.toUnitless(this.fontWeight);

--- a/navigator/src/epub/css/Properties.ts
+++ b/navigator/src/epub/css/Properties.ts
@@ -230,6 +230,7 @@ export interface IRSProperties {
   maxMediaHeight?: number | null;
   modernTf?: string | null;
   monospaceTf?: string | null;
+  noOverflow?: boolean | null;
   noVerticalPagination?: boolean | null;
   oldStyleTf?: string | null;
   pageGutter?: number | null;
@@ -269,6 +270,7 @@ export class RSProperties extends Properties {
   maxMediaHeight: number | null;
   modernTf: string | null;
   monospaceTf: string | null;
+  noOverflow: boolean | null;
   noVerticalPagination: boolean | null;
   oldStyleTf: string | null;
   pageGutter: number | null;
@@ -308,6 +310,7 @@ export class RSProperties extends Properties {
     this.maxMediaHeight = props.maxMediaHeight ?? null;
     this.modernTf = props.modernTf ?? null;
     this.monospaceTf = props.monospaceTf ?? null;
+    this.noOverflow = props.noOverflow ?? null;
     this.noVerticalPagination = props.noVerticalPagination ?? null;
     this.oldStyleTf = props.oldStyleTf ?? null;
     this.pageGutter = props.pageGutter ?? null;
@@ -349,6 +352,7 @@ export class RSProperties extends Properties {
     if (this.maxMediaHeight) cssProperties["--RS__maxMediaHeight"] = this.toVh(this.maxMediaHeight);
     if (this.modernTf) cssProperties["--RS__modernTf"] = this.modernTf;
     if (this.monospaceTf) cssProperties["--RS__monospaceTf"] = this.monospaceTf;
+    if (this.noOverflow) cssProperties["--RS__disableOverflow"] = this.toFlag("noOverflow");
     if (this.noVerticalPagination) cssProperties["--RS__disablePagination"] = this.toFlag("noVerticalPagination");
     if (this.oldStyleTf) cssProperties["--RS__oldStyleTf"] = this.oldStyleTf;
     if (this.pageGutter != null) cssProperties["--RS__pageGutter"] = this.toPx(this.pageGutter);

--- a/navigator/src/epub/css/ReadiumCSS.ts
+++ b/navigator/src/epub/css/ReadiumCSS.ts
@@ -85,12 +85,6 @@ export class ReadiumCSS {
         : settings.fontOpticalSizing 
           ? "auto" 
           : "none",
-      fontOverride: settings.fontOverride !== null 
-        ? settings.fontOverride 
-        : (settings.textNormalization || settings.fontFamily 
-          ? true 
-          : false
-        ),
       fontSize: settings.fontSize,
       fontSizeNormalize: settings.fontSizeNormalize,
       fontWeight: settings.fontWeight,

--- a/navigator/src/epub/preferences/EpubDefaults.ts
+++ b/navigator/src/epub/preferences/EpubDefaults.ts
@@ -32,7 +32,6 @@ export interface IEpubDefaults {
   fontSize?: number | null,
   fontSizeNormalize?: boolean | null,
   fontOpticalSizing?: boolean | null,
-  fontOverride?: boolean | null,
   fontWeight?: number | null,
   fontWidth?: number | null,
   hyphens?: boolean | null,
@@ -73,7 +72,6 @@ export class EpubDefaults {
   fontSize: number | null;
   fontSizeNormalize: boolean | null;
   fontOpticalSizing: boolean | null;
-  fontOverride: boolean | null;
   fontWeight: number | null;
   fontWidth: number | null;
   hyphens: boolean | null;
@@ -116,7 +114,6 @@ export class EpubDefaults {
     this.fontSize = ensureValueInRange(defaults.fontSize, fontSizeRangeConfig.range) || 1;
     this.fontSizeNormalize = ensureBoolean(defaults.fontSizeNormalize) ?? false;
     this.fontOpticalSizing = ensureBoolean(defaults.fontOpticalSizing) ?? null;
-    this.fontOverride = ensureBoolean(defaults.fontOverride) ?? null;
     this.fontWeight = ensureValueInRange(defaults.fontWeight, fontWeightRangeConfig.range) || null;
     this.fontWidth = ensureValueInRange(defaults.fontWidth,fontWidthRangeConfig.range) || null;
     this.hyphens = ensureBoolean(defaults.hyphens) ?? null;

--- a/navigator/src/epub/preferences/EpubPreferences.ts
+++ b/navigator/src/epub/preferences/EpubPreferences.ts
@@ -29,7 +29,6 @@ export interface IEpubPreferences {
   fontSize?: number | null,
   fontSizeNormalize?: boolean | null,
   fontOpticalSizing?: boolean | null,
-  fontOverride?: boolean | null,
   fontWeight?: number | null,
   fontWidth?: number | null,
   hyphens?: boolean | null,
@@ -70,7 +69,6 @@ export class EpubPreferences implements ConfigurablePreferences {
   fontSize?: number | null;
   fontSizeNormalize?: boolean | null;
   fontOpticalSizing?: boolean | null;
-  fontOverride?: boolean | null;
   fontWeight?: number | null;
   fontWidth?: number | null;
   hyphens?: boolean | null;
@@ -110,7 +108,6 @@ export class EpubPreferences implements ConfigurablePreferences {
     this.fontSize = ensureValueInRange(preferences.fontSize, fontSizeRangeConfig.range);
     this.fontSizeNormalize = ensureBoolean(preferences.fontSizeNormalize);
     this.fontOpticalSizing = ensureBoolean(preferences.fontOpticalSizing);
-    this.fontOverride = ensureBoolean(preferences.fontOverride);
     this.fontWeight = ensureValueInRange(preferences.fontWeight, fontWeightRangeConfig.range);
     this.fontWidth = ensureValueInRange(preferences.fontWidth,fontWidthRangeConfig.range);
     this.hyphens = ensureBoolean(preferences.hyphens);

--- a/navigator/src/epub/preferences/EpubPreferencesEditor.ts
+++ b/navigator/src/epub/preferences/EpubPreferencesEditor.ts
@@ -12,7 +12,7 @@ import {
   fontWidthRangeConfig 
 } from "../../preferences/Types";
 
-import dayMode from "@readium/css/css/vars/day.json";
+import defaultColors from "@readium/css/css/vars/day.json";
 
 // WIP: will change cos’ of all the missing pieces
 export class EpubPreferencesEditor implements IPreferencesEditor {
@@ -39,7 +39,7 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
   get backgroundColor(): Preference<string> {
     return new Preference<string>({
       initialValue: this.preferences.backgroundColor,
-      effectiveValue: this.settings.backgroundColor || dayMode.RS__backgroundColor,
+      effectiveValue: this.settings.backgroundColor || defaultColors.RS__backgroundColor,
       isEffective: this.preferences.backgroundColor !== null,
       onChange: (newValue: string | null | undefined) => {
         this.updatePreference("backgroundColor", newValue || null);
@@ -277,7 +277,7 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
   get linkColor(): Preference<string> {
     return new Preference<string>({
       initialValue: this.preferences.linkColor,
-      effectiveValue: this.settings.linkColor || dayMode.RS__linkColor,
+      effectiveValue: this.settings.linkColor || defaultColors.RS__linkColor,
       isEffective: this.layout === EPUBLayout.reflowable && this.preferences.linkColor !== null,
       onChange: (newValue: string | null | undefined) => {
         this.updatePreference("linkColor", newValue || null);
@@ -386,7 +386,7 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
   get selectionBackgroundColor(): Preference<string> {
     return new Preference<string>({
       initialValue: this.preferences.selectionBackgroundColor,
-      effectiveValue: this.settings.selectionBackgroundColor || dayMode.RS__selectionBackgroundColor,
+      effectiveValue: this.settings.selectionBackgroundColor || defaultColors.RS__selectionBackgroundColor,
       isEffective: this.layout === EPUBLayout.reflowable && this.preferences.selectionBackgroundColor !== null,
       onChange: (newValue: string | null | undefined) => {
         this.updatePreference("selectionBackgroundColor", newValue || null);
@@ -397,7 +397,7 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
   get selectionTextColor(): Preference<string> {
     return new Preference<string>({
       initialValue: this.preferences.selectionTextColor,
-      effectiveValue: this.settings.selectionTextColor || dayMode.RS__selectionTextColor,
+      effectiveValue: this.settings.selectionTextColor || defaultColors.RS__selectionTextColor,
       isEffective: this.layout === EPUBLayout.reflowable && this.preferences.selectionTextColor !== null,
       onChange: (newValue: string | null | undefined) => {
         this.updatePreference("selectionTextColor", newValue || null);
@@ -420,7 +420,7 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
   get textColor(): Preference<string> {
     return new Preference<string>({
       initialValue: this.preferences.textColor,
-      effectiveValue: this.settings.textColor || dayMode.RS__textColor,
+      effectiveValue: this.settings.textColor || defaultColors.RS__textColor,
       isEffective: this.layout === EPUBLayout.reflowable && this.preferences.textColor !== null,
       onChange: (newValue: string | null | undefined) => {
         this.updatePreference("textColor", newValue || null);
@@ -442,7 +442,7 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
   get theme(): EnumPreference<Theme> {
     return new EnumPreference<Theme>({
       initialValue: this.preferences.theme,
-      effectiveValue: this.settings.theme || Theme.day,
+      effectiveValue: this.settings.theme || null,
       isEffective: this.layout === EPUBLayout.reflowable,
       onChange: (newValue: Theme | null | undefined) => {
         this.updatePreference("theme", newValue || null);
@@ -454,7 +454,7 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
   get visitedColor(): Preference<string> {
     return new Preference<string>({
       initialValue: this.preferences.visitedColor,
-      effectiveValue: this.settings.visitedColor || dayMode.RS__visitedColor,
+      effectiveValue: this.settings.visitedColor || defaultColors.RS__visitedColor,
       isEffective: this.layout === EPUBLayout.reflowable && this.preferences.visitedColor !== null,
       onChange: (newValue: string | null | undefined) => {
         this.updatePreference("visitedColor", newValue || null);

--- a/navigator/src/epub/preferences/EpubPreferencesEditor.ts
+++ b/navigator/src/epub/preferences/EpubPreferencesEditor.ts
@@ -149,17 +149,6 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
     });
   }
 
-  get fontOverride(): BooleanPreference {
-    return new BooleanPreference({
-      initialValue: this.preferences.fontOverride,
-      effectiveValue: this.settings.fontOverride || false,
-      isEffective: this.layout === EPUBLayout.reflowable && this.preferences.fontOverride !== null,
-      onChange: (newValue: boolean | null | undefined) => {
-        this.updatePreference("fontOverride", newValue || null);
-      }
-    });
-  }
-
   get fontWeight(): RangePreference<number> {
     return new RangePreference<number>({
       initialValue: this.preferences.fontWeight,

--- a/navigator/src/epub/preferences/EpubSettings.ts
+++ b/navigator/src/epub/preferences/EpubSettings.ts
@@ -16,7 +16,6 @@ export interface IEpubSettings {
   fontSize?: number | null,
   fontSizeNormalize?: boolean | null,
   fontOpticalSizing?: boolean | null,
-  fontOverride?: boolean | null,
   fontWeight?: number | null,
   fontWidth?: number | null,
   hyphens?: boolean | null,
@@ -57,7 +56,6 @@ export class EpubSettings implements ConfigurableSettings {
   fontSize: number | null;
   fontSizeNormalize: boolean | null;
   fontOpticalSizing: boolean | null;
-  fontOverride: boolean | null;
   fontWeight: number | null;
   fontWidth: number | null;
   hyphens: boolean | null;
@@ -115,9 +113,6 @@ export class EpubSettings implements ConfigurableSettings {
     this.fontOpticalSizing = typeof preferences.fontOpticalSizing === "boolean" 
       ? preferences.fontOpticalSizing 
       : defaults.fontOpticalSizing ?? null;
-    this.fontOverride = typeof preferences.fontOverride === "boolean" 
-      ? preferences.fontOverride 
-      : defaults.fontOverride ?? null;
     this.fontWeight = preferences.fontWeight !== undefined 
       ? preferences.fontWeight 
       : defaults.fontWeight !== undefined 

--- a/navigator/src/preferences/Types.ts
+++ b/navigator/src/preferences/Types.ts
@@ -6,7 +6,6 @@ export enum TextAlignment {
 };
 
 export enum Theme {
-  day = "day",
   sepia = "sepia",
   night = "night",
   custom = "custom"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.5.25
         version: 0.5.25(vite@4.5.5(@types/node@20.4.8)(less@4.2.0)(sass@1.81.0)(stylus@0.62.0))
       '@readium/css':
-        specifier: '>=2.0.0-beta.13'
-        version: 2.0.0-beta.13
+        specifier: '>=2.0.0-beta.14'
+        version: 2.0.0-beta.14
       '@readium/navigator-html-injectables':
         specifier: workspace:*
         version: link:../navigator-html-injectables
@@ -1241,8 +1241,8 @@ packages:
   '@readium/css@1.1.0':
     resolution: {integrity: sha512-vcUx/+UYlWXuG6ioZNVBFDlKCuyH+65x9dNJM9jLlA8yT5ReH0k2UR9DN8cwx5/BgJhoQLUsA9s2DPhGaMhX6A==}
 
-  '@readium/css@2.0.0-beta.13':
-    resolution: {integrity: sha512-45WweTkywrRmPiaKE0gCKOxyMJjCyNzv/FG4H31vxeOdmGpZXeoQSpK7jm5DGnrlCUHUPQzkLSwJtNJhXBY3AQ==}
+  '@readium/css@2.0.0-beta.14':
+    resolution: {integrity: sha512-Js7kDFCJAoUCLqpWsesO/ywP+BwrLMzBUvKB7MnimHIZrkHAMZKzpm8W3O02vQkQm3mTW185Wa1KllQkA0tUhA==}
 
   '@sinclair/typebox@0.24.51':
     resolution: {integrity: sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==}
@@ -3976,7 +3976,7 @@ snapshots:
 
   '@readium/css@1.1.0': {}
 
-  '@readium/css@2.0.0-beta.13': {}
+  '@readium/css@2.0.0-beta.14': {}
 
   '@sinclair/typebox@0.24.51': {}
 


### PR DESCRIPTION
This removes `fontOverride` as it is no longer required to set font-related settings, as well as `day` theme since it is now part of `base` and no longer a fake theme in ReadiumCSS. 

This also adds RS property `noOverflow` in case we need to disable overflow management from ReadiumCSS. This was made available for other platforms where the declarations are problematic, and we may need it in the future for writing modes or for when we change how progression through resources is handled. 