### PR TITLE
Scroll listener

### DIFF
--- a/navigator-html-injectables/package.json
+++ b/navigator-html-injectables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator-html-injectables",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "type": "module",
   "description": "An embeddable solution for connecting frames of HTML publications with a Readium Navigator",
   "author": "readium",

--- a/navigator-html-injectables/src/comms/keys.ts
+++ b/navigator-html-injectables/src/comms/keys.ts
@@ -12,6 +12,7 @@ export type CommsEventKey =
     "no_more" |
     "no_less" |
     "swipe" |
+    "scroll" |
     "progress" |
     "first_visible_locator" |
     "text_selected" |

--- a/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
@@ -13,13 +13,19 @@ export class ScrollSnapper extends Snapper {
     private wnd!: ReadiumWindow;
     private comms!: Comms;
     private resizeObserver!: ResizeObserver;
+
+    private initialScrollHandled = false;
     private isScrolling = false;
+    private lastScrollTop = 0;
+    private isResizing = false;
+    private resizeDebounce: number | null = null;
 
     private doc() {
         return this.wnd.document.scrollingElement as HTMLElement;
     }
 
     private reportProgress() {
+        if (!this.comms.ready) return;
         // We have to round up the scroll position because
         // Android may never reach 100% of the scroll height
         // due to the way it rounds scrollTop…
@@ -36,10 +42,37 @@ export class ScrollSnapper extends Snapper {
     }
 
     private handleScroll = () => {
+        if (!this.comms.ready) return;
+        
+        // We have to filter scroll from resize events
+        if (this.isResizing) {
+            return;
+        }
+
+        // We have to filter the first scroll event because
+        // it is triggered by the progression sync’ing
+        // on load, and is not triggered by the user
+        if (!this.initialScrollHandled) {
+            this.lastScrollTop = this.doc().scrollTop;
+            this.initialScrollHandled = true;
+            this.reportProgress();
+            return;
+        }
+
         if (!this.isScrolling) {
             this.isScrolling = true;
             this.wnd.requestAnimationFrame(() => {
                 this.reportProgress();
+
+                const currentScrollTop = this.doc().scrollTop;
+                const deltaY = currentScrollTop - this.lastScrollTop;
+                this.lastScrollTop = currentScrollTop;
+
+                this.comms.send("scroll", {
+                    deltaY,
+                    scrollTop: currentScrollTop
+                });
+            
                 this.isScrolling = false;
             });
         }
@@ -48,6 +81,14 @@ export class ScrollSnapper extends Snapper {
     mount(wnd: ReadiumWindow, comms: Comms): boolean {
         this.wnd = wnd;
         this.comms = comms;
+
+        this.initialScrollHandled = false;
+        this.lastScrollTop = 0;
+        this.isResizing = false;
+        if (this.resizeDebounce) {
+            this.wnd.clearTimeout(this.resizeDebounce);
+            this.resizeDebounce = null;
+        }
 
         wnd.navigator.epubReadingSystem.layoutStyle = "scrolling";
 
@@ -66,14 +107,24 @@ export class ScrollSnapper extends Snapper {
         `;
         wnd.document.head.appendChild(style);
 
+        // We have to debounce resize events so that
+        // we don’t send scroll events when the user
+        // resizes the window
         this.resizeObserver = new ResizeObserver(() => {
-            this.comms.ready && this.handleScroll();
+            if (this.resizeDebounce) {
+                this.wnd.clearTimeout(this.resizeDebounce);
+            }
+            
+            this.isResizing = true;
+            this.resizeDebounce = this.wnd.setTimeout(() => {
+                this.isResizing = false;
+                this.resizeDebounce = null;
+                this.reportProgress();
+            }, 50);
         });
         this.resizeObserver.observe(wnd.document.body);
 
-        wnd.addEventListener("scroll", this.handleScroll, {
-            passive: true
-        });
+        wnd.addEventListener("scroll", this.handleScroll, { passive: true });
 
         comms.register("force_webkit_recalc", ScrollSnapper.moduleName, () => {
             forceWebkitRecalc(this.wnd);
@@ -89,7 +140,6 @@ export class ScrollSnapper extends Snapper {
                 this.doc().scrollTop = currentScroll + 1;
             }
             this.doc().scrollTop = currentScroll;
-
         });
 
         comms.register("go_progression", ScrollSnapper.moduleName, (data, ack) => {

--- a/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
@@ -13,8 +13,7 @@ export class ScrollSnapper extends Snapper {
     private wnd!: ReadiumWindow;
     private comms!: Comms;
     private resizeObserver!: ResizeObserver;
-    private scrollEndTimer: number | null = null;
-    private readonly SCROLL_END_DELAY = 100;
+    private isScrolling = false;
 
     private doc() {
         return this.wnd.document.scrollingElement as HTMLElement;
@@ -36,23 +35,14 @@ export class ScrollSnapper extends Snapper {
         });
     }
 
-    // scrollEnd not available in Safari yet so 
-    // we are using the old school timeout method
     private handleScroll = () => {
-        // Clear any existing timeout
-        if (this.scrollEndTimer !== null) {
-            this.wnd.clearTimeout(this.scrollEndTimer);
+        if (!this.isScrolling) {
+            this.isScrolling = true;
+            this.wnd.requestAnimationFrame(() => {
+                this.reportProgress();
+                this.isScrolling = false;
+            });
         }
-
-        // Set a new timeout
-        this.scrollEndTimer = this.wnd.setTimeout(() => {
-            this.onScrollEnd();
-        }, this.SCROLL_END_DELAY);
-    };
-
-    private onScrollEnd = () => {
-        this.scrollEndTimer = null;
-        this.reportProgress();
     };
 
     mount(wnd: ReadiumWindow, comms: Comms): boolean {
@@ -99,6 +89,7 @@ export class ScrollSnapper extends Snapper {
                 this.doc().scrollTop = currentScroll + 1;
             }
             this.doc().scrollTop = currentScroll;
+
         });
 
         comms.register("go_progression", ScrollSnapper.moduleName, (data, ack) => {
@@ -209,13 +200,6 @@ export class ScrollSnapper extends Snapper {
         this.resizeObserver.disconnect();
         if (this.handleScroll) wnd.removeEventListener("scroll", this.handleScroll);
         wnd.document.getElementById(SCROLL_SNAPPER_STYLE_ID)?.remove();
-        
-        // Clean up scroll end timer
-        if (this.scrollEndTimer !== null) {
-            clearTimeout(this.scrollEndTimer);
-            this.scrollEndTimer = null;
-        }
-        
         comms.log("ScrollSnapper Unmounted");
         return true;
     }

--- a/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
@@ -68,10 +68,7 @@ export class ScrollSnapper extends Snapper {
                 const deltaY = currentScrollTop - this.lastScrollTop;
                 this.lastScrollTop = currentScrollTop;
 
-                this.comms.send("scroll", {
-                    deltaY,
-                    scrollTop: currentScrollTop
-                });
+                this.comms.send("scroll", deltaY);
             
                 this.isScrolling = false;
             });

--- a/navigator/docs/epub/CustomizingListeners.md
+++ b/navigator/docs/epub/CustomizingListeners.md
@@ -8,6 +8,7 @@ The following events are exposed:
 - `tap`: fires when a tap has not been handled by default
 - `click`: fires when a click has not been handled
 - `zoom`: fires when the user has zoomed into the iframe
+- `scroll`: fires when the user has scrolled into the iframe
 - `miscPointer`: fires when a tap or a click was made in the middle of the iframe e.g. show/hide UI
 - `customEvent`: fires when the EpubNavigator doesn’t handle the event by default
 - `handleLocator`: fires when a link has been tapped or clicked
@@ -26,6 +27,7 @@ const listeners: EpubNavigatorListeners = {
     return false;
   },
   zoom: function (_scale: number): void {},
+  scroll: function (_delta: number): void {},
   miscPointer: function (_amount: number): void {},
   customEvent: function (_key: string, _data: unknown): void {},
   handleLocator: function (locator: Locator): boolean {
@@ -86,13 +88,17 @@ const listeners: EpubNavigatorListeners = {
 
 Fires when the user has zoomed in a Fixed-Layout publication.
 
+### Scroll
+
+Fires when the user has scrolled in a Fixed-Layout publication. The `delta` is the number of pixels scrolled.
+
 ### miscPointer
 
 Fires when a tap or a click was made in the middle of the iframe e.g. it can be used to show/hide UI.
 
 ### customEvent
 
-Fires when the EpubNavigator doesn’t handle the event by default.
+Fires when a custom event has been triggered from the publication.
 
 ### handleLocator
 

--- a/navigator/docs/epub/EpubNavigator.md
+++ b/navigator/docs/epub/EpubNavigator.md
@@ -67,7 +67,7 @@ Additionally, the `EpubNavigator` class provides the following properties:
 - `publication`: The publication (`Publication`) rendered by this navigator.
 - `currentLocator`: The current position (`Locator`) in the publication. Can be used to save a bookmark to the current position.
 - `readingProgression`: The current reading progression direction (`ReadingProgression`).
-- `currentPositionNumbers`: The current position numbers in the publication. Can be used to update a progression affordance.
+- `viewport`: Information about what is visible into the current viewport (`Viewport`) i.e. the current resources, their progression, and the positions from the `PositionsList`. Can be used to update a progression affordance.
 
 ### Preferences API
 
@@ -124,3 +124,14 @@ navigator.goRight(true, () => {
   console.log('Navigated to the right');
 });
 ```
+
+## Helpers
+
+Finally, `EpubNavigator` provides a few helpers to help derive information about navigation:
+
+- `canGoForward()`: Returns `true` if the navigator can go forward in the publication.
+- `canGoBackward()`: Returns `true` if the navigator can go backward in the publication.
+- `isScrollStart()`: Returns `true` if the navigator is at the start of the resources in the viewport.
+- `isScrollEnd()`: Returns `true` if the navigator is at the end of the resources in the viewport.
+
+These can come in handy if you want to disable navigation buttons when the user is at the start or end of the publication, or show the UI if the user is scrolling to the end of the resources in the viewport.

--- a/navigator/package.json
+++ b/navigator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator",
-  "version": "2.0.0-beta.13",
+  "version": "2.0.0-beta.14",
   "type": "module",
   "description": "Next generation SDK for publications in Web Apps",
   "author": "readium",

--- a/navigator/src/epub/EpubNavigator.ts
+++ b/navigator/src/epub/EpubNavigator.ts
@@ -15,6 +15,11 @@ import { ReadiumCSS } from "./css/ReadiumCSS";
 import { RSProperties, UserProperties } from "./css/Properties";
 import { getContentWidth } from "../helpers/dimensions";
 
+export interface ScrollData {
+    deltaY: number;
+    scrollTop: number;
+}
+
 export type ManagerEventKey = "zoom";
 
 export interface EpubNavigatorConfiguration {
@@ -29,6 +34,7 @@ export interface EpubNavigatorListeners {
     click: (e: FrameClickEvent) => boolean;  // Return true to prevent handling here
     zoom: (scale: number) => void;
     miscPointer: (amount: number) => void;
+    scroll: (data: ScrollData) => void;
     customEvent: (key: string, data: unknown) => void;
     handleLocator: (locator: Locator) => boolean; // Retrun true to prevent handling here
     textSelected: (selection: BasicTextSelection) => void;
@@ -42,6 +48,7 @@ const defaultListeners = (listeners: EpubNavigatorListeners): EpubNavigatorListe
     click: listeners.click || (() => false),
     zoom: listeners.zoom || (() => {}),
     miscPointer: listeners.miscPointer || (() => {}),
+    scroll: listeners.scroll || (() => {}),
     customEvent: listeners.customEvent || (() => {}),
     handleLocator: listeners.handleLocator || (() => false),
     textSelected: listeners.textSelected || (() => {})
@@ -395,6 +402,9 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
                 break;
             case "swipe":
                 // Swipe event
+                break;
+            case "scroll":
+                this.listeners.scroll(data as ScrollData);
                 break;
             case "zoom":
                 this.listeners.zoom(data as number);

--- a/navigator/src/epub/EpubNavigator.ts
+++ b/navigator/src/epub/EpubNavigator.ts
@@ -15,11 +15,6 @@ import { ReadiumCSS } from "./css/ReadiumCSS";
 import { RSProperties, UserProperties } from "./css/Properties";
 import { getContentWidth } from "../helpers/dimensions";
 
-export interface ScrollData {
-    deltaY: number;
-    scrollTop: number;
-}
-
 export type ManagerEventKey = "zoom";
 
 export interface EpubNavigatorConfiguration {
@@ -34,7 +29,7 @@ export interface EpubNavigatorListeners {
     click: (e: FrameClickEvent) => boolean;  // Return true to prevent handling here
     zoom: (scale: number) => void;
     miscPointer: (amount: number) => void;
-    scroll: (data: ScrollData) => void;
+    scroll: (delta: number) => void;
     customEvent: (key: string, data: unknown) => void;
     handleLocator: (locator: Locator) => boolean; // Retrun true to prevent handling here
     textSelected: (selection: BasicTextSelection) => void;
@@ -404,7 +399,7 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
                 // Swipe event
                 break;
             case "scroll":
-                this.listeners.scroll(data as ScrollData);
+                this.listeners.scroll(data as number);
                 break;
             case "zoom":
                 this.listeners.zoom(data as number);


### PR DESCRIPTION
This adds `scroll` in `EpubNavigatorListeners`, which allows to pass a callback with `delta` as an argument. 

Resolves #151

The implementation is less trivial that you would maybe expect, as there is some filtering happening in the `ScrollSnapper`:

- on resize;
- on the initial `scroll` event firing, since we sync the position after mounting the snapper. 

It also removes the previous “scrollEnd” implementation as it was not satisfactory to resolve the root issue we were trying to solve: you had to use `progressionChanged` as a proxy to the scroll event, with side effects and extra complexities, and no way to apply a threshold if needed. 