### PR TITLE
Scroll padding

### DIFF
--- a/navigator/package.json
+++ b/navigator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "type": "module",
   "description": "Next generation SDK for publications in Web Apps",
   "author": "readium",
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@laynezh/vite-plugin-lib-assets": "^0.5.25",
-    "@readium/css": ">=2.0.0-beta.14",
+    "@readium/css": ">=2.0.0-beta.15",
     "@readium/navigator-html-injectables": "workspace:*",
     "@readium/shared": "workspace:*",
     "@types/path-browserify": "^1.0.3",

--- a/navigator/src/epub/css/Properties.ts
+++ b/navigator/src/epub/css/Properties.ts
@@ -240,6 +240,10 @@ export interface IRSProperties {
   sansSerifJa?: string | null;
   sansSerifJaV?: string | null;
   sansTf?: string | null;
+  scrollPaddingBottom?: number | null;
+  scrollPaddingLeft?: number | null;
+  scrollPaddingRight?: number | null;
+  scrollPaddingTop?: number | null;
   secondaryColor?: string | null;
   selectionBackgroundColor?: string | null;
   selectionTextColor?: string | null;
@@ -280,6 +284,10 @@ export class RSProperties extends Properties {
   sansSerifJa: string | null;
   sansSerifJaV: string | null;
   sansTf: string | null;
+  scrollPaddingBottom: number | null;
+  scrollPaddingLeft: number | null;
+  scrollPaddingRight: number | null;
+  scrollPaddingTop: number | null;
   secondaryColor: string | null;
   selectionBackgroundColor: string | null;
   selectionTextColor: string | null;
@@ -317,6 +325,10 @@ export class RSProperties extends Properties {
     this.paraIndent = props.paraIndent ?? null;
     this.paraSpacing = props.paraSpacing ?? null;
     this.primaryColor = props.primaryColor ?? null;
+    this.scrollPaddingBottom = props.scrollPaddingBottom ?? null;
+    this.scrollPaddingLeft = props.scrollPaddingLeft ?? null;
+    this.scrollPaddingRight = props.scrollPaddingRight ?? null;
+    this.scrollPaddingTop = props.scrollPaddingTop ?? null;
     this.sansSerifJa = props.sansSerifJa ?? null;
     this.sansSerifJaV = props.sansSerifJaV ?? null;
     this.sansTf = props.sansTf ?? null;
@@ -362,6 +374,10 @@ export class RSProperties extends Properties {
     if (this.sansSerifJa) cssProperties["--RS__sans-serif-ja"] = this.sansSerifJa;
     if (this.sansSerifJaV) cssProperties["--RS__sans-serif-ja-v"] = this.sansSerifJaV;
     if (this.sansTf) cssProperties["--RS__sansTf"] = this.sansTf;
+    if (this.scrollPaddingBottom != null) cssProperties["--RS__scrollPaddingBottom"] = this.toPx(this.scrollPaddingBottom);
+    if (this.scrollPaddingLeft != null) cssProperties["--RS__scrollPaddingLeft"] = this.toPx(this.scrollPaddingLeft);
+    if (this.scrollPaddingRight != null) cssProperties["--RS__scrollPaddingRight"] = this.toPx(this.scrollPaddingRight);
+    if (this.scrollPaddingTop != null) cssProperties["--RS__scrollPaddingTop"] = this.toPx(this.scrollPaddingTop);
     if (this.secondaryColor) cssProperties["--RS__secondaryColor"] = this.secondaryColor;
     if (this.selectionBackgroundColor) cssProperties["--RS__selectionBackgroundColor"] = this.selectionBackgroundColor;
     if (this.selectionTextColor) cssProperties["--RS__selectionTextColor"] = this.selectionTextColor;

--- a/navigator/src/epub/css/Properties.ts
+++ b/navigator/src/epub/css/Properties.ts
@@ -241,8 +241,8 @@ export interface IRSProperties {
   sansSerifJaV?: string | null;
   sansTf?: string | null;
   scrollPaddingBottom?: number | null;
-  scrollPaddingLeft?: number | null;
-  scrollPaddingRight?: number | null;
+  // scrollPaddingLeft?: number | null;
+  // scrollPaddingRight?: number | null;
   scrollPaddingTop?: number | null;
   secondaryColor?: string | null;
   selectionBackgroundColor?: string | null;
@@ -285,8 +285,8 @@ export class RSProperties extends Properties {
   sansSerifJaV: string | null;
   sansTf: string | null;
   scrollPaddingBottom: number | null;
-  scrollPaddingLeft: number | null;
-  scrollPaddingRight: number | null;
+  // scrollPaddingLeft: number | null;
+  // scrollPaddingRight: number | null;
   scrollPaddingTop: number | null;
   secondaryColor: string | null;
   selectionBackgroundColor: string | null;
@@ -326,8 +326,8 @@ export class RSProperties extends Properties {
     this.paraSpacing = props.paraSpacing ?? null;
     this.primaryColor = props.primaryColor ?? null;
     this.scrollPaddingBottom = props.scrollPaddingBottom ?? null;
-    this.scrollPaddingLeft = props.scrollPaddingLeft ?? null;
-    this.scrollPaddingRight = props.scrollPaddingRight ?? null;
+    // this.scrollPaddingLeft = props.scrollPaddingLeft ?? null;
+    // this.scrollPaddingRight = props.scrollPaddingRight ?? null;
     this.scrollPaddingTop = props.scrollPaddingTop ?? null;
     this.sansSerifJa = props.sansSerifJa ?? null;
     this.sansSerifJaV = props.sansSerifJaV ?? null;
@@ -375,8 +375,8 @@ export class RSProperties extends Properties {
     if (this.sansSerifJaV) cssProperties["--RS__sans-serif-ja-v"] = this.sansSerifJaV;
     if (this.sansTf) cssProperties["--RS__sansTf"] = this.sansTf;
     if (this.scrollPaddingBottom != null) cssProperties["--RS__scrollPaddingBottom"] = this.toPx(this.scrollPaddingBottom);
-    if (this.scrollPaddingLeft != null) cssProperties["--RS__scrollPaddingLeft"] = this.toPx(this.scrollPaddingLeft);
-    if (this.scrollPaddingRight != null) cssProperties["--RS__scrollPaddingRight"] = this.toPx(this.scrollPaddingRight);
+    // if (this.scrollPaddingLeft != null) cssProperties["--RS__scrollPaddingLeft"] = this.toPx(this.scrollPaddingLeft);
+    // if (this.scrollPaddingRight != null) cssProperties["--RS__scrollPaddingRight"] = this.toPx(this.scrollPaddingRight);
     if (this.scrollPaddingTop != null) cssProperties["--RS__scrollPaddingTop"] = this.toPx(this.scrollPaddingTop);
     if (this.secondaryColor) cssProperties["--RS__secondaryColor"] = this.secondaryColor;
     if (this.selectionBackgroundColor) cssProperties["--RS__selectionBackgroundColor"] = this.selectionBackgroundColor;

--- a/navigator/src/epub/css/ReadiumCSS.ts
+++ b/navigator/src/epub/css/ReadiumCSS.ts
@@ -52,11 +52,11 @@ export class ReadiumCSS {
     if (settings.scrollPaddingBottom !== this.rsProperties.scrollPaddingBottom)
       this.rsProperties.scrollPaddingBottom = settings.scrollPaddingBottom;
 
-    if (settings.scrollPaddingLeft !== this.rsProperties.scrollPaddingLeft)
-      this.rsProperties.scrollPaddingLeft = settings.scrollPaddingLeft;
+    // if (settings.scrollPaddingLeft !== this.rsProperties.scrollPaddingLeft)
+    //   this.rsProperties.scrollPaddingLeft = settings.scrollPaddingLeft;
 
-    if (settings.scrollPaddingRight !== this.rsProperties.scrollPaddingRight)
-      this.rsProperties.scrollPaddingRight = settings.scrollPaddingRight;
+    // if (settings.scrollPaddingRight !== this.rsProperties.scrollPaddingRight)
+    //   this.rsProperties.scrollPaddingRight = settings.scrollPaddingRight;
 
     if (settings.scrollPaddingTop !== this.rsProperties.scrollPaddingTop)
       this.rsProperties.scrollPaddingTop = settings.scrollPaddingTop;

--- a/navigator/src/epub/css/ReadiumCSS.ts
+++ b/navigator/src/epub/css/ReadiumCSS.ts
@@ -49,6 +49,18 @@ export class ReadiumCSS {
     if (settings.pageGutter !== this.rsProperties.pageGutter)
       this.rsProperties.pageGutter = settings.pageGutter;
 
+    if (settings.scrollPaddingBottom !== this.rsProperties.scrollPaddingBottom)
+      this.rsProperties.scrollPaddingBottom = settings.scrollPaddingBottom;
+
+    if (settings.scrollPaddingLeft !== this.rsProperties.scrollPaddingLeft)
+      this.rsProperties.scrollPaddingLeft = settings.scrollPaddingLeft;
+
+    if (settings.scrollPaddingRight !== this.rsProperties.scrollPaddingRight)
+      this.rsProperties.scrollPaddingRight = settings.scrollPaddingRight;
+
+    if (settings.scrollPaddingTop !== this.rsProperties.scrollPaddingTop)
+      this.rsProperties.scrollPaddingTop = settings.scrollPaddingTop;
+
     // This has to be updated before pagination
     // otherwise the metrics won’t be correct for line length
     this.lineLengths.update({

--- a/navigator/src/epub/preferences/EpubDefaults.ts
+++ b/navigator/src/epub/preferences/EpubDefaults.ts
@@ -51,6 +51,10 @@ export interface IEpubDefaults {
   paragraphIndent?: number | null,
   paragraphSpacing?: number | null,
   scroll?: boolean | null,
+  scrollPaddingTop?: number | null,
+  scrollPaddingBottom?: number | null,
+  scrollPaddingLeft?: number | null,
+  scrollPaddingRight?: number | null,
   selectionBackgroundColor?: string | null,
   selectionTextColor?: string | null,
   textAlign?: TextAlignment | null,
@@ -91,6 +95,10 @@ export class EpubDefaults {
   paragraphIndent: number | null;
   paragraphSpacing: number | null;
   scroll: boolean | null;
+  scrollPaddingTop: number | null;
+  scrollPaddingBottom: number | null;
+  scrollPaddingLeft: number | null;
+  scrollPaddingRight: number | null;
   selectionBackgroundColor: string | null;
   selectionTextColor: string | null;
   textAlign: TextAlignment | null;
@@ -132,6 +140,10 @@ export class EpubDefaults {
     this.paragraphIndent = ensureNonNegative(defaults.paragraphIndent) ?? null;
     this.paragraphSpacing = ensureNonNegative(defaults.paragraphSpacing) ?? null;
     this.scroll = ensureBoolean(defaults.scroll) ?? false;
+    this.scrollPaddingTop = ensureNonNegative(defaults.scrollPaddingTop) ?? null;
+    this.scrollPaddingBottom = ensureNonNegative(defaults.scrollPaddingBottom) ?? null;
+    this.scrollPaddingLeft = ensureNonNegative(defaults.scrollPaddingLeft) ?? null;
+    this.scrollPaddingRight = ensureNonNegative(defaults.scrollPaddingRight) ?? null;
     this.selectionBackgroundColor = ensureString(defaults.selectionBackgroundColor) || null;
     this.selectionTextColor = ensureString(defaults.selectionTextColor) || null;
     this.textAlign = ensureEnumValue<TextAlignment>(defaults.textAlign, TextAlignment) || null;

--- a/navigator/src/epub/preferences/EpubDefaults.ts
+++ b/navigator/src/epub/preferences/EpubDefaults.ts
@@ -53,8 +53,8 @@ export interface IEpubDefaults {
   scroll?: boolean | null,
   scrollPaddingTop?: number | null,
   scrollPaddingBottom?: number | null,
-  scrollPaddingLeft?: number | null,
-  scrollPaddingRight?: number | null,
+  // scrollPaddingLeft?: number | null,
+  // scrollPaddingRight?: number | null,
   selectionBackgroundColor?: string | null,
   selectionTextColor?: string | null,
   textAlign?: TextAlignment | null,
@@ -97,8 +97,8 @@ export class EpubDefaults {
   scroll: boolean | null;
   scrollPaddingTop: number | null;
   scrollPaddingBottom: number | null;
-  scrollPaddingLeft: number | null;
-  scrollPaddingRight: number | null;
+  // scrollPaddingLeft: number | null;
+  // scrollPaddingRight: number | null;
   selectionBackgroundColor: string | null;
   selectionTextColor: string | null;
   textAlign: TextAlignment | null;
@@ -142,8 +142,8 @@ export class EpubDefaults {
     this.scroll = ensureBoolean(defaults.scroll) ?? false;
     this.scrollPaddingTop = ensureNonNegative(defaults.scrollPaddingTop) ?? null;
     this.scrollPaddingBottom = ensureNonNegative(defaults.scrollPaddingBottom) ?? null;
-    this.scrollPaddingLeft = ensureNonNegative(defaults.scrollPaddingLeft) ?? null;
-    this.scrollPaddingRight = ensureNonNegative(defaults.scrollPaddingRight) ?? null;
+    // this.scrollPaddingLeft = ensureNonNegative(defaults.scrollPaddingLeft) ?? null;
+    // this.scrollPaddingRight = ensureNonNegative(defaults.scrollPaddingRight) ?? null;
     this.selectionBackgroundColor = ensureString(defaults.selectionBackgroundColor) || null;
     this.selectionTextColor = ensureString(defaults.selectionTextColor) || null;
     this.textAlign = ensureEnumValue<TextAlignment>(defaults.textAlign, TextAlignment) || null;

--- a/navigator/src/epub/preferences/EpubPreferences.ts
+++ b/navigator/src/epub/preferences/EpubPreferences.ts
@@ -50,8 +50,8 @@ export interface IEpubPreferences {
   scroll?: boolean | null,
   scrollPaddingTop?: number | null,
   scrollPaddingBottom?: number | null,
-  scrollPaddingLeft?: number | null,
-  scrollPaddingRight?: number | null,
+  // scrollPaddingLeft?: number | null,
+  // scrollPaddingRight?: number | null,
   selectionBackgroundColor?: string | null,
   selectionTextColor?: string | null,
   textAlign?: TextAlignment | null,
@@ -94,8 +94,8 @@ export class EpubPreferences implements ConfigurablePreferences {
   scroll?: boolean | null;
   scrollPaddingTop?: number | null;
   scrollPaddingBottom?: number | null;
-  scrollPaddingLeft?: number | null;
-  scrollPaddingRight?: number | null;
+  // scrollPaddingLeft?: number | null;
+  // scrollPaddingRight?: number | null;
   selectionBackgroundColor?: string | null;
   selectionTextColor?: string | null;
   textAlign?: TextAlignment | null;
@@ -134,8 +134,8 @@ export class EpubPreferences implements ConfigurablePreferences {
     this.scroll = ensureBoolean(preferences.scroll);
     this.scrollPaddingTop = ensureNonNegative(preferences.scrollPaddingTop);
     this.scrollPaddingBottom = ensureNonNegative(preferences.scrollPaddingBottom);
-    this.scrollPaddingLeft = ensureNonNegative(preferences.scrollPaddingLeft);
-    this.scrollPaddingRight = ensureNonNegative(preferences.scrollPaddingRight);
+    // this.scrollPaddingLeft = ensureNonNegative(preferences.scrollPaddingLeft);
+    // this.scrollPaddingRight = ensureNonNegative(preferences.scrollPaddingRight);
     this.selectionBackgroundColor = ensureString(preferences.selectionBackgroundColor);
     this.selectionTextColor = ensureString(preferences.selectionTextColor);
     this.textAlign = ensureEnumValue<TextAlignment>(preferences.textAlign, TextAlignment);

--- a/navigator/src/epub/preferences/EpubPreferences.ts
+++ b/navigator/src/epub/preferences/EpubPreferences.ts
@@ -48,6 +48,10 @@ export interface IEpubPreferences {
   paragraphIndent?: number | null,
   paragraphSpacing?: number | null,
   scroll?: boolean | null,
+  scrollPaddingTop?: number | null,
+  scrollPaddingBottom?: number | null,
+  scrollPaddingLeft?: number | null,
+  scrollPaddingRight?: number | null,
   selectionBackgroundColor?: string | null,
   selectionTextColor?: string | null,
   textAlign?: TextAlignment | null,
@@ -88,6 +92,10 @@ export class EpubPreferences implements ConfigurablePreferences {
   paragraphIndent?: number | null;
   paragraphSpacing?: number | null;
   scroll?: boolean | null;
+  scrollPaddingTop?: number | null;
+  scrollPaddingBottom?: number | null;
+  scrollPaddingLeft?: number | null;
+  scrollPaddingRight?: number | null;
   selectionBackgroundColor?: string | null;
   selectionTextColor?: string | null;
   textAlign?: TextAlignment | null;
@@ -124,6 +132,10 @@ export class EpubPreferences implements ConfigurablePreferences {
     this.paragraphIndent = ensureNonNegative(preferences.paragraphIndent);
     this.paragraphSpacing = ensureNonNegative(preferences.paragraphSpacing);
     this.scroll = ensureBoolean(preferences.scroll);
+    this.scrollPaddingTop = ensureNonNegative(preferences.scrollPaddingTop);
+    this.scrollPaddingBottom = ensureNonNegative(preferences.scrollPaddingBottom);
+    this.scrollPaddingLeft = ensureNonNegative(preferences.scrollPaddingLeft);
+    this.scrollPaddingRight = ensureNonNegative(preferences.scrollPaddingRight);
     this.selectionBackgroundColor = ensureString(preferences.selectionBackgroundColor);
     this.selectionTextColor = ensureString(preferences.selectionTextColor);
     this.textAlign = ensureEnumValue<TextAlignment>(preferences.textAlign, TextAlignment);

--- a/navigator/src/epub/preferences/EpubPreferencesEditor.ts
+++ b/navigator/src/epub/preferences/EpubPreferencesEditor.ts
@@ -405,6 +405,7 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
     });
   }
 
+  /* 
   get scrollPaddingLeft(): Preference<number> {
     return new Preference<number>({
       initialValue: this.preferences.scrollPaddingLeft,
@@ -425,7 +426,8 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
         this.updatePreference("scrollPaddingRight", newValue || null);
       }
     });
-  }
+  } 
+  */
 
   get selectionBackgroundColor(): Preference<string> {
     return new Preference<string>({

--- a/navigator/src/epub/preferences/EpubPreferencesEditor.ts
+++ b/navigator/src/epub/preferences/EpubPreferencesEditor.ts
@@ -383,6 +383,50 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
     });
   }
 
+  get scrollPaddingTop(): Preference<number> {
+    return new Preference<number>({
+      initialValue: this.preferences.scrollPaddingTop,
+      effectiveValue: this.settings.scrollPaddingTop || 0,
+      isEffective: this.layout === EPUBLayout.reflowable && !!this.settings.scroll && this.preferences.scrollPaddingTop !== null,
+      onChange: (newValue: number | null | undefined) => {
+        this.updatePreference("scrollPaddingTop", newValue || null);
+      }
+    });
+  }
+
+  get scrollPaddingBottom(): Preference<number> {
+    return new Preference<number>({
+      initialValue: this.preferences.scrollPaddingBottom,
+      effectiveValue: this.settings.scrollPaddingBottom || 0,
+      isEffective: this.layout === EPUBLayout.reflowable && !!this.settings.scroll && this.preferences.scrollPaddingBottom !== null,
+      onChange: (newValue: number | null | undefined) => {
+        this.updatePreference("scrollPaddingBottom", newValue || null);
+      }
+    });
+  }
+
+  get scrollPaddingLeft(): Preference<number> {
+    return new Preference<number>({
+      initialValue: this.preferences.scrollPaddingLeft,
+      effectiveValue: this.settings.scrollPaddingLeft || 0,
+      isEffective: this.layout === EPUBLayout.reflowable && !!this.settings.scroll && this.preferences.scrollPaddingLeft !== null,
+      onChange: (newValue: number | null | undefined) => {
+        this.updatePreference("scrollPaddingLeft", newValue || null);
+      }
+    });
+  }
+
+  get scrollPaddingRight(): Preference<number> {
+    return new Preference<number>({
+      initialValue: this.preferences.scrollPaddingRight,
+      effectiveValue: this.settings.scrollPaddingRight || 0,
+      isEffective: this.layout === EPUBLayout.reflowable && !!this.settings.scroll && this.preferences.scrollPaddingRight !== null,
+      onChange: (newValue: number | null | undefined) => {
+        this.updatePreference("scrollPaddingRight", newValue || null);
+      }
+    });
+  }
+
   get selectionBackgroundColor(): Preference<string> {
     return new Preference<string>({
       initialValue: this.preferences.selectionBackgroundColor,

--- a/navigator/src/epub/preferences/EpubSettings.ts
+++ b/navigator/src/epub/preferences/EpubSettings.ts
@@ -35,6 +35,10 @@ export interface IEpubSettings {
   paragraphIndent?: number | null,
   paragraphSpacing?: number | null,
   scroll?: boolean | null,
+  scrollPaddingTop?: number | null,
+  scrollPaddingBottom?: number | null,
+  scrollPaddingLeft?: number | null,
+  scrollPaddingRight?: number | null,
   selectionBackgroundColor?: string | null,
   selectionTextColor?: string | null,
   textAlign?: TextAlignment | null,
@@ -75,6 +79,10 @@ export class EpubSettings implements ConfigurableSettings {
   paragraphIndent: number | null;
   paragraphSpacing: number | null;
   scroll: boolean | null;
+  scrollPaddingTop: number | null;
+  scrollPaddingBottom: number | null;
+  scrollPaddingLeft: number | null;
+  scrollPaddingRight: number | null;
   selectionBackgroundColor: string | null;
   selectionTextColor: string | null;
   textAlign: TextAlignment | null;
@@ -182,6 +190,26 @@ export class EpubSettings implements ConfigurableSettings {
     this.scroll = typeof preferences.scroll === "boolean" 
       ? preferences.scroll 
       : defaults.scroll ?? null;
+    this.scrollPaddingTop = preferences.scrollPaddingTop !== undefined 
+      ? preferences.scrollPaddingTop 
+      : defaults.scrollPaddingTop !== undefined 
+        ? defaults.scrollPaddingTop 
+        : null;
+    this.scrollPaddingBottom = preferences.scrollPaddingBottom !== undefined 
+      ? preferences.scrollPaddingBottom 
+      : defaults.scrollPaddingBottom !== undefined 
+        ? defaults.scrollPaddingBottom 
+        : null;
+    this.scrollPaddingLeft = preferences.scrollPaddingLeft !== undefined 
+      ? preferences.scrollPaddingLeft 
+      : defaults.scrollPaddingLeft !== undefined 
+        ? defaults.scrollPaddingLeft 
+        : null;
+    this.scrollPaddingRight = preferences.scrollPaddingRight !== undefined 
+      ? preferences.scrollPaddingRight 
+      : defaults.scrollPaddingRight !== undefined 
+        ? defaults.scrollPaddingRight 
+        : null;
     this.selectionBackgroundColor = preferences.selectionBackgroundColor || defaults.selectionBackgroundColor || null;
     this.selectionTextColor = preferences.selectionTextColor || defaults.selectionTextColor || null;
     this.textAlign = preferences.textAlign || defaults.textAlign || null;

--- a/navigator/src/epub/preferences/EpubSettings.ts
+++ b/navigator/src/epub/preferences/EpubSettings.ts
@@ -37,8 +37,8 @@ export interface IEpubSettings {
   scroll?: boolean | null,
   scrollPaddingTop?: number | null,
   scrollPaddingBottom?: number | null,
-  scrollPaddingLeft?: number | null,
-  scrollPaddingRight?: number | null,
+  // scrollPaddingLeft?: number | null,
+  // scrollPaddingRight?: number | null,
   selectionBackgroundColor?: string | null,
   selectionTextColor?: string | null,
   textAlign?: TextAlignment | null,
@@ -81,8 +81,8 @@ export class EpubSettings implements ConfigurableSettings {
   scroll: boolean | null;
   scrollPaddingTop: number | null;
   scrollPaddingBottom: number | null;
-  scrollPaddingLeft: number | null;
-  scrollPaddingRight: number | null;
+  // scrollPaddingLeft: number | null;
+  // scrollPaddingRight: number | null;
   selectionBackgroundColor: string | null;
   selectionTextColor: string | null;
   textAlign: TextAlignment | null;
@@ -200,6 +200,7 @@ export class EpubSettings implements ConfigurableSettings {
       : defaults.scrollPaddingBottom !== undefined 
         ? defaults.scrollPaddingBottom 
         : null;
+    /* 
     this.scrollPaddingLeft = preferences.scrollPaddingLeft !== undefined 
       ? preferences.scrollPaddingLeft 
       : defaults.scrollPaddingLeft !== undefined 
@@ -210,6 +211,7 @@ export class EpubSettings implements ConfigurableSettings {
       : defaults.scrollPaddingRight !== undefined 
         ? defaults.scrollPaddingRight 
         : null;
+    */
     this.selectionBackgroundColor = preferences.selectionBackgroundColor || defaults.selectionBackgroundColor || null;
     this.selectionTextColor = preferences.selectionTextColor || defaults.selectionTextColor || null;
     this.textAlign = preferences.textAlign || defaults.textAlign || null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.5.25
         version: 0.5.25(vite@4.5.5(@types/node@20.4.8)(less@4.2.0)(sass@1.81.0)(stylus@0.62.0))
       '@readium/css':
-        specifier: '>=2.0.0-beta.14'
-        version: 2.0.0-beta.14
+        specifier: '>=2.0.0-beta.15'
+        version: 2.0.0-beta.15
       '@readium/navigator-html-injectables':
         specifier: workspace:*
         version: link:../navigator-html-injectables
@@ -1241,8 +1241,8 @@ packages:
   '@readium/css@1.1.0':
     resolution: {integrity: sha512-vcUx/+UYlWXuG6ioZNVBFDlKCuyH+65x9dNJM9jLlA8yT5ReH0k2UR9DN8cwx5/BgJhoQLUsA9s2DPhGaMhX6A==}
 
-  '@readium/css@2.0.0-beta.14':
-    resolution: {integrity: sha512-Js7kDFCJAoUCLqpWsesO/ywP+BwrLMzBUvKB7MnimHIZrkHAMZKzpm8W3O02vQkQm3mTW185Wa1KllQkA0tUhA==}
+  '@readium/css@2.0.0-beta.15':
+    resolution: {integrity: sha512-kNY7a5ckgGABKhu+zJj0J9zaJbYyekpnDaMy2Yg3nk1W8hCjhlDSMwsZSD0Ncgqg5IWsZaPU0SSlgca2gSeuyA==}
 
   '@sinclair/typebox@0.24.51':
     resolution: {integrity: sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==}
@@ -3976,7 +3976,7 @@ snapshots:
 
   '@readium/css@1.1.0': {}
 
-  '@readium/css@2.0.0-beta.14': {}
+  '@readium/css@2.0.0-beta.15': {}
 
   '@sinclair/typebox@0.24.51': {}
 


### PR DESCRIPTION
This partially exposes [the new padding custom properties from ReadiumCSS](https://github.com/readium/css/blob/develop/docs/CSS28-migration_guide.md#addition-of-scroll-padding-module) in the Preferences API so that we can implement the [scroll ui in Thorium Web](https://github.com/edrlab/thorium-web/pull/103). We need to add padding to `body` in scroll so that UI components (top and bottom bars) are not hiding the start and end of the resource.

Note there is an issue that has to be resolved in ReadiumCSS, where the left and right properties conflict with `pageGutter` so they have been temporarily disabled until we reach a resolution. Otherwise it would be blocking for Thorium Web v1. 