### PR TITLE
Paginate fix

### DIFF
--- a/navigator/CHANGELOG.MD
+++ b/navigator/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2025-08-29
+
+### Fixed
+
+- Fix `n > 1` discrepancy in ReadiumCSS `paginate` method when falling back to 1 column
+
 ## [2.0.0] - 2025-08-01
 
 ### Added

--- a/navigator/package.json
+++ b/navigator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "description": "Next generation SDK for publications in Web Apps",
   "author": "readium",

--- a/navigator/src/epub/css/ReadiumCSS.ts
+++ b/navigator/src/epub/css/ReadiumCSS.ts
@@ -161,12 +161,17 @@ export class ReadiumCSS {
   // TODO: As scroll shows, the effective line-length
   // should be the same as uncompensated when scale >= 1
   private paginate(scale: number | null, ignoreCompensation: boolean | null, colCount?: number | null) {
-    const constrainedWidth = Math.round(getContentWidth(this.containerParent) - (this.constraint));
+    const constrainedWidth = Math.round(getContentWidth(this.containerParent) - this.constraint);
     const metrics = this.getCompensatedMetrics(scale, ignoreCompensation);
-    const zoomCompensation = metrics.zoomCompensation;
-    const optimal = metrics.optimal;
-    const minimal = metrics.minimal;
-    const maximal = metrics.maximal;
+    const { zoomCompensation, optimal, minimal, maximal } = metrics;
+
+    // Helper function for single column width calculation
+    const getSingleColWidth = (): number => {
+      if (constrainedWidth >= optimal && maximal !== null) {
+        return Math.min(Math.round(maximal * zoomCompensation), constrainedWidth);
+      }
+      return constrainedWidth;
+    };
 
     let RCSSColCount = 1;
     let effectiveContainerWidth = constrainedWidth;
@@ -180,13 +185,12 @@ export class ReadiumCSS {
     }
     
     if (colCount === null) {
-      if (constrainedWidth < optimal || maximal === null) {
-        RCSSColCount = 1;
-        effectiveContainerWidth = constrainedWidth;
-      } else {
+      if (constrainedWidth >= optimal && maximal !== null) {
         RCSSColCount = Math.floor(constrainedWidth / optimal);
         const requiredWidth = Math.round(RCSSColCount * (maximal * zoomCompensation));
         effectiveContainerWidth = Math.min(requiredWidth, constrainedWidth);
+      } else {
+        effectiveContainerWidth = getSingleColWidth();
       }
     } else if (colCount > 1) {
       const minRequiredWidth = Math.round(colCount * (minimal !== null ? minimal : optimal));
@@ -202,25 +206,22 @@ export class ReadiumCSS {
       } else {
         if (minimal !== null && constrainedWidth < Math.round(colCount * minimal)) {
           RCSSColCount = Math.floor(constrainedWidth / minimal);
+          if (RCSSColCount <= 1) {
+            RCSSColCount = 1;
+            effectiveContainerWidth = getSingleColWidth();
+          } else {
+            const requiredWidth = Math.round(RCSSColCount * (optimal * zoomCompensation));
+            effectiveContainerWidth = Math.min(requiredWidth, constrainedWidth);
+          }
         } else {
           RCSSColCount = colCount;
+          const requiredWidth = Math.round(RCSSColCount * (optimal * zoomCompensation));
+          effectiveContainerWidth = Math.min(requiredWidth, constrainedWidth);
         }
-        const requiredWidth = Math.round((RCSSColCount * (optimal * zoomCompensation)));
-        effectiveContainerWidth = Math.min(requiredWidth, constrainedWidth);
       }
     } else {
       RCSSColCount = 1;
-      
-      if (constrainedWidth >= optimal) {
-        if (maximal === null) {
-          effectiveContainerWidth = constrainedWidth
-        } else {
-          const requiredWidth = Math.round(maximal * zoomCompensation);
-          effectiveContainerWidth = Math.min(requiredWidth, constrainedWidth);
-        }
-      } else {
-        effectiveContainerWidth = constrainedWidth 
-      }
+      effectiveContainerWidth = getSingleColWidth();
     }
 
     return { 


### PR DESCRIPTION
This is resolving an inconsistency in the handling of pagination when the number of columns is greater than 1 but there is only space available for a single one. In that case, the `effectiveContainerWidth` was set differently than when columns is `null` or `1`. 

The logic was refactored in the process, so that it can be more readable. 