### PR TITLE
fix: remove postinstall hook for @readium/shared

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -48,7 +48,6 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "update-accessibility-locales": "node update-accessibility-locales.mjs",
-    "postinstall": "npm run update-accessibility-locales",
     "test": "jest",
     "size": "size-limit"
   },


### PR DESCRIPTION
When running

```sh
npm i @readium/shared@2.1.0
```

the install fails due to a missing file necessary for the `postinstall` hook, see full error below.

This is because `update-accessibility-locales.mjs` is not included in the `npm` bundle.

Although this issue could also be solved by including it, it doesn't appear that the resulting files are necessary for the consumer, only for the developer. Therefore I suggest removing it, and finding another way (a commit/push hook eg) to make the `update-accessibility-locales` script work.

This may have gone undetected bc `pnpm` does not run `postinstall` scripts by default, but `yarn` and `npm` do.



```log
npm error code 1
npm error path ~/Projects/test-readium-shared-install/node_modules/@readium/shared
npm error command failed
npm error command sh -c npm run update-accessibility-locales
npm error > @readium/shared@2.1.0 update-accessibility-locales
npm error > node update-accessibility-locales.mjs
npm error npm warn Unknown env config "python". This will stop working in the next major version of npm.
npm error npm warn Unknown user config "python". This will stop working in the next major version of npm.
npm error node:internal/modules/cjs/loader:1372
npm error   throw err;
npm error   ^
npm error
npm error Error: Cannot find module '~/Projects/test-readium-shared-install/node_modules/@readium/shared/update-accessibility-locales.mjs'
npm error     at Module._resolveFilename (node:internal/modules/cjs/loader:1369:15)
npm error     at defaultResolveImpl (node:internal/modules/cjs/loader:1025:19)
npm error     at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1030:22)
npm error     at Module._load (node:internal/modules/cjs/loader:1179:37)
npm error     at TracingChannel.traceSync (node:diagnostics_channel:322:14)
npm error     at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
npm error     at Module.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:152:5)
npm error     at node:internal/main/run_main_module:33:47 {
npm error   code: 'MODULE_NOT_FOUND',
npm error   requireStack: []
npm error }
npm error
npm error Node.js v24.4.1
npm error A complete log of this run can be found in: ~/.npm/_logs/2025-09-09T13_37_12_939Z-debug-0.log
```


