### PR TITLE
Fix pageGutter in scroll

### DIFF
--- a/navigator/package.json
+++ b/navigator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "type": "module",
   "description": "Next generation SDK for publications in Web Apps",
   "author": "readium",
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@laynezh/vite-plugin-lib-assets": "^0.5.25",
-    "@readium/css": ">=2.0.0-beta.15",
+    "@readium/css": ">=2.0.0-beta.16",
     "@readium/navigator-html-injectables": "workspace:*",
     "@readium/shared": "workspace:*",
     "@types/path-browserify": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.5.25
         version: 0.5.25(vite@4.5.5(@types/node@20.4.8)(less@4.2.0)(sass@1.81.0)(stylus@0.62.0))
       '@readium/css':
-        specifier: '>=2.0.0-beta.15'
-        version: 2.0.0-beta.15
+        specifier: '>=2.0.0-beta.16'
+        version: 2.0.0-beta.16
       '@readium/navigator-html-injectables':
         specifier: workspace:*
         version: link:../navigator-html-injectables
@@ -1241,8 +1241,8 @@ packages:
   '@readium/css@1.1.0':
     resolution: {integrity: sha512-vcUx/+UYlWXuG6ioZNVBFDlKCuyH+65x9dNJM9jLlA8yT5ReH0k2UR9DN8cwx5/BgJhoQLUsA9s2DPhGaMhX6A==}
 
-  '@readium/css@2.0.0-beta.15':
-    resolution: {integrity: sha512-kNY7a5ckgGABKhu+zJj0J9zaJbYyekpnDaMy2Yg3nk1W8hCjhlDSMwsZSD0Ncgqg5IWsZaPU0SSlgca2gSeuyA==}
+  '@readium/css@2.0.0-beta.16':
+    resolution: {integrity: sha512-Gzv6PIkiKk8bFxD6srqA7YSeRiB6M4TpuOf7xd28d8PVtJu5iAt1UXnPjr2euB3BaWc6Bas/dAZ9ta+bIpFcMw==}
 
   '@sinclair/typebox@0.24.51':
     resolution: {integrity: sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==}
@@ -3976,7 +3976,7 @@ snapshots:
 
   '@readium/css@1.1.0': {}
 
-  '@readium/css@2.0.0-beta.15': {}
+  '@readium/css@2.0.0-beta.16': {}
 
   '@sinclair/typebox@0.24.51': {}
 


### PR DESCRIPTION
TL;DR: Readium CSS accidentally overrode `pageGutter` due to `scrollPaddingTop/Bottom` being applied since the attribute selector only checked for a loose match instead of the entire word, so the global `scrollPadding` would be enabled but undefined…