### PR TITLE
fix: replace instanceof checks with more appropriate ones

### DIFF
--- a/shared/src/opds/Acquisition.ts
+++ b/shared/src/opds/Acquisition.ts
@@ -35,7 +35,7 @@ export class Acquisition {
   }
 
   public static deserializeArray(json: any): Array<Acquisition> | undefined {
-    if (!(json instanceof Array)) return;
+    if (!(Array.isArray(json))) return;
     return json
       .map<Acquisition>(item => Acquisition.deserialize(item) as Acquisition)
       .filter(x => x !== undefined);

--- a/shared/src/publication/BelongsTo.ts
+++ b/shared/src/publication/BelongsTo.ts
@@ -25,7 +25,7 @@ export class BelongsTo {
    * Parses a [BelongsTo] from its RWPM JSON representation.
    */
   public static deserialize(json: any): BelongsTo | undefined {
-    if (!(json && json instanceof Object)) return;
+    if (!(json && typeof json === 'object')) return;
 
     const items = new Map<string, Collection>();
     Object.entries(json).forEach(([key, value]) => {

--- a/shared/src/publication/Contributor.ts
+++ b/shared/src/publication/Contributor.ts
@@ -77,7 +77,7 @@ export class Contributor {
         sortAs: json.sortAs,
         identifier: json.identifier,
         altIdentifiers: json.altIdentifier
-          ? (json.altIdentifier instanceof Array
+          ? (Array.isArray(json.altIdentifier)
             ? new Set<AltIdentifier>(json.altIdentifier
                 .map((x: string | { value: string; scheme?: string }) => AltIdentifier.deserialize(x))
                 .filter((x: AltIdentifier | undefined): x is AltIdentifier => x !== undefined))
@@ -127,7 +127,7 @@ export class Contributors {
    */
   public static deserialize(json: any): Contributors | undefined {
     if (!json) return;
-    const items = json instanceof Array ? json : [json];
+    const items = Array.isArray(json) ? json : [json];
     return new Contributors(
       items
         .map<Contributor>(item => Contributor.deserialize(item) as Contributor)

--- a/shared/src/publication/GuidedNavigation.ts
+++ b/shared/src/publication/GuidedNavigation.ts
@@ -211,7 +211,7 @@ export class GuidedNavigationObject {
      * Parses a [GuidedNavigationObject] array from its RWPM JSON representation.
      */
     public static deserializeArray(json: any): GuidedNavigationObject[] | undefined {
-        if (!(json instanceof Array)) return undefined;
+        if (!(Array.isArray(json))) return undefined;
         return json
             .map<GuidedNavigationObject>((item) => GuidedNavigationObject.deserialize(item) as GuidedNavigationObject)
             .filter((x) => x !== undefined);

--- a/shared/src/publication/Link.ts
+++ b/shared/src/publication/Link.ts
@@ -107,7 +107,7 @@ export class Link {
       type: json.type,
       title: json.title,
       rels: json.rel
-        ? json.rel instanceof Array
+        ? Array.isArray(json.rel)
           ? new Set<string>(json.rel as Array<string>)
           : new Set<string>([json.rel as string])
         : undefined,
@@ -226,7 +226,7 @@ export class Links {
    * Creates a list of [Link] from its RWPM JSON representation.
    */
   public static deserialize(json: any): Links | undefined {
-    if (!(json && json instanceof Array)) return;
+    if (!(json && Array.isArray(json))) return;
     return new Links(
       json
         .map<Link>(item => Link.deserialize(item) as Link)

--- a/shared/src/publication/LocatorCollection.ts
+++ b/shared/src/publication/LocatorCollection.ts
@@ -102,7 +102,7 @@ export class LocatorCollection {
 
     let jsonList = json.locators;
 
-    if (jsonList && jsonList instanceof Array) {
+    if (jsonList && Array.isArray(jsonList)) {
       locators = jsonList
         .map<Locator>(x => Locator.deserialize(x) as Locator)
         .filter(x => x !== undefined);

--- a/shared/src/publication/PublicationCollection.ts
+++ b/shared/src/publication/PublicationCollection.ts
@@ -42,7 +42,7 @@ export class PublicationCollection {
     if (Array.isArray(json)) {
       // Parses an array of links.
       links = Links.deserialize(json);
-    } else if (json instanceof Object) {
+    } else if (typeof json === 'object') {
       // Parses a sub-collection object.
       links = Links.deserialize(json.links);
 

--- a/shared/src/publication/PublicationCollection.ts
+++ b/shared/src/publication/PublicationCollection.ts
@@ -39,7 +39,7 @@ export class PublicationCollection {
     let metadata: Map<string, any> | undefined;
     let subcollections: Map<string, Array<PublicationCollection>> | undefined;
 
-    if (json instanceof Array) {
+    if (Array.isArray(json)) {
       // Parses an array of links.
       links = Links.deserialize(json);
     } else if (json instanceof Object) {
@@ -86,7 +86,7 @@ export class PublicationCollection {
           const list = new Array<PublicationCollection>();
           list.push(collection);
           collections.set(role, list);
-        } else if (subJSON instanceof Array) {
+        } else if (Array.isArray(subJSON)) {
           // Parses a list of collection objects.
           const list = subJSON
             .map<PublicationCollection>(

--- a/shared/src/publication/Subject.ts
+++ b/shared/src/publication/Subject.ts
@@ -98,7 +98,7 @@ export class Subjects {
    */
   public static deserialize(json: any): Subjects | undefined {
     if (!json) return;
-    const items = json instanceof Array ? json : [json];
+    const items = Array.isArray(json) ? json : [json];
     return new Subjects(
       items
         .map<Subject>(item => Subject.deserialize(item) as Subject)
@@ -110,6 +110,6 @@ export class Subjects {
    * Serializes a [Subjects] to its RWPM JSON representation.
    */
   public serialize(): any {
-    return this.items.map(x => x.serialize());
+    return this.items.map((x) => x.serialize());
   }
 }

--- a/shared/src/publication/Subject.ts
+++ b/shared/src/publication/Subject.ts
@@ -110,6 +110,6 @@ export class Subjects {
    * Serializes a [Subjects] to its RWPM JSON representation.
    */
   public serialize(): any {
-    return this.items.map((x) => x.serialize());
+    return this.items.map(x => x.serialize());
   }
 }

--- a/shared/src/publication/opds/Properties.ts
+++ b/shared/src/publication/opds/Properties.ts
@@ -61,7 +61,7 @@ Properties.prototype.getIndirectAcquisitions = function():
   | Array<Acquisition>
   | undefined {
   const json = this.otherProperties['indirectAcquisition'];
-  if (!(json && json instanceof Array)) return;
+  if (!(json && Array.isArray(json))) return;
   return json
     .map<Acquisition>(item => Acquisition.deserialize(item) as Acquisition)
     .filter(x => x !== undefined);

--- a/shared/src/util/JSONParse.ts
+++ b/shared/src/util/JSONParse.ts
@@ -1,6 +1,6 @@
 /** Parses the given array (or undefined it it's not an array) */
 export function arrayfromJSON(json: any): Array<any> | undefined {
-  return json && json instanceof Array ? json : undefined;
+  return json && Array.isArray(json) ? json : undefined;
 }
 
 export function arrayfromJSONorString(json: any): Array<any> | undefined {


### PR DESCRIPTION
This PR replaces ~10 `instanceof Array` checks with `Array.isArray`, and two `instanceof Object` checks with `typeof x === 'object'`)

This is because I ran into the following issue when trying to test the `decorations`.

Say i have a button like so (assuming i have access to the `navigator` in some way)

```tsx
 <Button
              onClick={async () => {

                const positionLocator = new Locator({
                  href: "some href",
                  type: "application/xhtml+xml",
                  locations: new LocatorLocations({
					// just an example
                    fragments: [`c09-sentence0`],
                  }),
                })

                navigator.send("decorate", {
                  group: "highlight",
                  action: "add",
                  decoration: {
                    id: "highlight",
                    locator: positionLocator,
                    style: {
                      tint: "red",
                      width: Width.Wrap,
                      layout: Layout.Bounds,
                    },
                  },
                })
           }}
>
              Manual higlhight
 </Button>
```

When `arrayFromJsonOrString` is called here on `positionLocator.locations.fragments`

https://github.com/readium/ts-toolkit/blob/94e518c3a43e624d82063ac4e864149aba787aad/shared/src/publication/Locator.ts#L70

it will always return `undefined`, because the `Array` referenced in `instanceof Array` is `navigator._cframes[number].window.Array`, not window `Array`

You can see this by doing the following in the console a page with an `iframe` , like here: https://playground.readium.org/read/moby-dick

```js
arr = ['a', 'b']; arr instanceof (document.querySelector('iframe').contentWindow).Array  // false
```

vs doing

```js
arr = ['a', 'b']; (document.querySelector('iframe').contentWindow).Array.isArray(arr) // true
```


The same goes for `instanceof Object`.

On `instanceof Object`, you might worry that `typeof x === 'object'` does not cover the same ground. In the cases where I replaced this, I'm quite confident it does however.


## Caveats

It might be possible that this is somehow intended, but I don't think so, given the subtle nature of the bug (took me a couple hours to figure out).

