### PR TITLE
Implement viewport + helpers in EpubNavigator

### DIFF
--- a/navigator-html-injectables/src/modules/snapper/ColumnSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ColumnSnapper.ts
@@ -39,7 +39,14 @@ export class ColumnSnapper extends Snapper {
     }
 
     reportProgress() {
-        this.comms.send("progress", { progress: this.wnd.scrollX / this.cachedScrollWidth, reference: this.wnd.innerWidth / this.doc().scrollWidth });
+        const scrollX = this.wnd.scrollX;
+        const scrollWidth = this.cachedScrollWidth;
+        const progress = Math.max(0, Math.min(1, scrollX / scrollWidth));
+        const viewportEnd = Math.max(0, Math.min(1, (scrollX + this.wnd.innerWidth) / scrollWidth));
+        this.comms.send("progress", {
+            start: progress,
+            end: viewportEnd
+        });
     }
 
     private shakeTimeout = 0;

--- a/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
@@ -18,16 +18,22 @@ export class ScrollSnapper extends Snapper {
         return this.wnd.document.scrollingElement as HTMLElement;
     }
 
-    private reportProgress(data: { progress: number, reference: number }) {
-        this.comms.send("progress", data);
+    private reportProgress() {
+        const scrollTop = this.doc().scrollTop;
+        const scrollHeight = this.doc().scrollHeight;
+        const progress = Math.max(0, Math.min(1, scrollTop / scrollHeight));
+        const viewportEnd = Math.max(0, Math.min(1, (scrollTop + this.wnd.innerHeight) / scrollHeight));
+        this.comms.send("progress", {
+            start: progress,
+            end: viewportEnd
+        });
     }
 
     private handleScroll = () => {
         if (!this.isScrolling) {
             this.isScrolling = true;
             this.wnd.requestAnimationFrame(() => {
-                const progress = this.doc().scrollTop / this.doc().offsetHeight;
-                this.reportProgress({ progress: progress, reference: this.wnd.innerHeight / this.doc().scrollHeight });
+                this.reportProgress();
                 this.isScrolling = false;
             });
         }
@@ -76,7 +82,7 @@ export class ScrollSnapper extends Snapper {
 
             this.wnd.requestAnimationFrame(() => {
               this.doc().scrollTop = this.doc().offsetHeight * position;
-              this.reportProgress({ progress: position, reference: this.wnd.innerHeight / this.doc().scrollHeight });
+              this.reportProgress();
               deselect(this.wnd);
               ack(true);
           });
@@ -90,8 +96,7 @@ export class ScrollSnapper extends Snapper {
             }
             this.wnd.requestAnimationFrame(() => {
                 this.doc().scrollTop = element.getBoundingClientRect().top + wnd.scrollY - wnd.innerHeight / 2;
-                const progress = this.doc().scrollTop / this.doc().offsetHeight;
-                this.reportProgress({ progress: progress, reference: this.wnd.innerHeight / this.doc().scrollHeight });
+                this.reportProgress();
                 deselect(this.wnd);
                 ack(true);
             });
@@ -122,8 +127,7 @@ export class ScrollSnapper extends Snapper {
             }
             this.wnd.requestAnimationFrame(() => {
                 this.doc().scrollTop = r.getBoundingClientRect().top + wnd.scrollY - wnd.innerHeight / 2;
-                const progress = this.doc().scrollTop / this.doc().offsetHeight
-                this.reportProgress({ progress: progress, reference: this.wnd.innerHeight / this.doc().scrollHeight });
+                this.reportProgress();
                 deselect(this.wnd);
                 ack(true);
             });
@@ -132,14 +136,14 @@ export class ScrollSnapper extends Snapper {
         comms.register("go_start", ScrollSnapper.moduleName, (_, ack) => {
             if (this.doc().scrollTop === 0) return ack(false);
             this.doc().scrollTop = 0;
-            this.reportProgress({ progress: 0, reference: this.wnd.innerHeight / this.doc().scrollHeight });
+            this.reportProgress();
             ack(true);
         });
 
         comms.register("go_end", ScrollSnapper.moduleName, (_, ack) => {
-            if (this.doc().scrollTop === 0) return ack(false);
-            this.doc().scrollTop = 0;
-            this.reportProgress({ progress: 0, reference: this.wnd.innerHeight / this.doc().scrollHeight });
+            if (this.doc().scrollTop === this.doc().scrollHeight - this.doc().offsetHeight) return ack(false);
+            this.doc().scrollTop = this.doc().scrollHeight - this.doc().offsetHeight;
+            this.reportProgress();
             ack(true);
         })
 
@@ -154,8 +158,7 @@ export class ScrollSnapper extends Snapper {
         ], ScrollSnapper.moduleName, (_, ack) => ack(false));
 
         comms.register("focus", ScrollSnapper.moduleName, (_, ack) => {
-            const progress = this.doc().scrollTop / this.doc().offsetHeight
-            this.reportProgress({ progress: progress, reference: this.wnd.innerHeight / this.doc().scrollHeight });
+            this.reportProgress();
             ack(true);
         });
 

--- a/navigator/src/Navigator.ts
+++ b/navigator/src/Navigator.ts
@@ -2,6 +2,17 @@ import { Link, Locator, Publication, ReadingProgression } from "@readium/shared"
 
 type cbb = (ok: boolean) => void;
 
+export interface ProgressionRange {
+    start: number;
+    end: number;
+}
+
+export interface VisualNavigatorViewport {
+    readingOrder: string[];  // Array of href strings for visible resources
+    progressions: Map<string, ProgressionRange>;  // Map from href to visible scroll progression range
+    positions: number[] | null;  // Range of visible positions
+}
+
 export abstract class Navigator {
     abstract get publication(): Publication; // Publication rendered by this navigator.
     abstract get currentLocator(): Locator; // Current position (detailed) in the publication. Can be used to save a bookmark to the current position.

--- a/navigator/src/epub/EpubNavigator.ts
+++ b/navigator/src/epub/EpubNavigator.ts
@@ -640,21 +640,23 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
     }
 
     get isResourceStart(): boolean {
-        const currentProgression = this.viewport.progressions.get(this.currentLocation?.href);
-        return currentProgression?.start === 0;
+        const firstHref = this.viewport.readingOrder[0];
+        const progression = this.viewport.progressions.get(firstHref);
+        return progression?.start === 0;
     }
     
     get isResourceEnd(): boolean {
-        const currentProgression = this.viewport.progressions.get(this.currentLocation?.href);
-        return currentProgression?.end === 1;
+        const lastHref = this.viewport.readingOrder[this.viewport.readingOrder.length - 1];
+        const progression = this.viewport.progressions.get(lastHref);
+        return progression?.end === 1;
     }
     
-    get isPublicationStart(): boolean {
+    get canGoBackward(): boolean {
         const firstResource = this.pub.readingOrder.items[0]?.href;
         return this.viewport.progressions.has(firstResource) && this.viewport.progressions.get(firstResource)?.start === 0;
     }
     
-    get isPublicationEnd(): boolean {
+    get canGoForward(): boolean {
         const lastResource = this.pub.readingOrder.items[this.pub.readingOrder.items.length - 1]?.href;
         return this.viewport.progressions.has(lastResource) && this.viewport.progressions.get(lastResource)?.end === 1;
     }

--- a/navigator/src/epub/EpubNavigator.ts
+++ b/navigator/src/epub/EpubNavigator.ts
@@ -1,5 +1,5 @@
 import { EPUBLayout, Link, Locator, Publication, ReadingProgression } from "@readium/shared";
-import { Configurable, ConfigurablePreferences, ConfigurableSettings, LineLengths, VisualNavigator } from "../";
+import { Configurable, ConfigurablePreferences, ConfigurableSettings, LineLengths, VisualNavigator, VisualNavigatorViewport, ProgressionRange } from "../";
 import { FramePoolManager } from "./frame/FramePoolManager";
 import { FXLFramePoolManager } from "./fxl/FXLFramePoolManager";
 import { CommsEventKey, FXLModules, ModuleLibrary, ModuleName, ReflowableModules } from "@readium/navigator-html-injectables";
@@ -65,6 +65,12 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
     private _preferencesEditor: EpubPreferencesEditor | null = null;
 
     private resizeObserver: ResizeObserver;
+
+    private reflowViewport: VisualNavigatorViewport = {
+        readingOrder: [],
+        progressions: new Map(),
+        positions: null
+    };
 
     constructor(container: HTMLElement, pub: Publication, listeners: EpubNavigatorListeners, positions: Locator[] = [], initialPosition: Locator | undefined = undefined, configuration: EpubNavigatorConfiguration = { preferences: {}, defaults: {} }) {
         super();
@@ -394,7 +400,7 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
                 this.listeners.zoom(data as number);
                 break;
             case "progress":
-                this.syncLocation(data as { progress: number, reference: number });
+                this.syncLocation(data as ProgressionRange);
                 break;
             case "log":
                 console.log(this._cframes[0]?.source?.split("/")[3], ...(data as any[]));
@@ -452,7 +458,7 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
 
         if(this.layout === EPUBLayout.fixed) {
             const p = this.framePool as FXLFramePoolManager;
-            const old = p.currentNumbers[0];
+            const old = p.viewport.positions![0];
             if(relative === 1) {
                 if(!p.next(p.perPage)) return false;
             } else if(relative === -1) {
@@ -461,7 +467,7 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
                 throw Error("Invalid relative value for FXL");
 
             // Apply change
-            const neW = p.currentNumbers[0]
+            const neW = p.viewport.positions![0]
             if(old > neW)
                 for (let j = this.positions.length - 1; j >= 0; j--) {
                     if(this.positions[j].href === this.pub.readingOrder.items[neW-1].href) {
@@ -514,10 +520,10 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
         return true;
     }
 
-    private findLastPositionInProgressionRange(positions: Locator[], range: number[]): Locator | undefined {
+    private findLastPositionInProgressionRange(positions: Locator[], range: ProgressionRange): Locator | undefined {
         const match = positions.findLastIndex((p) => {
             const pr = p.locations.progression;
-            if (pr && pr > Math.min(...range) && pr <= Math.max(...range)) {
+            if (pr && pr > range.start && pr <= range.end) {
                 return true;
             } else {
                 return false;
@@ -526,7 +532,7 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
         return match !== -1 ? positions[match] : undefined;
     }
 
-    private findNearestPositions(fromProgression: { progress: number, reference: number }):  { first: Locator, last: Locator | undefined } {
+    private findNearestPositions(fromProgression: ProgressionRange):  { first: Locator, last: Locator | undefined } {
         // TODO replace with locator service
         const potentialPositions = this.positions.filter(
             (p) => p.href === this.currentLocation.href
@@ -538,13 +544,12 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
         // smaller than or equal to the requested progression.
         potentialPositions.some((p, idx) => {
             const pr = p.locations.progression ?? 0;
-            if (fromProgression.progress <= pr) {
+            if (fromProgression.start <= pr) {
                 first = p;
 
                 // If there’s a match, check the last in view, from the next progression
                 const nextPositions = potentialPositions.splice(idx + 1, potentialPositions.length);
-                const range = [fromProgression.progress, fromProgression.progress + fromProgression.reference];
-                last = this.findLastPositionInProgressionRange(nextPositions, range);
+                last = this.findLastPositionInProgressionRange(nextPositions, fromProgression);
 
                 return true;
             }
@@ -553,12 +558,36 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
         return { first: first, last: last }
     }
 
-    private async syncLocation(iframeProgress: { progress: number, reference: number }) {
-        const nearestPositions = this.findNearestPositions(iframeProgress)
+    private updateViewport(progression: ProgressionRange) {
+        this.reflowViewport.readingOrder = [];
+        this.reflowViewport.progressions.clear();
+        this.reflowViewport.positions = null;
+    
+        // Use the current position's href
+        if (this.currentLocation) {
+            this.reflowViewport.readingOrder.push(this.currentLocation.href);
+            this.reflowViewport.progressions.set(this.currentLocation.href, progression);
+
+            if (this.currentLocation.locations?.position !== undefined) {
+                this.reflowViewport.positions = [this.currentLocation.locations.position];
+                if (this.lastLocationInView?.locations?.position !== undefined) {
+                    this.reflowViewport.positions.push(this.lastLocationInView.locations.position);
+                }
+            }
+        }
+    }
+
+    private async syncLocation(iframeProgress: ProgressionRange) {
+        const progression = iframeProgress;
+        
+        const nearestPositions = this.findNearestPositions(progression);
+        
         this.currentLocation = nearestPositions.first.copyWithLocations({
-            progression: iframeProgress.progress // Most accurate progression in resource
+            progression: progression.start
         });
+        
         this.lastLocationInView = nearestPositions.last;
+        this.updateViewport(progression);
         this.listeners.positionChanged(this.currentLocation);
         await this.framePool.update(this.pub, this.currentLocation, this.determineModules());
     }
@@ -604,12 +633,30 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
         return this.currentLocation;
     }
 
-    // Starting and ending position currently showing in the reader
-    get currentPositionNumbers(): number[] {
-        if(this.layout === EPUBLayout.fixed)
-         return (this.framePool as FXLFramePoolManager).currentNumbers;
+    get viewport(): VisualNavigatorViewport {
+        return this.layout === EPUBLayout.fixed 
+            ? (this.framePool as FXLFramePoolManager).viewport 
+            : this.reflowViewport;
+    }
 
-        return [this.currentLocator?.locations.position ?? 0, ...(this.lastLocationInView?.locations.position ? [this.lastLocationInView.locations.position] : [])];
+    get isResourceStart(): boolean {
+        const currentProgression = this.viewport.progressions.get(this.currentLocation?.href);
+        return currentProgression?.start === 0;
+    }
+    
+    get isResourceEnd(): boolean {
+        const currentProgression = this.viewport.progressions.get(this.currentLocation?.href);
+        return currentProgression?.end === 1;
+    }
+    
+    get isPublicationStart(): boolean {
+        const firstResource = this.pub.readingOrder.items[0]?.href;
+        return this.viewport.progressions.has(firstResource) && this.viewport.progressions.get(firstResource)?.start === 0;
+    }
+    
+    get isPublicationEnd(): boolean {
+        const lastResource = this.pub.readingOrder.items[this.pub.readingOrder.items.length - 1]?.href;
+        return this.viewport.progressions.has(lastResource) && this.viewport.progressions.get(lastResource)?.end === 1;
     }
 
     // TODO: This is temporary until user settings are implemented.

--- a/navigator/src/epub/EpubNavigator.ts
+++ b/navigator/src/epub/EpubNavigator.ts
@@ -639,13 +639,13 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
             : this.reflowViewport;
     }
 
-    get isResourceStart(): boolean {
+    get isScrollStart(): boolean {
         const firstHref = this.viewport.readingOrder[0];
         const progression = this.viewport.progressions.get(firstHref);
         return progression?.start === 0;
     }
     
-    get isResourceEnd(): boolean {
+    get isScrollEnd(): boolean {
         const lastHref = this.viewport.readingOrder[this.viewport.readingOrder.length - 1];
         const progression = this.viewport.progressions.get(lastHref);
         return progression?.end === 1;

--- a/navigator/src/epub/fxl/FXLFramePoolManager.ts
+++ b/navigator/src/epub/fxl/FXLFramePoolManager.ts
@@ -5,6 +5,7 @@ import FrameBlobBuider from "../frame/FrameBlobBuilder";
 import { FXLFrameManager } from "./FXLFrameManager";
 import { FXLPeripherals } from "./FXLPeripherals";
 import { FXLSpreader } from "./FXLSpreader";
+import { VisualNavigatorViewport } from "../../Navigator";
 
 const UPPER_BOUNDARY = 8;
 const LOWER_BOUNDARY = 5;
@@ -602,7 +603,25 @@ export class FXLFramePoolManager {
         return ret as DOMRect;
     }
 
-    get currentNumbers(): number[] {
+    get viewport(): VisualNavigatorViewport {
+        const viewport: VisualNavigatorViewport = {
+            readingOrder: [],
+            progressions: new Map(),
+            positions: null
+        };
+        const currentSpread = this.spreader.currentSpread(this.currentSlide, this.perPage);
+        currentSpread.forEach(link => {
+            viewport.readingOrder.push(link.href);
+            viewport.progressions.set(link.href, { start: 0, end: 1 }); // FXL always uses [0,1] progression
+        });
+
+        // Set positions using currentNumbers
+        viewport.positions = this.getCurrentNumbers();
+    
+        return viewport;
+    }
+
+    private getCurrentNumbers(): number[] {
         if(this.perPage < 2) {
             const link = this.pub.readingOrder.items[this.currentSlide];
             return [link.properties?.otherProperties["number"]];


### PR DESCRIPTION
This replaces currentNumbers with the new concept of `viewport`, as already implemented in Swift, and adds helpers that are using `viewport` to infer whether we are:

- at the start of the resource;
- at the end of the resource;
- at the start of the publication;
- at the end of the publication.

`Viewport` contains:

- `readingOrder`: the visible frames
- `progression`: the progression for each item in readingOrder
- `positions`: the positions for each item in `readingOrder`

It is worth noting `ColumnSnapper` and `ScrollSnapper` are now reporting a progression range so that we can infer a value of `1` at the end of the resource. 

This has been implemented in a non-disruptive way, replacing `currentNumbers` using the same logic – FXL is currently implemented as its own method in `FramePoolManager` while reflow is implemented in `EpubNavigator`. 

I tried leveraging the opportunity to handle issue #66 but this is less trivial than anticipated due to discrepancies in how FXL and reflow work, and I did not want to introduce unintended side-effects. I do think this should be its own PR with discussion informing the change. 