### PR TITLE
Remove theme from Preferences API

### DIFF
--- a/navigator-html-injectables/CHANGELOG.MD
+++ b/navigator-html-injectables/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2025-09-10
+
+### Changed
+
+- Updated shared models ([#159](https://github.com/readium/ts-toolkit/issues/159)) as some checks were not working properly in the `iframe` context.
+
 ## [2.1.0] - 2025-08-29
 
 ### Changed

--- a/navigator-html-injectables/package.json
+++ b/navigator-html-injectables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator-html-injectables",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "description": "An embeddable solution for connecting frames of HTML publications with a Readium Navigator",
   "author": "readium",

--- a/navigator/CHANGELOG.MD
+++ b/navigator/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2025-09-??
+
+### Removed
+
+- Removed `appearance` property from `UserProperties` and `ReadiumCSS`, `Theme` enum and `theme` property from the Preferences API, since ReadiumCSS is no longer providing reading modes (night, sepia) as of `v2.0.0-beta.19`.
+
 ## [2.1.0] - 2025-08-29
 
 ### Added

--- a/navigator/CHANGELOG.MD
+++ b/navigator/CHANGELOG.MD
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.1] - 2025-09-??
+## [2.1.1] - 2025-09-10
+
+### Changed
+
+- Updated shared models ([#159](https://github.com/readium/ts-toolkit/issues/159)) as some checks were not working properly in the `iframe` context..
 
 ### Removed
 

--- a/navigator/docs/epub/ConfiguringEpubNavigator.md
+++ b/navigator/docs/epub/ConfiguringEpubNavigator.md
@@ -130,7 +130,6 @@ EPUB comes in two very different flavors: reflowable which allows a lot of custo
 | textAlign                | ✅         |              |
 | textColor                | ✅         |              |
 | textNormalization        | ✅         |              |
-| theme                    | ✅         |              |
 | visitedColor             | ✅         |              |
 | wordSpacing              | ✅         |              |
 | zoom                     |            | WIP          |

--- a/navigator/package.json
+++ b/navigator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "description": "Next generation SDK for publications in Web Apps",
   "author": "readium",
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@laynezh/vite-plugin-lib-assets": "^2.1.0",
-    "@readium/css": "2.0.0-beta.18",
+    "@readium/css": "2.0.0-beta.19",
     "@readium/navigator-html-injectables": "workspace:*",
     "@readium/shared": "workspace:*",
     "@types/path-browserify": "^1.0.3",

--- a/navigator/src/epub/css/Properties.ts
+++ b/navigator/src/epub/css/Properties.ts
@@ -1,4 +1,4 @@
-import { TextAlignment, Theme } from "../../preferences/Types";
+import { TextAlignment } from "../../preferences/Types";
 
 export type BodyHyphens = "auto" | "none";
 export type BoxSizing = "content-box" | "border-box";
@@ -51,7 +51,6 @@ abstract class Properties {
 export interface IUserProperties {
   advancedSettings?: boolean | null;
   a11yNormalize?: boolean | null;
-  appearance?: Theme | null;
   backgroundColor?: string | null;
   blendFilter?: boolean | null;
   bodyHyphens?: BodyHyphens | null;
@@ -87,7 +86,6 @@ export interface IUserProperties {
 
 export class UserProperties extends Properties {
   a11yNormalize: boolean | null;
-  appearance: Theme | null;
   backgroundColor: string | null;
   blendFilter: boolean | null;
   bodyHyphens: BodyHyphens | null;
@@ -123,7 +121,6 @@ export class UserProperties extends Properties {
   constructor(props: IUserProperties) {
     super();
     this.a11yNormalize = props.a11yNormalize ?? null;
-    this.appearance = props.appearance ?? null;
     this.backgroundColor = props.backgroundColor ?? null;
     this.blendFilter = props.blendFilter ?? null;
     this.bodyHyphens = props.bodyHyphens ?? null;
@@ -161,7 +158,6 @@ export class UserProperties extends Properties {
     const cssProperties: { [key: string]: string } = {};
 
     if (this.a11yNormalize) cssProperties["--USER__a11yNormalize"] = this.toFlag("a11y");
-    if (this.appearance) cssProperties["--USER__appearance"] = this.toFlag(this.appearance);
     if (this.backgroundColor) cssProperties["--USER__backgroundColor"] = this.backgroundColor;
     if (this.blendFilter) cssProperties["--USER__blendFilter"] = this.toFlag("blend");
     if (this.bodyHyphens) cssProperties["--USER__bodyHyphens"] = this.bodyHyphens;

--- a/navigator/src/epub/css/ReadiumCSS.ts
+++ b/navigator/src/epub/css/ReadiumCSS.ts
@@ -73,7 +73,6 @@ export class ReadiumCSS {
     
     const updated: IUserProperties = {
       a11yNormalize: settings.textNormalization,
-      appearance: settings.theme,
       backgroundColor: settings.backgroundColor,
       blendFilter: settings.blendFilter,
       bodyHyphens: typeof settings.hyphens !== "boolean" 

--- a/navigator/src/epub/preferences/EpubDefaults.ts
+++ b/navigator/src/epub/preferences/EpubDefaults.ts
@@ -2,8 +2,7 @@ import {
   fontSizeRangeConfig, 
   fontWeightRangeConfig, 
   fontWidthRangeConfig, 
-  TextAlignment, 
-  Theme 
+  TextAlignment
 } from "../../preferences/Types";
 
 import { 
@@ -59,7 +58,6 @@ export interface IEpubDefaults {
   textAlign?: TextAlignment | null,
   textColor?: string | null,
   textNormalization?: boolean | null,
-  theme?: Theme | null,
   visitedColor?: string | null,
   wordSpacing?: number | null
 }
@@ -103,7 +101,6 @@ export class EpubDefaults {
   textAlign: TextAlignment | null;
   textColor: string | null;
   textNormalization: boolean | null;
-  theme: Theme | null;
   visitedColor: string | null;
   wordSpacing: number | null;
 
@@ -150,7 +147,6 @@ export class EpubDefaults {
     this.textAlign = ensureEnumValue<TextAlignment>(defaults.textAlign, TextAlignment) || null;
     this.textColor = ensureString(defaults.textColor) || null;
     this.textNormalization = ensureBoolean(defaults.textNormalization) ?? false;
-    this.theme = ensureEnumValue<Theme>(defaults.theme, Theme) || null;
     this.visitedColor = ensureString(defaults.visitedColor) || null;
     this.wordSpacing = ensureNonNegative(defaults.wordSpacing) || null;
 

--- a/navigator/src/epub/preferences/EpubPreferences.ts
+++ b/navigator/src/epub/preferences/EpubPreferences.ts
@@ -2,7 +2,6 @@ import { ConfigurablePreferences } from "../../preferences/Configurable";
 
 import { 
   TextAlignment, 
-  Theme, 
   fontSizeRangeConfig, 
   fontWeightRangeConfig, 
   fontWidthRangeConfig 
@@ -56,7 +55,6 @@ export interface IEpubPreferences {
   textAlign?: TextAlignment | null,
   textColor?: string | null,
   textNormalization?: boolean | null,
-  theme?: Theme | null,
   visitedColor?: string | null,
   wordSpacing?: number | null
 }
@@ -100,7 +98,6 @@ export class EpubPreferences implements ConfigurablePreferences {
   textAlign?: TextAlignment | null;
   textColor?: string | null;
   textNormalization?: boolean | null;
-  theme?: Theme | null;
   visitedColor?: string | null;
   wordSpacing?: number | null;
 
@@ -140,7 +137,6 @@ export class EpubPreferences implements ConfigurablePreferences {
     this.textAlign = ensureEnumValue<TextAlignment>(preferences.textAlign, TextAlignment);
     this.textColor = ensureString(preferences.textColor);
     this.textNormalization = ensureBoolean(preferences.textNormalization);
-    this.theme = ensureEnumValue<Theme>(preferences.theme, Theme);
     this.visitedColor = ensureString(preferences.visitedColor);
     this.wordSpacing = ensureNonNegative(preferences.wordSpacing);
 

--- a/navigator/src/epub/preferences/EpubPreferencesEditor.ts
+++ b/navigator/src/epub/preferences/EpubPreferencesEditor.ts
@@ -5,13 +5,12 @@ import { EpubSettings } from "./EpubSettings";
 import { BooleanPreference, EnumPreference, Preference, RangePreference } from "../../preferences/Preference";
 import { 
   TextAlignment, 
-  Theme, 
   fontSizeRangeConfig, 
   fontWeightRangeConfig, 
   fontWidthRangeConfig 
 } from "../../preferences/Types";
 
-import defaultColors from "@readium/css/css/vars/day.json";
+import defaultColors from "@readium/css/css/vars/colors.json";
 
 // WIP: will change cos’ of all the missing pieces
 export class EpubPreferencesEditor implements IPreferencesEditor {
@@ -480,18 +479,6 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
       onChange: (newValue: boolean | null | undefined) => {
         this.updatePreference("textNormalization", newValue || null);
       }
-    });
-  }
-
-  get theme(): EnumPreference<Theme> {
-    return new EnumPreference<Theme>({
-      initialValue: this.preferences.theme,
-      effectiveValue: this.settings.theme || null,
-      isEffective: this.layout !== Layout.fixed,
-      onChange: (newValue: Theme | null | undefined) => {
-        this.updatePreference("theme", newValue || null);
-      },
-      supportedValues: Object.values(Theme)
     });
   }
 

--- a/navigator/src/epub/preferences/EpubSettings.ts
+++ b/navigator/src/epub/preferences/EpubSettings.ts
@@ -1,5 +1,5 @@
 import { ConfigurableSettings } from "../../preferences/Configurable";
-import { TextAlignment, Theme } from "../../preferences/Types";
+import { TextAlignment } from "../../preferences/Types";
 import { EpubDefaults } from "./EpubDefaults";
 import { EpubPreferences } from "./EpubPreferences";
 
@@ -44,7 +44,6 @@ export interface IEpubSettings {
   textAlign?: TextAlignment | null,
   textColor?: string | null,
   textNormalization?: boolean | null,
-  theme?: Theme | null,
   visitedColor?: string | null,
   wordSpacing?: number | null
 }
@@ -88,7 +87,6 @@ export class EpubSettings implements ConfigurableSettings {
   textAlign: TextAlignment | null;
   textColor: string | null;
   textNormalization: boolean | null;
-  theme: Theme | null;
   visitedColor: string | null;
   wordSpacing: number | null;
 
@@ -225,7 +223,6 @@ export class EpubSettings implements ConfigurableSettings {
     this.textNormalization = typeof preferences.textNormalization === "boolean" 
       ? preferences.textNormalization 
       : defaults.textNormalization ?? null;
-    this.theme = preferences.theme || defaults.theme || null;
     this.visitedColor = preferences.visitedColor || defaults.visitedColor || null;
     this.wordSpacing = preferences.wordSpacing !== undefined 
       ? preferences.wordSpacing 

--- a/navigator/src/preferences/Types.ts
+++ b/navigator/src/preferences/Types.ts
@@ -5,12 +5,6 @@ export enum TextAlignment {
   justify = "justify"
 };
 
-export enum Theme {
-  sepia = "sepia",
-  night = "night",
-  custom = "custom"
-}
-
 export type RangeConfig = {
   range: [number, number],
   step: number

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0(vite@7.1.3(@types/node@24.3.0)(jiti@2.5.1)(less@4.4.1)(sass@1.91.0)(stylus@0.62.0))
       '@readium/css':
-        specifier: 2.0.0-beta.18
-        version: 2.0.0-beta.18
+        specifier: 2.0.0-beta.19
+        version: 2.0.0-beta.19
       '@readium/navigator-html-injectables':
         specifier: workspace:*
         version: link:../navigator-html-injectables
@@ -1264,8 +1264,8 @@ packages:
   '@readium/css@1.1.0':
     resolution: {integrity: sha512-vcUx/+UYlWXuG6ioZNVBFDlKCuyH+65x9dNJM9jLlA8yT5ReH0k2UR9DN8cwx5/BgJhoQLUsA9s2DPhGaMhX6A==}
 
-  '@readium/css@2.0.0-beta.18':
-    resolution: {integrity: sha512-YtejnbUQFu9JFlyMEJomw5NuItOECPI+/vkAePJ/EzqpRpap5FHFC1QpTCFRKz7m5K2znYDyilcyzV7SFtaO6Q==}
+  '@readium/css@2.0.0-beta.19':
+    resolution: {integrity: sha512-yZrWzxpG3RKgJ7+iVZYCNYZZeGxx9d4ipyppBd/1RGsodHgykjAt8pPT/Ngpob6KiZ1rga5boDFrH8JiNASg2g==}
 
   '@rollup/rollup-android-arm-eabi@4.49.0':
     resolution: {integrity: sha512-rlKIeL854Ed0e09QGYFlmDNbka6I3EQFw7iZuugQjMb11KMpJCLPFL4ZPbMfaEhLADEL1yx0oujGkBQ7+qW3eA==}
@@ -4093,7 +4093,7 @@ snapshots:
 
   '@readium/css@1.1.0': {}
 
-  '@readium/css@2.0.0-beta.18': {}
+  '@readium/css@2.0.0-beta.19': {}
 
   '@rollup/rollup-android-arm-eabi@4.49.0':
     optional: true

--- a/shared/CHANGELOG.MD
+++ b/shared/CHANGELOG.MD
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] – 2025–09–10
+
+### Fixed
+
+- Replaced `instanceof` checks with `Array.isArray` and `typeof === 'object'` to ensure compatibility with the `iframe` context. ([#159](https://github.com/readium/ts-toolkit/issues/159))
+- Removed `postinstall` script generating locale files as it was failing when installed as a dependency ([#160](https://github.com/readium/ts-toolkit/issues/160)).
+
 ## [2.1.0] - 2025-08-29
 
 ### Added

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/shared",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "description": "Shared models to be used across other Readium projects and implementations in Typescript",
   "author": "readium",


### PR DESCRIPTION
**Note: update release date before merging**

This PR updates ReadiumCSS in `Navigator`, which does no longer provide reading modes (sepia, night). These were previously and temporarily handled as `theme` enum and properties in the Preferences API, and converted into ReadiumCSS’ `appearance` flags. 