### PR TITLE
Scroll fixes

### DIFF
--- a/navigator-html-injectables/package.json
+++ b/navigator-html-injectables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator-html-injectables",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "type": "module",
   "description": "An embeddable solution for connecting frames of HTML publications with a Readium Navigator",
   "author": "readium",

--- a/navigator-html-injectables/src/modules/snapper/ColumnSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ColumnSnapper.ts
@@ -39,6 +39,8 @@ export class ColumnSnapper extends Snapper {
     }
 
     reportProgress() {
+        // Contrary to ScrollTop, Android slightly adds to scrollX
+        // So we do not need to round it up
         const scrollX = this.wnd.scrollX;
         const scrollWidth = this.cachedScrollWidth;
         const progress = Math.max(0, Math.min(1, scrollX / scrollWidth));

--- a/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
@@ -20,10 +20,15 @@ export class ScrollSnapper extends Snapper {
     }
 
     private reportProgress() {
-        const scrollTop = this.doc().scrollTop;
+        // We have to round up the scroll position because
+        // Android may never reach 100% of the scroll height
+        // due to the way it rounds scrollTop…
+        const scrollTop = Math.ceil(this.doc().scrollTop);
         const scrollHeight = this.doc().scrollHeight;
+        const viewportHeight = this.wnd.innerHeight;
         const progress = Math.max(0, Math.min(1, scrollTop / scrollHeight));
-        const viewportEnd = Math.max(0, Math.min(1, (scrollTop + this.wnd.innerHeight) / scrollHeight));
+        const viewportEnd = Math.max(0, Math.min(1, (scrollTop + viewportHeight) / scrollHeight));
+
         this.comms.send("progress", {
             start: progress,
             end: viewportEnd

--- a/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
@@ -78,8 +78,13 @@ export class ScrollSnapper extends Snapper {
             // Only the content at the start of the document, 
             // whose height is the viewport height, will be rendered.
             const currentScroll = this.doc().scrollTop;
-            this.doc().scrollTop = currentScroll + 1;
+            if (currentScroll > 1) {
+                this.doc().scrollTop = currentScroll - 1;
+            } else {
+                this.doc().scrollTop = currentScroll + 1;
+            }
             this.doc().scrollTop = currentScroll;
+
         });
 
         comms.register("go_progression", ScrollSnapper.moduleName, (data, ack) => {

--- a/navigator/package.json
+++ b/navigator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator",
-  "version": "2.0.0-beta.11",
+  "version": "2.0.0-beta.12",
   "type": "module",
   "description": "Next generation SDK for publications in Web Apps",
   "author": "readium",


### PR DESCRIPTION
This resolves rounding issues on some Android devices re. progression that could never reach `1` in scroll, hence making the `isScrollEnd` helper useless. 