### PR TITLE
Enable progression 0 on frame show

### DIFF
--- a/navigator/src/epub/frame/FrameManager.ts
+++ b/navigator/src/epub/frame/FrameManager.ts
@@ -97,7 +97,7 @@ export class FrameManager {
                         this.hidden = false;
                         res();
                     }
-                    if(atProgress && atProgress > 0) {
+                    if(atProgress !== undefined) {
                         this.comms?.send("go_progression", atProgress, remove);
                     } else {
                         remove();

--- a/navigator/src/epub/frame/FramePoolManager.ts
+++ b/navigator/src/epub/frame/FramePoolManager.ts
@@ -155,9 +155,8 @@ export class FramePoolManager {
                     await newFrame.load(modules); // In order to ensure modules match the latest configuration
 
                 // Update progression if necessary and show the new frame
-                const hasProgression = (locator?.locations?.progression ?? 0) > 0;
                 if(newFrame) // If user is speeding through the publication, this can get destroyed
-                    await newFrame.show(hasProgression ? locator.locations.progression! : undefined); // Show/activate new frame
+                    await newFrame.show(locator.locations.progression); // Show/activate new frame
 
                 this._currentFrame = newFrame;
             }


### PR DESCRIPTION
Resolves #132

This is particularly visible when using `go()` with a locator whose `progression` is explicitly `0`, because frames still in the pool will not update their progression as expected in that specific case and show at their previous progression in memory.

That can happen with features such as jump to location/position.
