### PR TITLE
Implement ReadiumCSS iOS patch

### DIFF
--- a/navigator/src/epub/css/Properties.ts
+++ b/navigator/src/epub/css/Properties.ts
@@ -66,6 +66,7 @@ export interface IUserProperties {
   fontWidth?: FontWidth | null;
   invertFilter?: boolean | number | null;
   invertGaijiFilter?: boolean | number | null;
+  iOSPatch?: boolean | null;
   iPadOSPatch?: boolean | null;
   letterSpacing?: number | null;
   ligatures?: Ligatures | null;
@@ -101,6 +102,7 @@ export class UserProperties extends Properties {
   fontWidth: FontWidth | null;
   invertFilter: boolean | number | null;
   invertGaijiFilter: boolean | number | null;
+  iOSPatch: boolean | null;
   iPadOSPatch: boolean | null;
   letterSpacing: number | null;
   ligatures: Ligatures | null;
@@ -136,6 +138,7 @@ export class UserProperties extends Properties {
     this.fontWidth = props.fontWidth ?? null;
     this.invertFilter = props.invertFilter ?? null;
     this.invertGaijiFilter = props.invertGaijiFilter ?? null;
+    this.iOSPatch = props.iOSPatch ?? null;
     this.iPadOSPatch = props.iPadOSPatch ?? null;
     this.letterSpacing = props.letterSpacing ?? null;
     this.ligatures = props.ligatures ?? null;
@@ -189,6 +192,7 @@ export class UserProperties extends Properties {
     } else if (typeof this.invertGaijiFilter === "number") {
       cssProperties["--USER__invertGaiji"] = this.toPercentage(this.invertGaijiFilter);
     }
+    if (this.iOSPatch) cssProperties["--USER__iOSPatch"] = this.toFlag("iOSPatch");
     if (this.iPadOSPatch) cssProperties["--USER__iPadOSPatch"] = this.toFlag("iPadOSPatch");
     if (this.letterSpacing != null) cssProperties["--USER__letterSpacing"] = this.toRem(this.letterSpacing);
     if (this.ligatures) cssProperties["--USER__ligatures"] = this.ligatures;

--- a/navigator/src/epub/css/ReadiumCSS.ts
+++ b/navigator/src/epub/css/ReadiumCSS.ts
@@ -73,7 +73,7 @@ export class ReadiumCSS {
       maxChars: settings.maximalLineLength
     });
 
-    const layout = this.updateLayout(settings.fontSize, settings.deprecatedFontSize, settings.scroll, settings.columnCount);
+    const layout = this.updateLayout(settings.fontSize, settings.deprecatedFontSize || settings.iOSPatch, settings.scroll, settings.columnCount);
 
     if (layout?.effectiveContainerWidth)
       this.effectiveContainerWidth = layout?.effectiveContainerWidth;
@@ -103,6 +103,7 @@ export class ReadiumCSS {
       fontWidth: settings.fontWidth,
       invertFilter: settings.invertFilter,
       invertGaijiFilter: settings.invertGaijiFilter,
+      iOSPatch: settings.iOSPatch,
       iPadOSPatch: settings.iPadOSPatch,
       letterSpacing: settings.letterSpacing,
       ligatures: typeof settings.ligatures !== "boolean" 
@@ -132,23 +133,23 @@ export class ReadiumCSS {
     this.userProperties = new UserProperties(updated);
   }
 
-  private updateLayout(scale: number | null, deprecatedImplem: boolean | null, scroll: boolean | null, colCount?: number | null) {
+  private updateLayout(scale: number | null, ignoreCompensation: boolean | null, scroll: boolean | null, colCount?: number | null) {
     const isScroll = scroll ?? this.userProperties.view === "scroll";
 
     if (isScroll) {
-      return this.computeScrollLength(scale, deprecatedImplem);
+      return this.computeScrollLength(scale, ignoreCompensation);
     } else {
-      return this.paginate(scale, deprecatedImplem, colCount);
+      return this.paginate(scale, ignoreCompensation, colCount);
     }
   }
 
-  private getCompensatedMetrics(scale: number | null, deprecatedImplem: boolean | null) {
+  private getCompensatedMetrics(scale: number | null, ignoreCompensation: boolean | null) {
     const zoomFactor = scale || this.userProperties.fontSize || 1;
     const zoomCompensation = zoomFactor < 1 
       ? this.layoutStrategy === LayoutStrategy.margin 
         ? 1 / (zoomFactor + 0.003)
         : 1 / zoomFactor
-      : deprecatedImplem 
+      : ignoreCompensation 
         ? zoomFactor 
         : 1;
 
@@ -168,9 +169,9 @@ export class ReadiumCSS {
   // Note: Kept intentionally verbose for debugging
   // TODO: As scroll shows, the effective line-length
   // should be the same as uncompensated when scale >= 1
-  private paginate(scale: number | null, deprecatedImplem: boolean | null, colCount?: number | null) {
+  private paginate(scale: number | null, ignoreCompensation: boolean | null, colCount?: number | null) {
     const constrainedWidth = Math.round(getContentWidth(this.containerParent) - (this.constraint));
-    const metrics = this.getCompensatedMetrics(scale, deprecatedImplem);
+    const metrics = this.getCompensatedMetrics(scale, ignoreCompensation);
     const zoomCompensation = metrics.zoomCompensation;
     const optimal = metrics.optimal;
     const minimal = metrics.minimal;
@@ -288,9 +289,9 @@ export class ReadiumCSS {
   }
 
   // This behaves as paginate where colCount = 1
-  private computeScrollLength(scale: number | null, deprecatedImplem: boolean | null) {
+  private computeScrollLength(scale: number | null, ignoreCompensation: boolean | null) {
     const constrainedWidth = Math.round(getContentWidth(this.containerParent) - (this.constraint));
-    const metrics = this.getCompensatedMetrics(scale && (scale < 1 || deprecatedImplem) ? scale : 1, deprecatedImplem);
+    const metrics = this.getCompensatedMetrics(scale && (scale < 1 || ignoreCompensation) ? scale : 1, ignoreCompensation);
     const zoomCompensation = metrics.zoomCompensation;
     const optimal = metrics.optimal;
     const maximal = metrics.maximal;
@@ -301,7 +302,7 @@ export class ReadiumCSS {
 
     if (this.layoutStrategy === LayoutStrategy.margin) {
       const computedWidth = Math.min(Math.round(optimal * zoomCompensation), constrainedWidth);
-      effectiveLineLength = deprecatedImplem ? computedWidth : Math.round(computedWidth * zoomCompensation);
+      effectiveLineLength = ignoreCompensation ? computedWidth : Math.round(computedWidth * zoomCompensation);
     } else if (
       this.layoutStrategy === LayoutStrategy.lineLength ||
       this.layoutStrategy === LayoutStrategy.columns
@@ -313,7 +314,7 @@ export class ReadiumCSS {
         effectiveLineLength = constrainedWidth;
       } else {
         const computedWidth = Math.min(Math.round(maximal * zoomCompensation), constrainedWidth);
-        effectiveLineLength = deprecatedImplem ? computedWidth : Math.round(computedWidth * zoomCompensation);
+        effectiveLineLength = ignoreCompensation ? computedWidth : Math.round(computedWidth * zoomCompensation);
       }
     }
 
@@ -329,7 +330,7 @@ export class ReadiumCSS {
   }
 
   resizeHandler() {
-    const pagination = this.updateLayout(this.userProperties.fontSize, this.userProperties.deprecatedFontSize, this.userProperties.view === "scroll", this.cachedColCount);
+    const pagination = this.updateLayout(this.userProperties.fontSize, this.userProperties.deprecatedFontSize || this.userProperties.iOSPatch, this.userProperties.view === "scroll", this.cachedColCount);
     this.userProperties.colCount = pagination.colCount;
     this.userProperties.lineLength = pagination.effectiveLineLength;
     this.effectiveContainerWidth = pagination.effectiveContainerWidth;

--- a/navigator/src/epub/preferences/EpubDefaults.ts
+++ b/navigator/src/epub/preferences/EpubDefaults.ts
@@ -37,6 +37,7 @@ export interface IEpubDefaults {
   hyphens?: boolean | null,
   invertFilter?: boolean | number | null,
   invertGaijiFilter?: boolean | number | null,
+  iOSPatch?: boolean | null,
   iPadOSPatch?: boolean | null,
   layoutStrategy?: LayoutStrategy | null,
   letterSpacing?: number | null,
@@ -81,6 +82,7 @@ export class EpubDefaults {
   hyphens: boolean | null;
   invertFilter: boolean | number | null;
   invertGaijiFilter: boolean | number | null;
+  iOSPatch: boolean;
   iPadOSPatch: boolean;
   layoutStrategy: LayoutStrategy | null;
   letterSpacing: number | null;
@@ -127,6 +129,9 @@ export class EpubDefaults {
     this.hyphens = ensureBoolean(defaults.hyphens) ?? null;
     this.invertFilter = ensureFilter(defaults.invertFilter) ?? false;
     this.invertGaijiFilter = ensureFilter(defaults.invertGaijiFilter) ?? false;
+    this.iOSPatch = defaults.iOSPatch === false 
+        ? false 
+        : ((sMLWithRequest.OS.iOS || sMLWithRequest.OS.iPadOS) && sMLWithRequest.iOSRequest === "mobile");
     this.iPadOSPatch = defaults.iPadOSPatch === false 
         ? false 
         : (sMLWithRequest.OS.iPadOS && sMLWithRequest.iOSRequest === "desktop");

--- a/navigator/src/epub/preferences/EpubPreferences.ts
+++ b/navigator/src/epub/preferences/EpubPreferences.ts
@@ -34,6 +34,7 @@ export interface IEpubPreferences {
   hyphens?: boolean | null,
   invertFilter?: boolean | number | null,
   invertGaijiFilter?: boolean | number | null,
+  iOSPatch?: boolean | null,
   iPadOSPatch?: boolean | null,
   layoutStrategy?: LayoutStrategy | null,
   letterSpacing?: number | null,
@@ -78,6 +79,7 @@ export class EpubPreferences implements ConfigurablePreferences {
   hyphens?: boolean | null;
   invertFilter?: boolean | number | null;
   invertGaijiFilter?: boolean | number | null;
+  iOSPatch?: boolean | null;
   iPadOSPatch?: boolean | null;
   layoutStrategy?: LayoutStrategy | null;
   letterSpacing?: number | null;
@@ -121,6 +123,7 @@ export class EpubPreferences implements ConfigurablePreferences {
     this.hyphens = ensureBoolean(preferences.hyphens);
     this.invertFilter = ensureFilter(preferences.invertFilter);
     this.invertGaijiFilter = ensureFilter(preferences.invertGaijiFilter);
+    this.iOSPatch = ensureBoolean(preferences.iOSPatch);
     this.iPadOSPatch = ensureBoolean(preferences.iPadOSPatch);
     this.layoutStrategy = ensureEnumValue<LayoutStrategy>(preferences.layoutStrategy, LayoutStrategy);
     this.letterSpacing = ensureNonNegative(preferences.letterSpacing);

--- a/navigator/src/epub/preferences/EpubPreferencesEditor.ts
+++ b/navigator/src/epub/preferences/EpubPreferencesEditor.ts
@@ -212,6 +212,17 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
     });
   }
 
+  get iOSPatch(): BooleanPreference {
+    return new BooleanPreference({
+      initialValue: this.preferences.iOSPatch,
+      effectiveValue: this.settings.iOSPatch || false,
+      isEffective: this.layout === EPUBLayout.reflowable,
+      onChange: (newValue: boolean | null | undefined) => {
+        this.updatePreference("iOSPatch", newValue || null);
+      }
+    });
+  }
+
   get iPadOSPatch(): BooleanPreference {
     return new BooleanPreference({
       initialValue: this.preferences.iPadOSPatch,

--- a/navigator/src/epub/preferences/EpubSettings.ts
+++ b/navigator/src/epub/preferences/EpubSettings.ts
@@ -21,6 +21,7 @@ export interface IEpubSettings {
   hyphens?: boolean | null,
   invertFilter?: boolean | number | null,
   invertGaijiFilter: boolean | number | null,
+  iOSPatch?: boolean | null,
   iPadOSPatch?: boolean | null,
   layoutStrategy?: LayoutStrategy | null,
   letterSpacing?: number | null,
@@ -65,6 +66,7 @@ export class EpubSettings implements ConfigurableSettings {
   hyphens: boolean | null;
   invertFilter: boolean | number | null;
   invertGaijiFilter: boolean | number | null;
+  iOSPatch: boolean;
   iPadOSPatch: boolean;
   layoutStrategy: LayoutStrategy | null;
   letterSpacing: number | null;
@@ -140,6 +142,13 @@ export class EpubSettings implements ConfigurableSettings {
     this.invertGaijiFilter = typeof preferences.invertGaijiFilter === "boolean" 
       ? preferences.invertGaijiFilter 
       : defaults.invertGaijiFilter ?? null;
+    this.iOSPatch = this.deprecatedFontSize 
+      ? false 
+      : preferences.iOSPatch === false 
+        ? false 
+        : preferences.iOSPatch === true 
+          ? ((sMLWithRequest.OS.iOS || sMLWithRequest.OS.iPadOS) && sMLWithRequest.iOSRequest === "mobile")
+          : defaults.iOSPatch;
     this.iPadOSPatch = this.deprecatedFontSize 
       ? false 
       : preferences.iPadOSPatch === false 


### PR DESCRIPTION
Depends on https://github.com/readium/css/pull/190

To sum things up, we have a weird unexplained issue on iOS where orientation change bump the size of paragraphs specifically in scroll… 

Since we cannot use `-webkit-text-size-adjust: 100%` because it breaks CSS `zoom` we have to replace the latter with the former on iOS. 

Readium CSS will expose a flag once the PR mentioned above is merged and published. 

This TS-Toolkit PR exposes this flag through the Preferences API, and handles it by default by sniffing iOS + Mobile, as it already does for the iPadOS Patch.