### PR TITLE
Remove layout Strategies

### DIFF
--- a/navigator/docs/epub/ConfiguringEpubNavigator.md
+++ b/navigator/docs/epub/ConfiguringEpubNavigator.md
@@ -45,7 +45,7 @@ navigator.submitPreferences(editor.preferences)
 
 Preferences are low-level technical properties. While some of them can be exposed directly to the user, such as the font size, others should not be displayed as-is.
 
-For instance, the `layoutStrategy` is a property that works in combination with `minimalLineLength`, `optimalLineLength` and `maximalLineLength`. It is set by the application and not by the user. It is not necessarily meant to be displayed to the user.
+For instance, line-length is derived from `minimalLineLength`, `optimalLineLength` and `maximalLineLength`. They are not necessarily meant to be displayed to the user, they will almost always be hidden behind a simple setting with the app handling values behind the scenes.
 
 ## Inactive settings
 
@@ -113,7 +113,6 @@ EPUB comes in two very different flavors: reflowable which allows a lot of custo
 | invertFilter             | ✅         | WIP          |
 | invertGaijiFilter        | ✅         |              |
 | iPadOSPatch              | ✅         |              |
-| layoutStrategy           | ✅         |              |
 | letterSpacing            | ✅         |              |
 | ligatures                | ✅         |              |
 | lineHeight               | ✅         |              |
@@ -136,15 +135,9 @@ EPUB comes in two very different flavors: reflowable which allows a lot of custo
 | wordSpacing              | ✅         |              |
 | zoom                     |            | WIP          |
 
-### Layout Strategy
-
-Layout strategy `columns` is not available in scroll mode (`scroll = true`) or when `columnCount` is not `null`.
-
 ### Line length
 
 There is no `lineLength` preference because the effective line length is calculated based on the `optimalLineLength`, `minimalLineLength` and `maximalLineLength` preferences. 
-
-If you prefer to set a line length yourself, you can set `optimalLineLength` to the desired value (`ch|ic` unit) with `layoutStrategy` set to `margins`.
 
 ### Scroll vs paginated
 

--- a/navigator/src/epub/css/ReadiumCSS.ts
+++ b/navigator/src/epub/css/ReadiumCSS.ts
@@ -1,6 +1,5 @@
 import { LineLengths } from "../../helpers";
 import { getContentWidth } from "../../helpers/dimensions";
-import { LayoutStrategy } from "../../preferences";
 import { EpubSettings } from "../preferences/EpubSettings";
 import { IUserProperties, RSProperties, UserProperties } from "./Properties";
 
@@ -10,7 +9,6 @@ export interface IReadiumCSS {
   lineLengths: LineLengths;
   container: HTMLElement;
   constraint: number;
-  layoutStrategy?: LayoutStrategy | null;
 }
 
 export class ReadiumCSS {
@@ -20,7 +18,6 @@ export class ReadiumCSS {
   container: HTMLElement;
   containerParent: HTMLElement;
   constraint: number;
-  layoutStrategy: LayoutStrategy;
   private cachedColCount: number | null | undefined;
   private effectiveContainerWidth: number;
 
@@ -31,7 +28,6 @@ export class ReadiumCSS {
     this.container = props.container;
     this.containerParent = props.container.parentElement || document.documentElement;
     this.constraint = props.constraint;
-    this.layoutStrategy = props.layoutStrategy || LayoutStrategy.lineLength;
     this.cachedColCount = props.userProperties.colCount;
     this.effectiveContainerWidth = getContentWidth(this.containerParent);
   }
@@ -42,9 +38,6 @@ export class ReadiumCSS {
 
     if (settings.constraint !== this.constraint) 
       this.constraint = settings.constraint;
-
-    if (settings.layoutStrategy && settings.layoutStrategy !== this.layoutStrategy) 
-      this.layoutStrategy = settings.layoutStrategy;
 
     if (settings.pageGutter !== this.rsProperties.pageGutter)
       this.rsProperties.pageGutter = settings.pageGutter;
@@ -145,9 +138,7 @@ export class ReadiumCSS {
   private getCompensatedMetrics(scale: number | null, deprecatedImplem: boolean | null) {
     const zoomFactor = scale || this.userProperties.fontSize || 1;
     const zoomCompensation = zoomFactor < 1 
-      ? this.layoutStrategy === LayoutStrategy.margin 
-        ? 1 / (zoomFactor + 0.003)
-        : 1 / zoomFactor
+      ? 1 / zoomFactor
       : deprecatedImplem 
         ? zoomFactor 
         : 1;
@@ -188,61 +179,24 @@ export class ReadiumCSS {
     }
     
     if (colCount === null) {
-      if (this.layoutStrategy === LayoutStrategy.margin) {
-        if (constrainedWidth >= optimal) {
-          RCSSColCount = Math.floor(constrainedWidth / optimal);
-          const requiredWidth = Math.round(RCSSColCount * (optimal * zoomCompensation));
-          effectiveContainerWidth = Math.min(requiredWidth, constrainedWidth);
-        } else {
-          RCSSColCount = 1;
-          effectiveContainerWidth = constrainedWidth;
-        }
-      } else if (this.layoutStrategy === LayoutStrategy.lineLength) {
-        if (constrainedWidth < optimal || maximal === null) {
-          RCSSColCount = 1;
-          effectiveContainerWidth = constrainedWidth;
-        } else {
-          RCSSColCount = Math.floor(constrainedWidth / optimal);
-          const requiredWidth = Math.round(RCSSColCount * (maximal * zoomCompensation));
-          effectiveContainerWidth = Math.min(requiredWidth, constrainedWidth);
-        }
-      } else if (this.layoutStrategy === LayoutStrategy.columns) {
-        if (constrainedWidth >= optimal) {
-          if (maximal === null) {
-            RCSSColCount = Math.floor(constrainedWidth / optimal);
-            effectiveContainerWidth = constrainedWidth;
-          } else {
-            RCSSColCount = Math.floor(constrainedWidth / (minimal || optimal));
-            const requiredWidth = Math.round((RCSSColCount * (optimal * zoomCompensation)));
-            effectiveContainerWidth = Math.min(requiredWidth, constrainedWidth);
-          }
-        } else {
-          RCSSColCount = 1;
-          effectiveContainerWidth = constrainedWidth;
-        }
+      if (constrainedWidth < optimal || maximal === null) {
+        RCSSColCount = 1;
+        effectiveContainerWidth = constrainedWidth;
+      } else {
+        RCSSColCount = Math.floor(constrainedWidth / optimal);
+        const requiredWidth = Math.round(RCSSColCount * (maximal * zoomCompensation));
+        effectiveContainerWidth = Math.min(requiredWidth, constrainedWidth);
       }
     } else if (colCount > 1) {
       const minRequiredWidth = Math.round(colCount * (minimal !== null ? minimal : optimal));
     
       if (constrainedWidth >= minRequiredWidth) {
         RCSSColCount = colCount;
-        if (this.layoutStrategy === LayoutStrategy.margin) {
-          const requiredWidth = Math.round(RCSSColCount * (optimal * zoomCompensation));
+        if (maximal === null) {
+          effectiveContainerWidth = constrainedWidth
+        } else {
+          const requiredWidth = Math.round(RCSSColCount * (maximal * zoomCompensation));
           effectiveContainerWidth = Math.min(requiredWidth, constrainedWidth);
-        } else if (
-          this.layoutStrategy === LayoutStrategy.lineLength ||
-          this.layoutStrategy === LayoutStrategy.columns
-        ) {
-          if (maximal === null) {
-            effectiveContainerWidth = constrainedWidth
-          } else {
-            const requiredWidth = Math.round(RCSSColCount * (maximal * zoomCompensation));
-            effectiveContainerWidth = Math.min(requiredWidth, constrainedWidth);
-          }
-
-          if (this.layoutStrategy === LayoutStrategy.columns) {
-            console.error("Columns strategy is not compatible with a column count whose value is a number. Falling back to lineLength strategy.");
-          }
         }
       } else {
         if (minimal !== null && constrainedWidth < Math.round(colCount * minimal)) {
@@ -257,23 +211,11 @@ export class ReadiumCSS {
       RCSSColCount = 1;
       
       if (constrainedWidth >= optimal) {
-        if (this.layoutStrategy === LayoutStrategy.margin) {
-          const requiredWidth = Math.round(optimal * zoomCompensation);
+        if (maximal === null) {
+          effectiveContainerWidth = constrainedWidth
+        } else {
+          const requiredWidth = Math.round(maximal * zoomCompensation);
           effectiveContainerWidth = Math.min(requiredWidth, constrainedWidth);
-        } else if (
-          this.layoutStrategy === LayoutStrategy.lineLength ||
-          this.layoutStrategy === LayoutStrategy.columns
-        ) {
-          if (maximal === null) {
-            effectiveContainerWidth = constrainedWidth
-          } else {
-            const requiredWidth = Math.round(maximal * zoomCompensation);
-            effectiveContainerWidth = Math.min(requiredWidth, constrainedWidth);
-          }
-          
-          if (this.layoutStrategy === LayoutStrategy.columns) {
-            console.error("Columns strategy is not compatible with a column count whose value is a number. Falling back to lineLength strategy.");
-          }
         }
       } else {
         effectiveContainerWidth = constrainedWidth 
@@ -299,22 +241,11 @@ export class ReadiumCSS {
     let effectiveContainerWidth = constrainedWidth;
     let effectiveLineLength = Math.round(optimal * zoomCompensation);
 
-    if (this.layoutStrategy === LayoutStrategy.margin) {
-      const computedWidth = Math.min(Math.round(optimal * zoomCompensation), constrainedWidth);
+    if (maximal === null) {
+      effectiveLineLength = constrainedWidth;
+    } else {
+      const computedWidth = Math.min(Math.round(maximal * zoomCompensation), constrainedWidth);
       effectiveLineLength = deprecatedImplem ? computedWidth : Math.round(computedWidth * zoomCompensation);
-    } else if (
-      this.layoutStrategy === LayoutStrategy.lineLength ||
-      this.layoutStrategy === LayoutStrategy.columns
-    ) {
-      if (this.layoutStrategy === LayoutStrategy.columns) {
-        console.error("Columns strategy is not compatible with scroll. Falling back to lineLength strategy.");
-      }
-      if (maximal === null) {
-        effectiveLineLength = constrainedWidth;
-      } else {
-        const computedWidth = Math.min(Math.round(maximal * zoomCompensation), constrainedWidth);
-        effectiveLineLength = deprecatedImplem ? computedWidth : Math.round(computedWidth * zoomCompensation);
-      }
     }
 
     return { 

--- a/navigator/src/epub/preferences/EpubDefaults.ts
+++ b/navigator/src/epub/preferences/EpubDefaults.ts
@@ -2,7 +2,6 @@ import {
   fontSizeRangeConfig, 
   fontWeightRangeConfig, 
   fontWidthRangeConfig, 
-  LayoutStrategy, 
   TextAlignment, 
   Theme 
 } from "../../preferences/Types";
@@ -38,7 +37,6 @@ export interface IEpubDefaults {
   invertFilter?: boolean | number | null,
   invertGaijiFilter?: boolean | number | null,
   iPadOSPatch?: boolean | null,
-  layoutStrategy?: LayoutStrategy | null,
   letterSpacing?: number | null,
   ligatures?: boolean | null,
   lineHeight?: number | null,
@@ -82,7 +80,6 @@ export class EpubDefaults {
   invertFilter: boolean | number | null;
   invertGaijiFilter: boolean | number | null;
   iPadOSPatch: boolean;
-  layoutStrategy: LayoutStrategy | null;
   letterSpacing: number | null;
   ligatures: boolean | null;
   lineHeight: number | null;
@@ -130,7 +127,6 @@ export class EpubDefaults {
     this.iPadOSPatch = defaults.iPadOSPatch === false 
         ? false 
         : (sMLWithRequest.OS.iPadOS && sMLWithRequest.iOSRequest === "desktop");
-    this.layoutStrategy = ensureEnumValue<LayoutStrategy>(defaults.layoutStrategy, LayoutStrategy) || LayoutStrategy.lineLength;
     this.letterSpacing = ensureNonNegative(defaults.letterSpacing) || null;
     this.ligatures = ensureBoolean(defaults.ligatures) ?? null;
     this.lineHeight = ensureNonNegative(defaults.lineHeight) || null;

--- a/navigator/src/epub/preferences/EpubPreferences.ts
+++ b/navigator/src/epub/preferences/EpubPreferences.ts
@@ -1,7 +1,6 @@
 import { ConfigurablePreferences } from "../../preferences/Configurable";
 
 import { 
-  LayoutStrategy,
   TextAlignment, 
   Theme, 
   fontSizeRangeConfig, 
@@ -35,7 +34,6 @@ export interface IEpubPreferences {
   invertFilter?: boolean | number | null,
   invertGaijiFilter?: boolean | number | null,
   iPadOSPatch?: boolean | null,
-  layoutStrategy?: LayoutStrategy | null,
   letterSpacing?: number | null,
   ligatures?: boolean | null,
   lineHeight?: number | null,
@@ -79,7 +77,6 @@ export class EpubPreferences implements ConfigurablePreferences {
   invertFilter?: boolean | number | null;
   invertGaijiFilter?: boolean | number | null;
   iPadOSPatch?: boolean | null;
-  layoutStrategy?: LayoutStrategy | null;
   letterSpacing?: number | null;
   ligatures?: boolean | null;
   lineHeight?: number | null;
@@ -122,7 +119,6 @@ export class EpubPreferences implements ConfigurablePreferences {
     this.invertFilter = ensureFilter(preferences.invertFilter);
     this.invertGaijiFilter = ensureFilter(preferences.invertGaijiFilter);
     this.iPadOSPatch = ensureBoolean(preferences.iPadOSPatch);
-    this.layoutStrategy = ensureEnumValue<LayoutStrategy>(preferences.layoutStrategy, LayoutStrategy);
     this.letterSpacing = ensureNonNegative(preferences.letterSpacing);
     this.ligatures = ensureBoolean(preferences.ligatures);
     this.lineHeight = ensureNonNegative(preferences.lineHeight);

--- a/navigator/src/epub/preferences/EpubPreferencesEditor.ts
+++ b/navigator/src/epub/preferences/EpubPreferencesEditor.ts
@@ -4,7 +4,6 @@ import { EpubPreferences } from "./EpubPreferences";
 import { EpubSettings } from "./EpubSettings";
 import { BooleanPreference, EnumPreference, Preference, RangePreference } from "../../preferences/Preference";
 import { 
-  LayoutStrategy,
   TextAlignment, 
   Theme, 
   fontSizeRangeConfig, 
@@ -221,18 +220,6 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
         this.updatePreference("iPadOSPatch", newValue || null);
       }
     });
-  }
-
-  get layoutStrategy(): EnumPreference<LayoutStrategy> {
-    return new EnumPreference<LayoutStrategy>({
-      initialValue: this.preferences.layoutStrategy,
-      effectiveValue: this.settings.layoutStrategy,
-      isEffective: this.layout === EPUBLayout.reflowable,
-      onChange: (newValue: LayoutStrategy | null | undefined) => {
-        this.updatePreference("layoutStrategy", newValue || null);
-      },
-      supportedValues: Object.values(LayoutStrategy)
-    })
   }
 
   get letterSpacing(): RangePreference<number> {

--- a/navigator/src/epub/preferences/EpubSettings.ts
+++ b/navigator/src/epub/preferences/EpubSettings.ts
@@ -1,5 +1,5 @@
 import { ConfigurableSettings } from "../../preferences/Configurable";
-import { LayoutStrategy, TextAlignment, Theme } from "../../preferences/Types";
+import { TextAlignment, Theme } from "../../preferences/Types";
 import { EpubDefaults } from "./EpubDefaults";
 import { EpubPreferences } from "./EpubPreferences";
 
@@ -22,7 +22,6 @@ export interface IEpubSettings {
   invertFilter?: boolean | number | null,
   invertGaijiFilter: boolean | number | null,
   iPadOSPatch?: boolean | null,
-  layoutStrategy?: LayoutStrategy | null,
   letterSpacing?: number | null,
   ligatures?: boolean | null,
   lineHeight?: number | null,
@@ -66,7 +65,6 @@ export class EpubSettings implements ConfigurableSettings {
   invertFilter: boolean | number | null;
   invertGaijiFilter: boolean | number | null;
   iPadOSPatch: boolean;
-  layoutStrategy: LayoutStrategy | null;
   letterSpacing: number | null;
   ligatures: boolean | null;
   lineHeight: number | null;
@@ -147,7 +145,6 @@ export class EpubSettings implements ConfigurableSettings {
         : preferences.iPadOSPatch === true 
           ? (sMLWithRequest.OS.iPadOS && sMLWithRequest.iOSRequest === "desktop") 
           : defaults.iPadOSPatch;
-    this.layoutStrategy = preferences.layoutStrategy || defaults.layoutStrategy || null;
     this.letterSpacing = preferences.letterSpacing !== undefined 
       ? preferences.letterSpacing 
       : defaults.letterSpacing !== undefined 

--- a/navigator/src/preferences/Types.ts
+++ b/navigator/src/preferences/Types.ts
@@ -11,12 +11,6 @@ export enum Theme {
   custom = "custom"
 }
 
-export enum LayoutStrategy {
-  margin = "margin",
-  lineLength = "lineLength",
-  columns = "columns"
-}
-
 export type RangeConfig = {
   range: [number, number],
   step: number


### PR DESCRIPTION
Strategies can be achieved through custom values/presets, which removes a lot of the algorithmic complexity of the paginate method. Resolves #137

In draft because it depends on pretty much all other PRs and a Thorium Web Package update. 