### PR TITLE
Web pub preferences

### DIFF
--- a/navigator-html-injectables/CHANGELOG.MD
+++ b/navigator-html-injectables/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2025-10-28
+
+### Added
+
+- Implemented Preferences API for WebPublication Navigator
+
 ## [2.2.0] - 2025-10-17
 
 ### Added

--- a/navigator-html-injectables/package.json
+++ b/navigator-html-injectables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator-html-injectables",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "description": "An embeddable solution for connecting frames of HTML publications with a Readium Navigator",
   "author": "readium",

--- a/navigator-html-injectables/src/modules/setup/WebPubSetup.ts
+++ b/navigator-html-injectables/src/modules/setup/WebPubSetup.ts
@@ -1,6 +1,7 @@
 import { Comms } from "../../comms/comms";
 import { ReadiumWindow } from "../../helpers/dom";
 import { Module } from "../Module";
+import { getProperties, removeProperty, setProperty, updateProperties } from "../../helpers/css";
 
 export class WebPubSetup extends Module {
     static readonly moduleName = "webpub_setup";
@@ -26,7 +27,25 @@ export class WebPubSetup extends Module {
             false
         );
 
-        // Handle activate message to prevent timeout warnings
+        // Handle property updates (like ReflowableSetup)
+        comms.register("get_properties", WebPubSetup.moduleName, (_, ack) => {
+            getProperties(wnd);
+            ack(true);
+        });
+        comms.register("update_properties", WebPubSetup.moduleName, (data, ack) => {
+            updateProperties(wnd, data as { [key: string]: string });
+            ack(true);
+        });
+        comms.register("set_property", WebPubSetup.moduleName, (data, ack) => {
+            const kv = data as string[];
+            setProperty(wnd, kv[0], kv[1]);
+            ack(true);
+        });
+        comms.register("remove_property", WebPubSetup.moduleName, (data, ack) => {
+            removeProperty(wnd, data as string);
+            ack(true);
+        });
+
         comms.register("activate", WebPubSetup.moduleName, (_, ack) => {
             ack(true);
         });
@@ -36,6 +55,7 @@ export class WebPubSetup extends Module {
     }
 
     unmount(wnd: ReadiumWindow, comms: Comms): boolean {
+        comms.unregisterAll(WebPubSetup.moduleName);
         wnd.removeEventListener("error", this.wndOnErr);
 
         comms.log("WebPubSetup Unmounted");

--- a/navigator/CHANGELOG.MD
+++ b/navigator/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2025-10-28
+
+### Added
+
+- Implemented Preferences API for WebPublication Navigator
+
 ## [2.2.0] - 2025-10-17
 
 ### Added
@@ -15,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated shared models ([#159](https://github.com/readium/ts-toolkit/issues/159)) as some checks were not working properly in the `iframe` context..
+- Updated shared models ([#159](https://github.com/readium/ts-toolkit/issues/159)) as some checks were not working properly in the `iframe` context.
 
 ### Removed
 

--- a/navigator/package.json
+++ b/navigator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "description": "Next generation SDK for publications in Web Apps",
   "author": "readium",

--- a/navigator/src/css/Properties.ts
+++ b/navigator/src/css/Properties.ts
@@ -1,0 +1,47 @@
+export type BodyHyphens = "auto" | "none";
+export type BoxSizing = "content-box" | "border-box";
+export type FontOpticalSizing = "auto" | "none";
+export type FontWidth = "ultra-condensed" | "extra-condensed" | "condensed" | "semi-condensed" | "normal" | "semi-expanded" | "expanded" | "extra-expanded" | "ultra-expanded" | number;
+export type Ligatures = "common-ligatures" | "none";
+export type TypeScale = 1 | 1.067 | 1.125 | 1.2 | 1.25 | 1.333 | 1.414 | 1.5 | 1.618;
+export type View = "paged" | "scroll";
+
+export abstract class Properties {
+  constructor() {}
+
+  protected toFlag(name: string) {
+    return `readium-${ name }-on`;
+  }
+
+  protected toUnitless(value: number) {
+    return value.toString();
+  }
+
+  protected toPercentage(value: number, ratio: boolean = false) {
+    if (ratio || value > 0 && value <= 1) {
+      return `${ Math.round(value * 100) }%`;
+    } else {
+      return `${ value }%`;
+    }
+  }
+
+  protected toVw(value: number) {
+    const percentage = Math.round(value * 100);
+    return `${ Math.min(percentage, 100) }vw`;
+  }
+
+  protected toVh(value: number) {
+    const percentage = Math.round(value * 100);
+    return `${ Math.min(percentage, 100) }vh`;
+  }
+
+  protected toPx(value: number) {
+    return `${ value }px`;
+  }
+
+  protected toRem(value: number) {
+    return `${ value }rem`;
+  }
+
+  abstract toCSSProperties(): { [key: string]: string };
+}

--- a/navigator/src/css/index.ts
+++ b/navigator/src/css/index.ts
@@ -1,0 +1,1 @@
+export * from "./Properties";

--- a/navigator/src/epub/css/Properties.ts
+++ b/navigator/src/epub/css/Properties.ts
@@ -1,52 +1,14 @@
 import { TextAlignment } from "../../preferences/Types";
-
-export type BodyHyphens = "auto" | "none";
-export type BoxSizing = "content-box" | "border-box";
-export type FontOpticalSizing = "auto" | "none";
-export type FontWidth = "ultra-condensed" | "extra-condensed" | "condensed" | "semi-condensed" | "normal" | "semi-expanded" | "expanded" | "extra-expanded" | "ultra-expanded" | number;
-export type Ligatures = "common-ligatures" | "none";
-export type TypeScale = 1 | 1.067 | 1.125 | 1.2 | 1.25 | 1.333 | 1.414 | 1.5 | 1.618;
-export type View = "paged" | "scroll";
-
-abstract class Properties {
-  constructor() {}
-
-  protected toFlag(name: string) {
-    return `readium-${ name }-on`;
-  }
-
-  protected toUnitless(value: number) {
-    return value.toString();
-  }
-
-  protected toPercentage(value: number, ratio: boolean = false) {
-    if (ratio || value > 0 && value <= 1) {
-      return `${ Math.round(value * 100) }%`;
-    } else {
-      return `${ value }%`;
-    }
-  }
-
-  protected toVw(value: number) {
-    const percentage = Math.round(value * 100);
-    return `${ Math.min(percentage, 100) }vw`;
-  }
-
-  protected toVh(value: number) {
-    const percentage = Math.round(value * 100);
-    return `${ Math.min(percentage, 100) }vh`;
-  }
-
-  protected toPx(value: number) {
-    return `${ value }px`;
-  }
-
-  protected toRem(value: number) {
-    return `${ value }rem`;
-  }
-
-  abstract toCSSProperties(): { [key: string]: string };
-}
+import { 
+  BodyHyphens, 
+  BoxSizing, 
+  FontOpticalSizing, 
+  FontWidth, 
+  Ligatures, 
+  Properties, 
+  TypeScale, 
+  View 
+} from "../../css/Properties";
 
 export interface IUserProperties {
   advancedSettings?: boolean | null;

--- a/navigator/src/epub/preferences/EpubDefaults.ts
+++ b/navigator/src/epub/preferences/EpubDefaults.ts
@@ -15,7 +15,7 @@ import {
   ensureString, 
   ensureValueInRange, 
   withFallback
-} from "./guards";
+} from "../../preferences/guards";
 
 import { sMLWithRequest } from "../../helpers";
 

--- a/navigator/src/epub/preferences/EpubPreferences.ts
+++ b/navigator/src/epub/preferences/EpubPreferences.ts
@@ -14,7 +14,7 @@ import {
   ensureNonNegative, 
   ensureString, 
   ensureValueInRange 
-} from "./guards";
+} from "../../preferences/guards";
 
 export interface IEpubPreferences {
   backgroundColor?: string | null,

--- a/navigator/src/epub/preferences/EpubPreferencesEditor.ts
+++ b/navigator/src/epub/preferences/EpubPreferencesEditor.ts
@@ -5,9 +5,16 @@ import { EpubSettings } from "./EpubSettings";
 import { BooleanPreference, EnumPreference, Preference, RangePreference } from "../../preferences/Preference";
 import { 
   TextAlignment, 
+  filterRangeConfig, 
   fontSizeRangeConfig, 
   fontWeightRangeConfig, 
-  fontWidthRangeConfig 
+  fontWidthRangeConfig, 
+  letterSpacingRangeConfig,
+  lineHeightRangeConfig,
+  lineLengthRangeConfig,
+  paragraphIndentRangeConfig,
+  paragraphSpacingRangeConfig,
+  wordSpacingRangeConfig
 } from "../../preferences/Types";
 
 import defaultColors from "@readium/css/css/vars/colors.json";
@@ -85,8 +92,8 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
       onChange: (newValue: number | boolean | null | undefined) => {
         this.updatePreference("darkenFilter", newValue || null);
       },
-      supportedRange: [0, 100],
-      step: 1
+      supportedRange: filterRangeConfig.range,
+      step: filterRangeConfig.step
     });
   }
 
@@ -192,8 +199,8 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
       onChange: (newValue: number | boolean | null | undefined) => {
         this.updatePreference("invertFilter", newValue || null);
       },
-      supportedRange: [0, 100],
-      step: 1
+      supportedRange: filterRangeConfig.range,
+      step: filterRangeConfig.step
     });
   }
 
@@ -205,8 +212,8 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
       onChange: (newValue: number | boolean | null | undefined) => {
         this.updatePreference("invertGaijiFilter", newValue || null);
       },
-      supportedRange: [0, 100],
-      step: 1
+      supportedRange: filterRangeConfig.range,
+      step: filterRangeConfig.step
     });
   }
 
@@ -240,8 +247,8 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
       onChange: (newValue: number | null | undefined) => {
         this.updatePreference("letterSpacing", newValue || null);
       },
-      supportedRange: [0, 1],
-      step: .125
+      supportedRange: letterSpacingRangeConfig.range,
+      step: letterSpacingRangeConfig.step
     });
   }
 
@@ -266,8 +273,8 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
       onChange: (newValue: number | null | undefined) => {
         this.updatePreference("lineHeight", newValue || null);
       },
-      supportedRange: [1, 2],
-      step: .1
+      supportedRange: lineHeightRangeConfig.range,
+      step: lineHeightRangeConfig.step
     });
   }
 
@@ -290,8 +297,8 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
       onChange: (newValue: number | null | undefined) => {
         this.updatePreference("maximalLineLength", newValue);
       },
-      supportedRange: [20, 100],
-      step: 1
+      supportedRange: lineLengthRangeConfig.range,
+      step: lineLengthRangeConfig.step
     });
   }
 
@@ -303,8 +310,8 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
       onChange: (newValue: number | null | undefined) => {
         this.updatePreference("minimalLineLength", newValue);
       },
-      supportedRange: [20, 100],
-      step: 1
+      supportedRange: lineLengthRangeConfig.range,
+      step: lineLengthRangeConfig.step
     });
   }
 
@@ -327,8 +334,8 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
       onChange: (newValue: number | null | undefined) => {
         this.updatePreference("optimalLineLength", newValue as number);
       },
-      supportedRange: [20, 100],
-      step: 1
+      supportedRange: lineLengthRangeConfig.range,
+      step: lineLengthRangeConfig.step
     });
   }
 
@@ -351,8 +358,8 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
       onChange: (newValue: number | null | undefined) => {
         this.updatePreference("paragraphIndent", newValue || null);
       },
-      supportedRange: [0, 3],
-      step: .25
+      supportedRange: paragraphIndentRangeConfig.range,
+      step: paragraphIndentRangeConfig.step
     });
   }
 
@@ -364,8 +371,8 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
       onChange: (newValue: number | null | undefined) => {
         this.updatePreference("paragraphSpacing", newValue || null);
       },
-      supportedRange: [0, 3],
-      step: .25
+      supportedRange: paragraphSpacingRangeConfig.range,
+      step: paragraphSpacingRangeConfig.step
     });
   }
 
@@ -501,8 +508,8 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
       onChange: (newValue: number | null | undefined) => {
         this.updatePreference("wordSpacing", newValue || null);
       },
-      supportedRange: [0, 2],
-      step: 0.125
+      supportedRange: wordSpacingRangeConfig.range,
+      step: wordSpacingRangeConfig.step
     });
   }
 }

--- a/navigator/src/index.ts
+++ b/navigator/src/index.ts
@@ -4,3 +4,4 @@ export * from './epub';
 export * from './audio';
 export * from './helpers';
 export * from './preferences';
+export * from './css';

--- a/navigator/src/preferences/Types.ts
+++ b/navigator/src/preferences/Types.ts
@@ -10,6 +10,11 @@ export type RangeConfig = {
   step: number
 }
 
+export const filterRangeConfig: RangeConfig = {
+  range: [0, 100],
+  step: 1
+}
+
 export const fontSizeRangeConfig: RangeConfig = {
   range: [0.7, 4],
   step: 0.05
@@ -23,6 +28,36 @@ export const fontWeightRangeConfig: RangeConfig = {
 export const fontWidthRangeConfig: RangeConfig = {
   range: [50, 250],
   step: 10
+}
+
+export const letterSpacingRangeConfig: RangeConfig = {
+  range: [0, 1],
+  step: .125
+}
+
+export const lineHeightRangeConfig: RangeConfig = {
+  range: [1, 2],
+  step: .1
+}
+
+export const lineLengthRangeConfig: RangeConfig = {
+  range: [20, 100],
+  step: 1
+}
+
+export const paragraphIndentRangeConfig: RangeConfig = {
+  range: [0, 3],
+  step: .25
+}
+
+export const paragraphSpacingRangeConfig: RangeConfig = {
+  range: [0, 3],
+  step: .25
+}
+
+export const wordSpacingRangeConfig: RangeConfig = {
+  range: [0, 2],
+  step: .125
 }
 
 export const zoomRangeConfig: RangeConfig = {

--- a/navigator/src/preferences/Types.ts
+++ b/navigator/src/preferences/Types.ts
@@ -24,3 +24,8 @@ export const fontWidthRangeConfig: RangeConfig = {
   range: [50, 250],
   step: 10
 }
+
+export const zoomRangeConfig: RangeConfig = {
+  range: [0.7, 4],
+  step: 0.05
+}

--- a/navigator/src/preferences/guards.ts
+++ b/navigator/src/preferences/guards.ts
@@ -29,13 +29,12 @@ export function ensureString(value: string | null | undefined): string | null | 
 }
 
 export function ensureBoolean(value: boolean | null | undefined): boolean | null | undefined {
-  return typeof value === "boolean" 
-    ? value 
-    : value === undefined || value === null 
-      ? value 
+  return typeof value === "boolean"
+    ? value
+    : value === undefined || value === null
+      ? value
       : undefined;
 }
-
 
 export function ensureEnumValue<T extends string>(value: T | null | undefined, enumType: Record<T, string>): T | null | undefined {
   if (value === undefined) {

--- a/navigator/src/preferences/index.ts
+++ b/navigator/src/preferences/index.ts
@@ -2,3 +2,4 @@ export * from "./Configurable";
 export * from "./Preference";
 export * from "./PreferencesEditor";
 export * from "./Types";
+export * from "./guards";

--- a/navigator/src/webpub/WebPubBlobBuilder.ts
+++ b/navigator/src/webpub/WebPubBlobBuilder.ts
@@ -1,4 +1,5 @@
 import { Link, Publication } from "@readium/shared";
+import { webPubStylesheet } from "./css/WebPubStylesheet";
 
 // Utilities (matching FrameBlobBuilder pattern)
 const blobify = (source: string, type: string) => URL.createObjectURL(new Blob([source], { type }));
@@ -7,6 +8,12 @@ const scriptify = (doc: Document, source: string) => {
     const s = doc.createElement("script");
     s.dataset.readium = "true";
     s.src = source.startsWith("blob:") ? source : blobify(source, "text/javascript");
+    return s;
+}
+const styleify = (doc: Document, source: string) => {
+    const s = doc.createElement("style");
+    s.dataset.readium = "true";
+    s.textContent = source;
     return s;
 }
 
@@ -46,11 +53,13 @@ export class WebPubBlobBuilder {
     private readonly item: Link;
     private readonly burl: string;
     private readonly pub: Publication;
+    private readonly cssProperties?: { [key: string]: string };
 
-    constructor(pub: Publication, baseURL: string, item: Link) {
+    constructor(pub: Publication, baseURL: string, item: Link, cssProperties?: { [key: string]: string }) {
         this.pub = pub;
         this.item = item;
         this.burl = item.toURL(baseURL) || "";
+        this.cssProperties = cssProperties;
     }
 
     public async build(): Promise<string> {
@@ -74,7 +83,7 @@ export class WebPubBlobBuilder {
             const details = perror.querySelector("div");
             throw new Error(`Failed parsing item ${this.item.href}: ${details?.textContent || perror.textContent}`);
         }
-        return this.finalizeDOM(doc, this.burl, this.item.mediaType, txt);
+        return this.finalizeDOM(doc, this.burl, this.item.mediaType, txt, this.cssProperties);
     }
 
     private hasExecutable(doc: Document): boolean {
@@ -84,8 +93,22 @@ export class WebPubBlobBuilder {
         );
     }
 
-    private finalizeDOM(doc: Document, base: string | undefined, mediaType: any, txt?: string): string {
+    private setProperties(cssProperties: { [key: string]: string }, doc: Document) {
+        for (const key in cssProperties) {
+            const value = cssProperties[key];
+            if (value) doc.documentElement.style.setProperty(key, value);
+        }
+    }
+
+    private finalizeDOM(doc: Document, base: string | undefined, mediaType: any, txt?: string, cssProperties?: { [key: string]: string }): string {
         if(!doc) return "";
+
+        // Add WebPubCSS stylesheet at end of head (like EPUB ReadiumCSS-after)
+        const webPubStyle = styleify(doc, webPubStylesheet);
+        doc.head.appendChild(webPubStyle);
+        if (cssProperties) {
+            this.setProperties(cssProperties, doc);
+        }
 
         doc.body.querySelectorAll("img").forEach((img) => {
             img.setAttribute("fetchpriority", "high");
@@ -97,7 +120,6 @@ export class WebPubBlobBuilder {
             b.dataset.readium = "true";
             doc.head.firstChild!.before(b);
         }
-
 
         const hasExecutable = this.hasExecutable(doc);
         if(hasExecutable) doc.head.firstChild!.before(rBefore(doc));

--- a/navigator/src/webpub/WebPubFrameManager.ts
+++ b/navigator/src/webpub/WebPubFrameManager.ts
@@ -8,6 +8,7 @@ export class WebPubFrameManager {
     private loader: Loader | undefined;
     public readonly source: string;
     private comms: FrameComms | undefined;
+    private hidden: boolean = true;
     private destroyed: boolean = false;
 
     private currModules: ModuleName[] = [];
@@ -69,6 +70,7 @@ export class WebPubFrameManager {
         this.frame.style.setProperty("aria-hidden", "true");
         this.frame.style.opacity = "0";
         this.frame.style.pointerEvents = "none";
+        this.hidden = true;
 
         if(this.frame.parentElement) {
             if(this.comms === undefined || !this.comms.ready) return;
@@ -97,6 +99,7 @@ export class WebPubFrameManager {
                         this.frame.style.removeProperty("aria-hidden");
                         this.frame.style.removeProperty("opacity");
                         this.frame.style.removeProperty("pointer-events");
+                        this.hidden = false;
 
                         if (sML.UA.WebKit) {
                             this.comms?.send("force_webkit_recalc", undefined);
@@ -113,6 +116,19 @@ export class WebPubFrameManager {
                 });
             });
         });
+    }
+
+    setCSSProperties(properties: { [key: string]: string }) {
+        if(this.destroyed || !this.frame.contentWindow) return;
+
+        // We need to resume and halt postMessage to update the properties
+        // if the frame is hidden since it's been halted in hide()
+        if (this.hidden) {
+            if (this.comms) this.comms?.resume();
+            else this.comms = new FrameComms(this.frame.contentWindow!, this.source);
+        }
+        this.comms?.send("update_properties", properties);
+        if (this.hidden) this.comms?.halt();
     }
 
     get iframe() {

--- a/navigator/src/webpub/WebPubFramePoolManager.ts
+++ b/navigator/src/webpub/WebPubFramePoolManager.ts
@@ -6,13 +6,16 @@ import { WebPubFrameManager } from "./WebPubFrameManager";
 export class WebPubFramePoolManager {
     private readonly container: HTMLElement;
     private _currentFrame: WebPubFrameManager | undefined;
+    private currentCssProperties: { [key: string]: string } | undefined;
     private readonly pool: Map<string, WebPubFrameManager> = new Map();
     private readonly blobs: Map<string, string> = new Map();
     private readonly inprogress: Map<string, Promise<void>> = new Map();
+    private pendingUpdates: Map<string, { inPool: boolean }> = new Map();
     private currentBaseURL: string | undefined;
 
-    constructor(container: HTMLElement) {
+    constructor(container: HTMLElement, cssProperties?: { [key: string]: string }) {
         this.container = container;
+        this.currentCssProperties = cssProperties;
     }
 
     async destroy() {
@@ -90,11 +93,22 @@ export class WebPubFramePoolManager {
             this.currentBaseURL = pub.baseURL;
 
             const creator = async (href: string) => {
+                // Check if blob needs to be recreated due to CSS property changes
+                if(this.pendingUpdates.has(href) && this.pendingUpdates.get(href)?.inPool === false) {
+                    const url = this.blobs.get(href);
+                    if(url) {
+                        URL.revokeObjectURL(url);
+                        this.blobs.delete(href);
+                        this.pendingUpdates.delete(href);
+                    }
+                }
+
                 if(this.pool.has(href)) {
                     const fm = this.pool.get(href)!;
                     if(!this.blobs.has(href)) {
                         await fm.destroy();
                         this.pool.delete(href);
+                        this.pendingUpdates.delete(href);
                     } else {
                         await fm.load(modules);
                         return;
@@ -103,7 +117,7 @@ export class WebPubFramePoolManager {
                 const itm = pub.readingOrder.findWithHref(href);
                 if(!itm) return;
                 if(!this.blobs.has(href)) {
-                    const blobBuilder = new WebPubBlobBuilder(pub, this.currentBaseURL || "", itm);
+                    const blobBuilder = new WebPubBlobBuilder(pub, this.currentBaseURL || "", itm, this.currentCssProperties);
                     const blobURL = await blobBuilder.build();
                     this.blobs.set(href, blobURL);
                 }
@@ -139,6 +153,39 @@ export class WebPubFramePoolManager {
         this.inprogress.delete(newHref);
     }
 
+    setCSSProperties(properties: { [key: string]: string }) {
+        const deepCompare = (obj1: { [key: string]: string }, obj2: { [key: string]: string }) => {
+            const keys1 = Object.keys(obj1);
+            const keys2 = Object.keys(obj2);
+
+            if (keys1.length !== keys2.length) {
+              return false;
+            }
+
+            for (const key of keys1) {
+              if (obj1[key] !== obj2[key]) {
+                return false;
+              }
+            }
+
+            return true;
+        };
+
+        // If CSSProperties have changed, we update the currentCssProperties,
+        // and set the CSS Properties to all frames already in the pool
+        // We also need to invalidate the blobs and recreate them with the new properties.
+        // We do that in update, by updating them when needed (they are added into the pool)
+        // so that we do not invalidate and recreate blobs over and over again.
+        if(!deepCompare(this.currentCssProperties || {}, properties)) {
+            this.currentCssProperties = properties;
+            this.pool.forEach((frame) => {
+                frame.setCSSProperties(properties);
+            });
+            for (const href of this.blobs.keys()) {
+                this.pendingUpdates.set(href, { inPool: this.pool.has(href) });
+            }
+        }
+    }
     get currentFrames(): (WebPubFrameManager | undefined)[] {
         return [this._currentFrame];
     }

--- a/navigator/src/webpub/WebPubNavigator.ts
+++ b/navigator/src/webpub/WebPubNavigator.ts
@@ -104,7 +104,7 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
 
     public get preferencesEditor(): IPreferencesEditor {
         if (this._preferencesEditor === null) {
-            this._preferencesEditor = new WebPubPreferencesEditor(this._preferences, this.settings, this.pub.metadata);
+            this._preferencesEditor = new WebPubPreferencesEditor(this._preferences, this.settings);
         }
         return this._preferencesEditor;
     }
@@ -118,7 +118,7 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
         this._settings = new WebPubSettings(this._preferences, this._defaults);
 
         if (this._preferencesEditor !== null) {
-            this._preferencesEditor = new WebPubPreferencesEditor(this._preferences, this.settings, this.pub.metadata);
+            this._preferencesEditor = new WebPubPreferencesEditor(this._preferences, this.settings);
         }
 
         // Apply preferences using CSS system like EPUB
@@ -133,7 +133,7 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
 
     private compileCSSProperties(css: WebPubCSS) {
         const properties: { [key: string]: string } = {};
-        
+
         for (const [key, value] of Object.entries(css.userProperties.toCSSProperties())) {
             properties[key] = value;
         }

--- a/navigator/src/webpub/WebPubNavigator.ts
+++ b/navigator/src/webpub/WebPubNavigator.ts
@@ -104,7 +104,7 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
 
     public get preferencesEditor(): IPreferencesEditor {
         if (this._preferencesEditor === null) {
-            this._preferencesEditor = new WebPubPreferencesEditor(this._preferences, this.settings);
+            this._preferencesEditor = new WebPubPreferencesEditor(this._preferences, this.settings, this.pub.metadata);
         }
         return this._preferencesEditor;
     }
@@ -118,7 +118,7 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
         this._settings = new WebPubSettings(this._preferences, this._defaults);
 
         if (this._preferencesEditor !== null) {
-            this._preferencesEditor = new WebPubPreferencesEditor(this._preferences, this.settings);
+            this._preferencesEditor = new WebPubPreferencesEditor(this._preferences, this.settings, this.pub.metadata);
         }
 
         // Apply preferences using CSS system like EPUB

--- a/navigator/src/webpub/WebPubNavigator.ts
+++ b/navigator/src/webpub/WebPubNavigator.ts
@@ -6,7 +6,7 @@ import { BasicTextSelection, CommsEventKey, FrameClickEvent, ModuleLibrary, Modu
 import * as path from "path-browserify";
 import { ManagerEventKey } from "../epub/EpubNavigator";
 import { WebPubCSS } from "./css/WebPubCSS";
-import { UserProperties } from "./css/Properties";
+import { WebUserProperties } from "./css/Properties";
 import { IWebPubPreferences, WebPubPreferences } from "./preferences/WebPubPreferences";
 import { IWebPubDefaults, WebPubDefaults } from "./preferences/WebPubDefaults";
 import { WebPubSettings } from "./preferences/WebPubSettings";
@@ -73,7 +73,7 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
         this._defaults = new WebPubDefaults(configuration.defaults);
         this._settings = new WebPubSettings(this._preferences, this._defaults);
         this._css = new WebPubCSS({
-            userProperties: new UserProperties({ zoom: this._settings.zoom })
+            userProperties: new WebUserProperties({ zoom: this._settings.zoom })
         });
 
         // Initialize current location

--- a/navigator/src/webpub/WebPubNavigator.ts
+++ b/navigator/src/webpub/WebPubNavigator.ts
@@ -1,9 +1,22 @@
 import { Link, Locator, Publication, ReadingProgression, LocatorLocations } from "@readium/shared";
 import { VisualNavigator, VisualNavigatorViewport, ProgressionRange } from "../Navigator";
+import { Configurable } from "../preferences/Configurable";
 import { WebPubFramePoolManager } from "./WebPubFramePoolManager";
 import { BasicTextSelection, CommsEventKey, FrameClickEvent, ModuleLibrary, ModuleName, WebPubModules } from "@readium/navigator-html-injectables";
 import * as path from "path-browserify";
 import { ManagerEventKey } from "../epub/EpubNavigator";
+import { WebPubCSS } from "./css/WebPubCSS";
+import { UserProperties } from "./css/Properties";
+import { IWebPubPreferences, WebPubPreferences } from "./preferences/WebPubPreferences";
+import { IWebPubDefaults, WebPubDefaults } from "./preferences/WebPubDefaults";
+import { WebPubSettings } from "./preferences/WebPubSettings";
+import { IPreferencesEditor } from "../preferences/PreferencesEditor";
+import { WebPubPreferencesEditor } from "./preferences/WebPubPreferencesEditor";
+
+export interface WebPubNavigatorConfiguration {
+    preferences: IWebPubPreferences;
+    defaults: IWebPubDefaults;
+}
 
 export interface WebPubNavigatorListeners {
     frameLoaded: (wnd: Window) => void;
@@ -27,27 +40,43 @@ const defaultListeners = (listeners: WebPubNavigatorListeners): WebPubNavigatorL
     customEvent: listeners.customEvent || (() => {}),
     handleLocator: listeners.handleLocator || (() => false),
     textSelected: listeners.textSelected || (() => {})
-});
+})
 
-class WebPubNavigator extends VisualNavigator {
+export class WebPubNavigator extends VisualNavigator implements Configurable<WebPubSettings, WebPubPreferences> {
     private readonly pub: Publication;
     private readonly container: HTMLElement;
     private readonly listeners: WebPubNavigatorListeners;
-    private framePool: WebPubFramePoolManager;
+    private framePool!: WebPubFramePoolManager;
     private currentIndex: number = 0;
     private currentLocation: Locator;
+
+    private _preferences: WebPubPreferences;
+    private _defaults: WebPubDefaults;
+    private _settings: WebPubSettings;
+    private _css: WebPubCSS;
+    private _preferencesEditor: WebPubPreferencesEditor | null = null;
+    
     private webViewport: VisualNavigatorViewport = {
         readingOrder: [],
         progressions: new Map(),
         positions: null
     };
 
-    constructor(container: HTMLElement, pub: Publication, listeners: WebPubNavigatorListeners, initialPosition: Locator | undefined = undefined) {
+    constructor(container: HTMLElement, pub: Publication, listeners: WebPubNavigatorListeners, initialPosition: Locator | undefined = undefined, configuration: WebPubNavigatorConfiguration = { preferences: {}, defaults: {} }) {
         super();
         this.pub = pub;
         this.container = container;
         this.listeners = defaultListeners(listeners);
-        this.framePool = new WebPubFramePoolManager(this.container);
+
+        // Initialize preference system
+        this._preferences = new WebPubPreferences(configuration.preferences);
+        this._defaults = new WebPubDefaults(configuration.defaults);
+        this._settings = new WebPubSettings(this._preferences, this._defaults);
+        this._css = new WebPubCSS({
+            userProperties: new UserProperties({ zoom: this._settings.zoom })
+        });
+
+        // Initialize current location
         if (initialPosition && typeof initialPosition.copyWithLocations === 'function') {
             this.currentLocation = initialPosition;
             // Update currentIndex to match the initial position
@@ -60,13 +89,61 @@ class WebPubNavigator extends VisualNavigator {
         }
     }
 
-    async load(): Promise<void> {
-        await this.framePool.update(this.pub, this.currentLocation, this.determineModules());
+    public async load() {
+        await this.updateCSS(false);
+        const cssProperties = this.compileCSSProperties(this._css);
+        this.framePool = new WebPubFramePoolManager(this.container, cssProperties);
 
-        this.attachListener();
+        await this.apply();
+    }
 
-        // Notify listeners of initial position
-        this.listeners.positionChanged(this.currentLocation);
+    // Configurable interface implementation
+    public get settings(): Readonly<WebPubSettings> {
+        return Object.freeze({ ...this._settings });
+    }
+
+    public get preferencesEditor(): IPreferencesEditor {
+        if (this._preferencesEditor === null) {
+            this._preferencesEditor = new WebPubPreferencesEditor(this._preferences, this.settings, this.pub.metadata);
+        }
+        return this._preferencesEditor;
+    }
+
+    public async submitPreferences(preferences: WebPubPreferences) {
+        this._preferences = this._preferences.merging(preferences) as WebPubPreferences;
+        await this.applyPreferences();
+    }
+
+    private async applyPreferences() {
+        this._settings = new WebPubSettings(this._preferences, this._defaults);
+
+        if (this._preferencesEditor !== null) {
+            this._preferencesEditor = new WebPubPreferencesEditor(this._preferences, this.settings, this.pub.metadata);
+        }
+
+        // Apply preferences using CSS system like EPUB
+        await this.updateCSS(true);
+    }
+
+    private async updateCSS(commit: boolean) {
+        this._css.update(this._settings);
+
+        if (commit) await this.commitCSS(this._css);
+    };
+
+    private compileCSSProperties(css: WebPubCSS) {
+        const properties: { [key: string]: string } = {};
+        
+        for (const [key, value] of Object.entries(css.userProperties.toCSSProperties())) {
+            properties[key] = value;
+        }
+
+        return properties;
+    }
+
+    private async commitCSS(css: WebPubCSS) {
+        const properties = this.compileCSSProperties(css);
+        this.framePool.setCSSProperties(properties);
     }
 
     public eventListener(key: CommsEventKey | ManagerEventKey, data: unknown) {

--- a/navigator/src/webpub/css/Properties.ts
+++ b/navigator/src/webpub/css/Properties.ts
@@ -1,0 +1,27 @@
+export interface IUserProperties {
+  zoom: number | null;
+}
+
+export class UserProperties {
+  zoom: number | null;
+
+  constructor(props: IUserProperties) {
+    this.zoom = props.zoom ?? null;
+  }
+
+    private toPercentage(value: number, ratio: boolean = false) {
+    if (ratio || value > 0 && value <= 1) {
+      return `${ Math.round(value * 100) }%`;
+    } else {
+      return `${ value }%`;
+    }
+  }
+
+  toCSSProperties(): { [key: string]: string } {
+    const properties: { [key: string]: string } = {};
+
+    if (this.zoom !== null) properties["--USER__zoom"] = this.toPercentage(this.zoom, true);
+
+    return properties;
+  }
+}

--- a/navigator/src/webpub/css/Properties.ts
+++ b/navigator/src/webpub/css/Properties.ts
@@ -1,27 +1,71 @@
+import { TextAlignment } from "../../preferences/Types";
+import { BodyHyphens, Ligatures, Properties } from "../../css/Properties";
+
 export interface IUserProperties {
+  a11yNormalize?: boolean | null;
+  bodyHyphens?: BodyHyphens | null;
+  fontFamily?: string | null;
+  fontWeight?: number | null;
+  letterSpacing?: number | null;
+  ligatures?: Ligatures | null;
+  lineHeight?: number | null;
+  noRuby?: boolean | null;
+  paraIndent?: number | null;
+  paraSpacing?: number | null;
+  textAlign?: TextAlignment | null;
+  wordSpacing?: number | null;
   zoom: number | null;
 }
 
-export class UserProperties {
+export class UserProperties extends Properties {
+  a11yNormalize: boolean | null;
+  bodyHyphens: BodyHyphens | null;
+  fontFamily: string | null;
+  fontWeight: number | null;
+  letterSpacing: number | null;
+  ligatures: Ligatures | null;
+  lineHeight: number | null;
+  noRuby: boolean | null;
+  paraIndent: number | null;
+  paraSpacing: number | null;
+  textAlign: TextAlignment | null;
+  wordSpacing: number | null;
   zoom: number | null;
 
   constructor(props: IUserProperties) {
+    super();
+    this.a11yNormalize = props.a11yNormalize ?? null;
+    this.bodyHyphens = props.bodyHyphens ?? null;
+    this.fontFamily = props.fontFamily ?? null;
+    this.fontWeight = props.fontWeight ?? null;
+    this.letterSpacing = props.letterSpacing ?? null;
+    this.ligatures = props.ligatures ?? null;
+    this.lineHeight = props.lineHeight ?? null;
+    this.noRuby = props.noRuby ?? null;
+    this.paraIndent = props.paraIndent ?? null;
+    this.paraSpacing = props.paraSpacing ?? null;
+    this.textAlign = props.textAlign ?? null;
+    this.wordSpacing = props.wordSpacing ?? null;
     this.zoom = props.zoom ?? null;
   }
 
-    private toPercentage(value: number, ratio: boolean = false) {
-    if (ratio || value > 0 && value <= 1) {
-      return `${ Math.round(value * 100) }%`;
-    } else {
-      return `${ value }%`;
-    }
-  }
+  toCSSProperties() {
+    const cssProperties: { [key: string]: string } = {};
 
-  toCSSProperties(): { [key: string]: string } {
-    const properties: { [key: string]: string } = {};
+    if (this.a11yNormalize) cssProperties["--USER__a11yNormalize"] = this.toFlag("a11y");
+    if (this.bodyHyphens) cssProperties["--USER__bodyHyphens"] = this.bodyHyphens;
+    if (this.fontFamily) cssProperties["--USER__fontFamily"] = this.fontFamily;
+    if (this.fontWeight != null) cssProperties["--USER__fontWeight"] = this.toUnitless(this.fontWeight);
+    if (this.letterSpacing != null) cssProperties["--USER__letterSpacing"] = this.toRem(this.letterSpacing);
+    if (this.ligatures) cssProperties["--USER__ligatures"] = this.ligatures;
+    if (this.lineHeight != null) cssProperties["--USER__lineHeight"] = this.toUnitless(this.lineHeight);
+    if (this.noRuby) cssProperties["--USER__noRuby"] = this.toFlag("noRuby");
+    if (this.paraIndent != null) cssProperties["--USER__paraIndent"] = this.toRem(this.paraIndent);
+    if (this.paraSpacing != null) cssProperties["--USER__paraSpacing"] = this.toRem(this.paraSpacing);
+    if (this.textAlign) cssProperties["--USER__textAlign"] = this.textAlign;
+    if (this.wordSpacing != null) cssProperties["--USER__wordSpacing"] = this.toRem(this.wordSpacing);
+    if (this.zoom !== null) cssProperties["--USER__zoom"] = this.toPercentage(this.zoom, true);
 
-    if (this.zoom !== null) properties["--USER__zoom"] = this.toPercentage(this.zoom, true);
-
-    return properties;
+    return cssProperties;
   }
 }

--- a/navigator/src/webpub/css/Properties.ts
+++ b/navigator/src/webpub/css/Properties.ts
@@ -1,7 +1,7 @@
 import { TextAlignment } from "../../preferences/Types";
 import { BodyHyphens, Ligatures, Properties } from "../../css/Properties";
 
-export interface IUserProperties {
+export interface IWebUserProperties {
   a11yNormalize?: boolean | null;
   bodyHyphens?: BodyHyphens | null;
   fontFamily?: string | null;
@@ -17,7 +17,7 @@ export interface IUserProperties {
   zoom: number | null;
 }
 
-export class UserProperties extends Properties {
+export class WebUserProperties extends Properties {
   a11yNormalize: boolean | null;
   bodyHyphens: BodyHyphens | null;
   fontFamily: string | null;
@@ -32,7 +32,7 @@ export class UserProperties extends Properties {
   wordSpacing: number | null;
   zoom: number | null;
 
-  constructor(props: IUserProperties) {
+  constructor(props: IWebUserProperties) {
     super();
     this.a11yNormalize = props.a11yNormalize ?? null;
     this.bodyHyphens = props.bodyHyphens ?? null;

--- a/navigator/src/webpub/css/WebPubCSS.ts
+++ b/navigator/src/webpub/css/WebPubCSS.ts
@@ -12,8 +12,28 @@ export class WebPubCSS {
     this.userProperties = props.userProperties;
   }
 
-  update(settings: WebPubSettings): void {
+  update(settings: WebPubSettings) {
     const updated: IUserProperties = {
+      a11yNormalize: settings.textNormalization,
+      bodyHyphens: typeof settings.hyphens !== "boolean" 
+        ? null 
+        : settings.hyphens 
+          ? "auto" 
+          : "none",
+      fontFamily: settings.fontFamily,
+      fontWeight: settings.fontWeight,
+      letterSpacing: settings.letterSpacing,
+      ligatures: typeof settings.ligatures !== "boolean" 
+        ? null 
+        : settings.ligatures 
+          ? "common-ligatures" 
+          : "none",
+      lineHeight: settings.lineHeight,
+      noRuby: settings.noRuby,
+      paraIndent: settings.paragraphIndent,
+      paraSpacing: settings.paragraphSpacing,
+      textAlign: settings.textAlign,
+      wordSpacing: settings.wordSpacing,
       zoom: settings.zoom
     };
 

--- a/navigator/src/webpub/css/WebPubCSS.ts
+++ b/navigator/src/webpub/css/WebPubCSS.ts
@@ -1,0 +1,22 @@
+import { WebPubSettings } from "../preferences/WebPubSettings";
+import { IUserProperties, UserProperties } from "./Properties";
+
+export interface IWebPubCSS {
+  userProperties: UserProperties;
+}
+
+export class WebPubCSS {
+  userProperties: UserProperties;
+
+  constructor(props: IWebPubCSS) {
+    this.userProperties = props.userProperties;
+  }
+
+  update(settings: WebPubSettings): void {
+    const updated: IUserProperties = {
+      zoom: settings.zoom
+    };
+
+    this.userProperties = new UserProperties(updated);
+  }
+}

--- a/navigator/src/webpub/css/WebPubCSS.ts
+++ b/navigator/src/webpub/css/WebPubCSS.ts
@@ -1,19 +1,19 @@
 import { WebPubSettings } from "../preferences/WebPubSettings";
-import { IUserProperties, UserProperties } from "./Properties";
+import { IWebUserProperties, WebUserProperties } from "./Properties";
 
 export interface IWebPubCSS {
-  userProperties: UserProperties;
+  userProperties: WebUserProperties;
 }
 
 export class WebPubCSS {
-  userProperties: UserProperties;
+  userProperties: WebUserProperties;
 
   constructor(props: IWebPubCSS) {
     this.userProperties = props.userProperties;
   }
 
   update(settings: WebPubSettings) {
-    const updated: IUserProperties = {
+    const updated: IWebUserProperties = {
       a11yNormalize: settings.textNormalization,
       bodyHyphens: typeof settings.hyphens !== "boolean" 
         ? null 
@@ -37,6 +37,6 @@ export class WebPubCSS {
       zoom: settings.zoom
     };
 
-    this.userProperties = new UserProperties(updated);
+    this.userProperties = new WebUserProperties(updated);
   }
 }

--- a/navigator/src/webpub/css/WebPubStylesheet.ts
+++ b/navigator/src/webpub/css/WebPubStylesheet.ts
@@ -1,6 +1,174 @@
 // WebPubCSS is equivalent to ReadiumCSS for WebPub
 
 export const webPubStylesheet = `
+/* FontFamily */
+
+:root[style*="--USER__fontFamily"] {
+  font-family: var(--USER__fontFamily) !important;
+}
+
+:root[style*="--USER__fontFamily"] * {
+  font-family: revert !important;
+}
+
+/* FontWeight */
+
+:root[style*="--USER__fontWeight"] body {
+  font-weight: var(--USER__fontWeight) !important;
+}
+
+/* Attempt to handle known bolds */
+:root[style*="--USER__fontWeight"] b,
+:root[style*="--USER__fontWeight"] strong {
+  font-weight: bolder;
+}
+
+/* Hyphens */
+
+:root[style*="--USER__bodyHyphens"] {
+  -webkit-hyphens: var(--USER__bodyHyphens) !important;
+  -moz-hyphens: var(--USER__bodyHyphens) !important;
+  -ms-hyphens: var(--USER__bodyHyphens) !important;
+  -epub-hyphens: var(--USER__bodyHyphens) !important;
+  hyphens: var(--USER__bodyHyphens) !important;
+}
+
+:root[style*="--USER__bodyHyphens"] body,
+:root[style*="--USER__bodyHyphens"] p,
+:root[style*="--USER__bodyHyphens"] li,
+:root[style*="--USER__bodyHyphens"] div,
+:root[style*="--USER__bodyHyphens"] dd {
+  -webkit-hyphens: inherit;
+  -moz-hyphens: inherit;
+  -ms-hyphens: inherit;
+  -epub-hyphens: inherit;
+  hyphens: inherit;
+}
+
+/* LetterSpacing */
+
+:root[style*="--USER__letterSpacing"] h1,
+:root[style*="--USER__letterSpacing"] h2,
+:root[style*="--USER__letterSpacing"] h3,
+:root[style*="--USER__letterSpacing"] h4,
+:root[style*="--USER__letterSpacing"] h5,
+:root[style*="--USER__letterSpacing"] h6,
+:root[style*="--USER__letterSpacing"] p,
+:root[style*="--USER__letterSpacing"] li,
+:root[style*="--USER__letterSpacing"] div,
+:root[style*="--USER__letterSpacing"] dt,
+:root[style*="--USER__letterSpacing"] dd {
+  letter-spacing: var(--USER__letterSpacing);
+  font-variant: none;
+}
+
+/* Ligatures */
+
+:root[style*="--USER__ligatures"] {
+  font-variant-ligatures: var(--USER__ligatures) !important;
+}
+
+:root[style*="--USER__ligatures"] * {
+  font-variant-ligatures: inherit !important;
+}
+
+/* LineHeight */
+
+:root[style*="--USER__lineHeight"] {
+  line-height: var(--USER__lineHeight) !important;
+}
+
+:root[style*="--USER__lineHeight"] body,
+:root[style*="--USER__lineHeight"] p,
+:root[style*="--USER__lineHeight"] li,
+:root[style*="--USER__lineHeight"] div {
+  line-height: inherit;
+}
+
+/* ParagraphIndent */
+
+:root[style*="--USER__paraIndent"] p {
+  text-indent: var(--USER__paraIndent) !important;
+}
+
+:root[style*="--USER__paraIndent"] p *,
+:root[style*="--USER__paraIndent"] p:first-letter {
+  text-indent: 0 !important;
+}
+
+/* ParagraphSpacing */
+
+:root[style*="--USER__paraSpacing"] p {
+  margin-block: var(--USER__paraSpacing) !important;
+}
+
+/* Ruby */
+
+:root[style*="readium-noRuby-on"] body rt,
+:root[style*="readium-noRuby-on"] body rp {
+  display: none;
+}
+
+/* TextAlign */
+
+:root[style*="--USER__textAlign"] {
+  text-align: var(--USER__textAlign);
+}
+
+:root[style*="--USER__textAlign"] body,
+:root[style*="--USER__textAlign"] p:not(blockquote p):not(figcaption p):not(hgroup p),
+:root[style*="--USER__textAlign"] li,
+:root[style*="--USER__textAlign"] dd {
+  text-align: var(--USER__textAlign) !important;
+  -moz-text-align-last: auto !important;
+  -epub-text-align-last: auto !important;
+  text-align-last: auto !important;
+}
+
+/* TextNormalize */
+
+:root[style*="readium-a11y-on"] {
+  font-weight: normal !important;
+  font-style: normal !important;
+}
+
+:root[style*="readium-a11y-on"] *:not(code):not(var):not(kbd):not(samp) {
+  font-family: inherit !important;
+  font-weight: inherit !important;
+  font-style: inherit !important;
+}
+
+:root[style*="readium-a11y-on"] * {
+  text-decoration: none !important;
+  font-variant-caps: normal !important;
+  font-variant-position: normal !important;
+  font-variant-numeric: normal !important;
+}
+
+:root[style*="readium-a11y-on"] sup,
+:root[style*="readium-a11y-on"] sub {
+  font-size: 1rem !important;
+  vertical-align: baseline !important;
+}
+
+/* Word Spacing */
+
+:root[style*="--USER__wordSpacing"] h1,
+:root[style*="--USER__wordSpacing"] h2,
+:root[style*="--USER__wordSpacing"] h3,
+:root[style*="--USER__wordSpacing"] h4,
+:root[style*="--USER__wordSpacing"] h5,
+:root[style*="--USER__wordSpacing"] h6,
+:root[style*="--USER__wordSpacing"] p,
+:root[style*="--USER__wordSpacing"] li,
+:root[style*="--USER__wordSpacing"] div,
+:root[style*="--USER__wordSpacing"] dt,
+:root[style*="--USER__wordSpacing"] dd {
+  word-spacing: var(--USER__wordSpacing);
+}
+
+/* Zoom */
+
 :root {
   --USER__zoom: 1;
 }

--- a/navigator/src/webpub/css/WebPubStylesheet.ts
+++ b/navigator/src/webpub/css/WebPubStylesheet.ts
@@ -176,4 +176,27 @@ export const webPubStylesheet = `
 :root[style*="--USER__zoom"] body {
   zoom: var(--USER__zoom) !important;
 }
+
+:root[style*="--USER__zoom"] figure:has(> img),
+:root[style*="--USER__zoom"] figure:has(> video),
+:root[style*="--USER__zoom"] figure:has(> svg),
+:root[style*="--USER__zoom"] figure:has(> canvas),
+:root[style*="--USER__zoom"] figure:has(> iframe),
+:root[style*="--USER__zoom"] figure:has(> audio),
+:root[style*="--USER__zoom"] div:has(> img),
+:root[style*="--USER__zoom"] div:has(> video),
+:root[style*="--USER__zoom"] div:has(> svg),
+:root[style*="--USER__zoom"] div:has(> canvas),
+:root[style*="--USER__zoom"] div:has(> iframe),
+:root[style*="--USER__zoom"] div:has(> audio),
+:root[style*="--USER__zoom"] table {
+  zoom: calc(100% / var(--USER__zoom)) !important;
+}
+
+:root[style*="--USER__zoom"] figcaption,
+:root[style*="--USER__zoom"] caption,
+:root[style*="--USER__zoom"] td,
+:root[style*="--USER__zoom"] th {
+  zoom: var(--USER__zoom) !important;
+}
 `;

--- a/navigator/src/webpub/css/WebPubStylesheet.ts
+++ b/navigator/src/webpub/css/WebPubStylesheet.ts
@@ -1,0 +1,11 @@
+// WebPubCSS is equivalent to ReadiumCSS for WebPub
+
+export const webPubStylesheet = `
+:root {
+  --USER__zoom: 1;
+}
+
+:root[style*="--USER__zoom"] body {
+  zoom: var(--USER__zoom) !important;
+}
+`;

--- a/navigator/src/webpub/css/WebPubStylesheet.ts
+++ b/navigator/src/webpub/css/WebPubStylesheet.ts
@@ -177,26 +177,28 @@ export const webPubStylesheet = `
   zoom: var(--USER__zoom) !important;
 }
 
-:root[style*="--USER__zoom"] figure:has(> img),
-:root[style*="--USER__zoom"] figure:has(> video),
-:root[style*="--USER__zoom"] figure:has(> svg),
-:root[style*="--USER__zoom"] figure:has(> canvas),
-:root[style*="--USER__zoom"] figure:has(> iframe),
-:root[style*="--USER__zoom"] figure:has(> audio),
-:root[style*="--USER__zoom"] div:has(> img),
-:root[style*="--USER__zoom"] div:has(> video),
-:root[style*="--USER__zoom"] div:has(> svg),
-:root[style*="--USER__zoom"] div:has(> canvas),
-:root[style*="--USER__zoom"] div:has(> iframe),
-:root[style*="--USER__zoom"] div:has(> audio),
-:root[style*="--USER__zoom"] table {
-  zoom: calc(100% / var(--USER__zoom)) !important;
-}
+@supports selector(figure:has(> img)) {
+  :root[style*="--USER__zoom"] figure:has(> img),
+  :root[style*="--USER__zoom"] figure:has(> video),
+  :root[style*="--USER__zoom"] figure:has(> svg),
+  :root[style*="--USER__zoom"] figure:has(> canvas),
+  :root[style*="--USER__zoom"] figure:has(> iframe),
+  :root[style*="--USER__zoom"] figure:has(> audio),
+  :root[style*="--USER__zoom"] div:has(> img),
+  :root[style*="--USER__zoom"] div:has(> video),
+  :root[style*="--USER__zoom"] div:has(> svg),
+  :root[style*="--USER__zoom"] div:has(> canvas),
+  :root[style*="--USER__zoom"] div:has(> iframe),
+  :root[style*="--USER__zoom"] div:has(> audio),
+  :root[style*="--USER__zoom"] table {
+    zoom: calc(100% / var(--USER__zoom)) !important;
+  }
 
-:root[style*="--USER__zoom"] figcaption,
-:root[style*="--USER__zoom"] caption,
-:root[style*="--USER__zoom"] td,
-:root[style*="--USER__zoom"] th {
-  zoom: var(--USER__zoom) !important;
+  :root[style*="--USER__zoom"] figcaption,
+  :root[style*="--USER__zoom"] caption,
+  :root[style*="--USER__zoom"] td,
+  :root[style*="--USER__zoom"] th {
+    zoom: var(--USER__zoom) !important;
+  }
 }
 `;

--- a/navigator/src/webpub/css/index.ts
+++ b/navigator/src/webpub/css/index.ts
@@ -1,0 +1,3 @@
+export * from "./Properties";
+export * from "./WebPubCSS";
+export * from "./WebPubStylesheet";

--- a/navigator/src/webpub/index.ts
+++ b/navigator/src/webpub/index.ts
@@ -3,3 +3,4 @@ export * from "./WebPubBlobBuilder";
 export * from "./WebPubFrameManager";
 export * from "./WebPubFramePoolManager";
 export * from "./preferences";
+export * from "./css";

--- a/navigator/src/webpub/index.ts
+++ b/navigator/src/webpub/index.ts
@@ -2,3 +2,4 @@ export * from "./WebPubNavigator";
 export * from "./WebPubBlobBuilder";
 export * from "./WebPubFrameManager";
 export * from "./WebPubFramePoolManager";
+export * from "./preferences";

--- a/navigator/src/webpub/preferences/WebPubDefaults.ts
+++ b/navigator/src/webpub/preferences/WebPubDefaults.ts
@@ -1,17 +1,61 @@
-import { zoomRangeConfig } from "../../preferences/Types";
+import { 
+  fontWeightRangeConfig, 
+  TextAlignment, 
+  zoomRangeConfig 
+} from "../../preferences/Types";
 
 import {
-  ensureValueInRange
+  ensureBoolean,
+  ensureEnumValue,
+  ensureNonNegative,
+  ensureValueInRange,
+  ensureString
 } from "../../preferences/guards";
 
 export interface IWebPubDefaults {
-  zoom?: number | null;
+  fontFamily?: string | null,
+  fontWeight?: number | null,
+  hyphens?: boolean | null,
+  letterSpacing?: number | null,
+  ligatures?: boolean | null,
+  lineHeight?: number | null,
+  noRuby?: boolean | null,
+  paragraphIndent?: number | null,
+  paragraphSpacing?: number | null,
+  textAlign?: TextAlignment | null,
+  textNormalization?: boolean | null,
+  wordSpacing?: number | null,
+  zoom?: number | null
 }
 
 export class WebPubDefaults {
+  fontFamily: string | null;
+  fontWeight: number | null;
+  hyphens: boolean | null;
+  letterSpacing: number | null;
+  ligatures: boolean | null;
+  lineHeight: number | null;
+  noRuby: boolean | null;
+  paragraphIndent: number | null;
+  paragraphSpacing: number | null;
+  textAlign: TextAlignment | null;
+  textNormalization: boolean | null;
+  wordSpacing: number | null;
   zoom: number;
 
   constructor(defaults: IWebPubDefaults) {
+    this.fontFamily = ensureString(defaults.fontFamily) || null;
+    this.fontWeight = ensureValueInRange(defaults.fontWeight, fontWeightRangeConfig.range) || null;
+    this.hyphens = ensureBoolean(defaults.hyphens) ?? null;
+    this.letterSpacing = ensureNonNegative(defaults.letterSpacing) || null;
+    this.ligatures = ensureBoolean(defaults.ligatures) ?? null;
+    this.lineHeight = ensureNonNegative(defaults.lineHeight) || null;
+    this.noRuby = ensureBoolean(defaults.noRuby) ?? false;
+    this.paragraphIndent = ensureNonNegative(defaults.paragraphIndent) ?? null;
+    this.paragraphSpacing = ensureNonNegative(defaults.paragraphSpacing) ?? null;
+    this.textAlign = ensureEnumValue<TextAlignment>(defaults.textAlign, TextAlignment) || null;
+    this.textNormalization = ensureBoolean(defaults.textNormalization) ?? false;
+    this.wordSpacing = ensureNonNegative(defaults.wordSpacing) || null;
     this.zoom = ensureValueInRange(defaults.zoom, zoomRangeConfig.range) || 1;
   }
 }

--- a/navigator/src/webpub/preferences/WebPubDefaults.ts
+++ b/navigator/src/webpub/preferences/WebPubDefaults.ts
@@ -1,0 +1,17 @@
+import { zoomRangeConfig } from "../../preferences/Types";
+
+import {
+  ensureValueInRange
+} from "../../preferences/guards";
+
+export interface IWebPubDefaults {
+  zoom?: number | null;
+}
+
+export class WebPubDefaults {
+  zoom: number;
+
+  constructor(defaults: IWebPubDefaults) {
+    this.zoom = ensureValueInRange(defaults.zoom, zoomRangeConfig.range) || 1;
+  }
+}

--- a/navigator/src/webpub/preferences/WebPubPreferences.ts
+++ b/navigator/src/webpub/preferences/WebPubPreferences.ts
@@ -1,19 +1,63 @@
 import { ConfigurablePreferences } from "../../preferences/Configurable";
 
-import { zoomRangeConfig } from "../../preferences/Types";
+import { 
+  fontWeightRangeConfig, 
+  TextAlignment, 
+  zoomRangeConfig 
+} from "../../preferences/Types";
 
 import {
+  ensureBoolean,
+  ensureEnumValue,
+  ensureNonNegative,
+  ensureString,
   ensureValueInRange
 } from "../../preferences/guards";
 
 export interface IWebPubPreferences {
-  zoom?: number | null;
+  fontFamily?: string | null,
+  fontWeight?: number | null,
+  hyphens?: boolean | null,
+  letterSpacing?: number | null,
+  ligatures?: boolean | null,
+  lineHeight?: number | null,
+  noRuby?: boolean | null,
+  paragraphIndent?: number | null,
+  paragraphSpacing?: number | null,
+  textAlign?: TextAlignment | null,
+  textNormalization?: boolean | null,
+  wordSpacing?: number | null,
+  zoom?: number | null
 }
 
 export class WebPubPreferences implements ConfigurablePreferences {
+  fontFamily?: string | null;
+  fontWeight?: number | null;
+  hyphens?: boolean | null;
+  letterSpacing?: number | null;
+  ligatures?: boolean | null;
+  lineHeight?: number | null;
+  noRuby?: boolean | null;
+  paragraphIndent?: number | null;
+  paragraphSpacing?: number | null;
+  textAlign?: TextAlignment | null;
+  textNormalization?: boolean | null;
+  wordSpacing?: number | null;
   zoom?: number | null;
 
   constructor(preferences: IWebPubPreferences = {}) {
+    this.fontFamily = ensureString(preferences.fontFamily);
+    this.fontWeight = ensureValueInRange(preferences.fontWeight, fontWeightRangeConfig.range);
+    this.hyphens = ensureBoolean(preferences.hyphens);
+    this.letterSpacing = ensureNonNegative(preferences.letterSpacing);
+    this.ligatures = ensureBoolean(preferences.ligatures);
+    this.lineHeight = ensureNonNegative(preferences.lineHeight);
+    this.noRuby = ensureBoolean(preferences.noRuby);
+    this.paragraphIndent = ensureNonNegative(preferences.paragraphIndent);
+    this.paragraphSpacing = ensureNonNegative(preferences.paragraphSpacing);
+    this.textAlign = ensureEnumValue<TextAlignment>(preferences.textAlign, TextAlignment);
+    this.textNormalization = ensureBoolean(preferences.textNormalization);
+    this.wordSpacing = ensureNonNegative(preferences.wordSpacing);
     this.zoom = ensureValueInRange(preferences.zoom, zoomRangeConfig.range);
   }
 

--- a/navigator/src/webpub/preferences/WebPubPreferences.ts
+++ b/navigator/src/webpub/preferences/WebPubPreferences.ts
@@ -1,0 +1,44 @@
+import { ConfigurablePreferences } from "../../preferences/Configurable";
+
+import { zoomRangeConfig } from "../../preferences/Types";
+
+import {
+  ensureValueInRange
+} from "../../preferences/guards";
+
+export interface IWebPubPreferences {
+  zoom?: number | null;
+}
+
+export class WebPubPreferences implements ConfigurablePreferences {
+  zoom?: number | null;
+
+  constructor(preferences: IWebPubPreferences = {}) {
+    this.zoom = ensureValueInRange(preferences.zoom, zoomRangeConfig.range);
+  }
+
+  static serialize(preferences: WebPubPreferences): string {
+    const { ...properties } = preferences;
+    return JSON.stringify(properties);
+  }
+
+  static deserialize(preferences: string): WebPubPreferences | null {
+    try {
+      const parsedPreferences = JSON.parse(preferences);
+      return new WebPubPreferences(parsedPreferences);
+    } catch (error) {
+      console.error("Failed to deserialize preferences:", error);
+      return null;
+    }
+  }
+
+  merging(other: ConfigurablePreferences): ConfigurablePreferences {
+    const merged: IWebPubPreferences = { ...this };
+    for (const key of Object.keys(other) as (keyof IWebPubPreferences)[]) {
+      if (other[key] !== undefined) {
+        merged[key] = other[key];
+      }
+    }
+    return new WebPubPreferences(merged);
+  }
+}

--- a/navigator/src/webpub/preferences/WebPubPreferencesEditor.ts
+++ b/navigator/src/webpub/preferences/WebPubPreferencesEditor.ts
@@ -1,4 +1,3 @@
-import { Metadata } from "@readium/shared";
 import { IPreferencesEditor } from "../../preferences/PreferencesEditor";
 import { WebPubPreferences } from "./WebPubPreferences";
 import { WebPubSettings } from "./WebPubSettings";
@@ -9,12 +8,10 @@ import { zoomRangeConfig } from "../../preferences/Types";
 export class WebPubPreferencesEditor implements IPreferencesEditor {
   preferences: WebPubPreferences;
   private settings: WebPubSettings;
-  private metadata: Metadata | null;
 
-  constructor(initialPreferences: WebPubPreferences, settings: WebPubSettings, metadata: Metadata) {
+  constructor(initialPreferences: WebPubPreferences, settings: WebPubSettings) {
     this.preferences = initialPreferences;
     this.settings = settings;
-    this.metadata = metadata;
   }
 
   clear() {

--- a/navigator/src/webpub/preferences/WebPubPreferencesEditor.ts
+++ b/navigator/src/webpub/preferences/WebPubPreferencesEditor.ts
@@ -1,32 +1,188 @@
+import { Feature, Metadata } from "@readium/shared";
+
 import { IPreferencesEditor } from "../../preferences/PreferencesEditor";
 import { WebPubPreferences } from "./WebPubPreferences";
 import { WebPubSettings } from "./WebPubSettings";
-import { RangePreference } from "../../preferences/Preference";
-import { zoomRangeConfig } from "../../preferences/Types";
-
-// WIP: will change cos' of all the missing pieces
+import { BooleanPreference, EnumPreference, Preference, RangePreference } from "../../preferences/Preference";
+import { 
+  fontWeightRangeConfig, 
+  letterSpacingRangeConfig, 
+  lineHeightRangeConfig, 
+  paragraphIndentRangeConfig, 
+  paragraphSpacingRangeConfig, 
+  TextAlignment, 
+  wordSpacingRangeConfig, 
+  zoomRangeConfig 
+} from "../../preferences/Types";
 export class WebPubPreferencesEditor implements IPreferencesEditor {
   preferences: WebPubPreferences;
   private settings: WebPubSettings;
+  private metadata: Metadata | null;
 
-  constructor(initialPreferences: WebPubPreferences, settings: WebPubSettings) {
+  constructor(initialPreferences: WebPubPreferences, settings: WebPubSettings, metadata: Metadata) {
     this.preferences = initialPreferences;
     this.settings = settings;
+    this.metadata = metadata;
   }
 
   clear() {
-    this.preferences = new WebPubPreferences({ zoom: 1 });
+    this.preferences = new WebPubPreferences({});
   }
 
   private updatePreference<K extends keyof WebPubPreferences>(key: K, value: WebPubPreferences[K]) {
     this.preferences[key] = value;
   }
 
+  get fontFamily(): Preference<string> {
+    return new Preference<string>({
+      initialValue: this.preferences.fontFamily,
+      effectiveValue: this.settings.fontFamily || null,
+      isEffective: this.metadata?.accessibility?.feature?.includes(Feature.DISPLAY_TRANSFORMABILITY) ?? false,
+      onChange: (newValue: string | null | undefined) => {
+        this.updatePreference("fontFamily", newValue || null);
+      }
+    });
+  }
+
+  get fontWeight(): RangePreference<number> {
+    return new RangePreference<number>({
+      initialValue: this.preferences.fontWeight,
+      effectiveValue: this.settings.fontWeight || 400,
+      isEffective: this.metadata?.accessibility?.feature?.includes(Feature.DISPLAY_TRANSFORMABILITY) ?? false,
+      onChange: (newValue: number | null | undefined) => {
+        this.updatePreference("fontWeight", newValue || null);
+      },
+      supportedRange: fontWeightRangeConfig.range,
+      step: fontWeightRangeConfig.step
+    });
+  }
+
+  get hyphens(): BooleanPreference {
+    return new BooleanPreference({
+      initialValue: this.preferences.hyphens,
+      effectiveValue: this.settings.hyphens || false,
+      isEffective: this.metadata?.accessibility?.feature?.includes(Feature.DISPLAY_TRANSFORMABILITY) ?? false,
+      onChange: (newValue: boolean | null | undefined) => {
+        this.updatePreference("hyphens", newValue || null);
+      }
+    });
+  }
+
+  get letterSpacing(): RangePreference<number> {
+    return new RangePreference<number>({
+      initialValue: this.preferences.letterSpacing,
+      effectiveValue: this.settings.letterSpacing || 0,
+      isEffective: this.metadata?.accessibility?.feature?.includes(Feature.DISPLAY_TRANSFORMABILITY) ?? false,
+      onChange: (newValue: number | null | undefined) => {
+        this.updatePreference("letterSpacing", newValue || null);
+      },
+      supportedRange: letterSpacingRangeConfig.range,
+      step: letterSpacingRangeConfig.step
+    });
+  }
+
+  get ligatures(): BooleanPreference {
+    return new BooleanPreference({
+      initialValue: this.preferences.ligatures,
+      effectiveValue: this.settings.ligatures || true,
+      isEffective: this.metadata?.accessibility?.feature?.includes(Feature.DISPLAY_TRANSFORMABILITY) ?? false,
+      onChange: (newValue: boolean | null | undefined) => {
+        this.updatePreference("ligatures", newValue || null);
+      }
+    });
+  }
+
+  get lineHeight(): RangePreference<number> {
+    return new RangePreference<number>({
+      initialValue: this.preferences.lineHeight,
+      effectiveValue: this.settings.lineHeight,
+      isEffective: this.metadata?.accessibility?.feature?.includes(Feature.DISPLAY_TRANSFORMABILITY) ?? false,
+      onChange: (newValue: number | null | undefined) => {
+        this.updatePreference("lineHeight", newValue || null);
+      },
+      supportedRange: lineHeightRangeConfig.range,
+      step: lineHeightRangeConfig.step
+    });
+  }
+
+  get noRuby(): BooleanPreference {
+    return new BooleanPreference({
+      initialValue: this.preferences.noRuby,
+      effectiveValue: this.settings.noRuby || false,
+      isEffective: this.metadata?.accessibility?.feature?.includes(Feature.DISPLAY_TRANSFORMABILITY) ?? false,
+      onChange: (newValue: boolean | null | undefined) => {
+        this.updatePreference("noRuby", newValue || null);
+      }
+    });
+  }
+
+  get paragraphIndent(): RangePreference<number> {
+    return new RangePreference<number>({
+      initialValue: this.preferences.paragraphIndent,
+      effectiveValue: this.settings.paragraphIndent || 0,
+      isEffective: this.metadata?.accessibility?.feature?.includes(Feature.DISPLAY_TRANSFORMABILITY) ?? false,
+      onChange: (newValue: number | null | undefined) => {
+        this.updatePreference("paragraphIndent", newValue || null);
+      },
+      supportedRange: paragraphIndentRangeConfig.range,
+      step: paragraphIndentRangeConfig.step
+    });
+  }
+
+  get paragraphSpacing(): RangePreference<number> {
+    return new RangePreference<number>({
+      initialValue: this.preferences.paragraphSpacing,
+      effectiveValue: this.settings.paragraphSpacing || 0,
+      isEffective: this.metadata?.accessibility?.feature?.includes(Feature.DISPLAY_TRANSFORMABILITY) ?? false,
+      onChange: (newValue: number | null | undefined) => {
+        this.updatePreference("paragraphSpacing", newValue || null);
+      },
+      supportedRange: paragraphSpacingRangeConfig.range,
+      step: paragraphSpacingRangeConfig.step
+    });
+  }
+
+  get textAlign(): EnumPreference<TextAlignment> {
+    return new EnumPreference<TextAlignment>({
+      initialValue: this.preferences.textAlign,
+      effectiveValue: this.settings.textAlign || TextAlignment.start,
+      isEffective: this.metadata?.accessibility?.feature?.includes(Feature.DISPLAY_TRANSFORMABILITY) ?? false,
+      onChange: (newValue: TextAlignment | null | undefined) => {
+        this.updatePreference("textAlign", newValue || null);
+      },
+      supportedValues: Object.values(TextAlignment)
+    });
+  }
+
+  get textNormalization(): BooleanPreference {
+    return new BooleanPreference({
+      initialValue: this.preferences.textNormalization,
+      effectiveValue: this.settings.textNormalization || false,
+      isEffective: this.metadata?.accessibility?.feature?.includes(Feature.DISPLAY_TRANSFORMABILITY) ?? false,
+      onChange: (newValue: boolean | null | undefined) => {
+        this.updatePreference("textNormalization", newValue || null);
+      }
+    });
+  }
+
+  get wordSpacing(): RangePreference<number> {
+    return new RangePreference<number>({
+      initialValue: this.preferences.wordSpacing,
+      effectiveValue: this.settings.wordSpacing || 0,
+      isEffective: this.metadata?.accessibility?.feature?.includes(Feature.DISPLAY_TRANSFORMABILITY) ?? false,
+      onChange: (newValue: number | null | undefined) => {
+        this.updatePreference("wordSpacing", newValue || null);
+      },
+      supportedRange: wordSpacingRangeConfig.range,
+      step: wordSpacingRangeConfig.step
+    });
+  }
+
   get zoom(): RangePreference<number> {
     return new RangePreference<number>({
       initialValue: this.preferences.zoom,
       effectiveValue: this.settings.zoom || 1,
-      isEffective: true,
+      isEffective: CSS.supports("zoom", "1") ?? false,
       onChange: (newValue: number | null | undefined) => {
         this.updatePreference("zoom", newValue || null);
       },

--- a/navigator/src/webpub/preferences/WebPubPreferencesEditor.ts
+++ b/navigator/src/webpub/preferences/WebPubPreferencesEditor.ts
@@ -1,0 +1,40 @@
+import { Metadata } from "@readium/shared";
+import { IPreferencesEditor } from "../../preferences/PreferencesEditor";
+import { WebPubPreferences } from "./WebPubPreferences";
+import { WebPubSettings } from "./WebPubSettings";
+import { RangePreference } from "../../preferences/Preference";
+import { zoomRangeConfig } from "../../preferences/Types";
+
+// WIP: will change cos' of all the missing pieces
+export class WebPubPreferencesEditor implements IPreferencesEditor {
+  preferences: WebPubPreferences;
+  private settings: WebPubSettings;
+  private metadata: Metadata | null;
+
+  constructor(initialPreferences: WebPubPreferences, settings: WebPubSettings, metadata: Metadata) {
+    this.preferences = initialPreferences;
+    this.settings = settings;
+    this.metadata = metadata;
+  }
+
+  clear() {
+    this.preferences = new WebPubPreferences({ zoom: 1 });
+  }
+
+  private updatePreference<K extends keyof WebPubPreferences>(key: K, value: WebPubPreferences[K]) {
+    this.preferences[key] = value;
+  }
+
+  get zoom(): RangePreference<number> {
+    return new RangePreference<number>({
+      initialValue: this.preferences.zoom,
+      effectiveValue: this.settings.zoom || 1,
+      isEffective: true,
+      onChange: (newValue: number | null | undefined) => {
+        this.updatePreference("zoom", newValue || null);
+      },
+      supportedRange: zoomRangeConfig.range,
+      step: zoomRangeConfig.step
+    });
+  }
+}

--- a/navigator/src/webpub/preferences/WebPubSettings.ts
+++ b/navigator/src/webpub/preferences/WebPubSettings.ts
@@ -1,0 +1,19 @@
+import { ConfigurableSettings } from "../../preferences/Configurable";
+import { WebPubDefaults } from "./WebPubDefaults";
+import { WebPubPreferences } from "./WebPubPreferences";
+
+export interface IWebPubSettings {
+  zoom?: number | null;
+}
+
+export class WebPubSettings implements ConfigurableSettings {
+  zoom: number | null;
+
+  constructor(preferences: WebPubPreferences, defaults: WebPubDefaults) {
+    this.zoom = preferences.zoom !== undefined
+      ? preferences.zoom
+      : defaults.zoom !== undefined
+        ? defaults.zoom
+        : null;
+  }
+}

--- a/navigator/src/webpub/preferences/WebPubSettings.ts
+++ b/navigator/src/webpub/preferences/WebPubSettings.ts
@@ -1,15 +1,84 @@
 import { ConfigurableSettings } from "../../preferences/Configurable";
+import { TextAlignment } from "../../preferences/Types";
 import { WebPubDefaults } from "./WebPubDefaults";
 import { WebPubPreferences } from "./WebPubPreferences";
 
 export interface IWebPubSettings {
+  fontFamily?: string | null,
+  fontWeight?: number | null,
+  hyphens?: boolean | null,
+  letterSpacing?: number | null,
+  ligatures?: boolean | null,
+  lineHeight?: number | null,
+  noRuby?: boolean | null,
+  paragraphIndent?: number | null,
+  paragraphSpacing?: number | null,
+  textAlign?: TextAlignment | null,
+  textNormalization?: boolean | null,
+  wordSpacing?: number | null,
   zoom?: number | null;
 }
 
 export class WebPubSettings implements ConfigurableSettings {
+  fontFamily: string | null;
+  fontWeight: number | null;
+  hyphens: boolean | null;
+  letterSpacing: number | null;
+  ligatures: boolean | null;
+  lineHeight: number | null;
+  noRuby: boolean | null;
+  paragraphIndent: number | null;
+  paragraphSpacing: number | null;
+  textAlign: TextAlignment | null;
+  textNormalization: boolean | null;
+  wordSpacing: number | null;
   zoom: number | null;
 
   constructor(preferences: WebPubPreferences, defaults: WebPubDefaults) {
+    this.fontFamily = preferences.fontFamily || defaults.fontFamily || null;
+    this.fontWeight = preferences.fontWeight !== undefined 
+      ? preferences.fontWeight 
+      : defaults.fontWeight !== undefined 
+        ? defaults.fontWeight 
+        : null;
+    this.hyphens = typeof preferences.hyphens === "boolean" 
+      ? preferences.hyphens 
+      : defaults.hyphens ?? null;
+    this.letterSpacing = preferences.letterSpacing !== undefined 
+      ? preferences.letterSpacing 
+      : defaults.letterSpacing !== undefined 
+        ? defaults.letterSpacing 
+        : null;
+    this.ligatures = typeof preferences.ligatures === "boolean"
+      ? preferences.ligatures 
+      : defaults.ligatures ?? null;
+    this.lineHeight = preferences.lineHeight !== undefined 
+      ? preferences.lineHeight 
+      : defaults.lineHeight !== undefined 
+        ? defaults.lineHeight 
+        : null;
+    this.noRuby = typeof preferences.noRuby === "boolean" 
+      ? preferences.noRuby 
+      : defaults.noRuby ?? null;
+    this.paragraphIndent = preferences.paragraphIndent !== undefined 
+      ? preferences.paragraphIndent 
+      : defaults.paragraphIndent !== undefined 
+        ? defaults.paragraphIndent 
+        : null;
+    this.paragraphSpacing = preferences.paragraphSpacing !== undefined 
+      ? preferences.paragraphSpacing 
+      : defaults.paragraphSpacing !== undefined 
+        ? defaults.paragraphSpacing 
+        : null;
+    this.textAlign = preferences.textAlign || defaults.textAlign || null;
+    this.textNormalization = typeof preferences.textNormalization === "boolean" 
+      ? preferences.textNormalization 
+      : defaults.textNormalization ?? null;
+    this.wordSpacing = preferences.wordSpacing !== undefined 
+      ? preferences.wordSpacing 
+      : defaults.wordSpacing !== undefined 
+        ? defaults.wordSpacing 
+        : null;
     this.zoom = preferences.zoom !== undefined
       ? preferences.zoom
       : defaults.zoom !== undefined

--- a/navigator/src/webpub/preferences/index.ts
+++ b/navigator/src/webpub/preferences/index.ts
@@ -1,0 +1,4 @@
+export * from "./WebPubDefaults";
+export * from "./WebPubPreferencesEditor";
+export * from "./WebPubPreferences";
+export * from "./WebPubSettings";


### PR DESCRIPTION
This is implementing preferences API for Web Publications so that we can improve the prototype Navigator. 

It implements: 

- zoom
- font-family
- font-weight
- text-align
- hyphens
- text-normalization
- line-height
- paragraph spacing
- paragraph indent
- letter-spacing
- word-spacing
- ligatures
- ruby annotations

Zoom is effective if the browser supports zoom, there is no fallback in case it does not. 

All other preferences are tied to feature `displayTransformability` in `publication.metadata.accessibility`

At the moment, an internal Stylesheet is used to set properties following Readium CSS pattern. This is probably evolving in the future, with Readium CSS providing a proper stylesheet for web publications. 