### PR TITLE
fix: Metadata.serialize() sortAs and undefined language tag

### DIFF
--- a/shared/src/publication/LocalizedString.ts
+++ b/shared/src/publication/LocalizedString.ts
@@ -9,7 +9,7 @@
 export class LocalizedString {
   public readonly translations: { [key: string]: string };
 
-  public static readonly UNDEFINED_LANGUAGE = 'undefined';
+  public static readonly UNDEFINED_LANGUAGE = 'und';
   public static readonly LANGUAGE_EN = 'en';
 
   /**

--- a/shared/src/publication/Metadata.ts
+++ b/shared/src/publication/Metadata.ts
@@ -287,7 +287,7 @@ export class Metadata {
     if (this.identifier !== undefined) json.identifier = this.identifier;
     if (this.altIdentifier) json.altIdentifier = this.altIdentifier.serialize();
     if (this.subtitle) json.subtitle = this.subtitle.serialize();
-    if (this.sortAs) json.sortAs = this.sortAs.serialize();
+    if (this.sortAs) json.sortAs = this.sortAs.getTranslation();
     if (this.editors) json.editor = this.editors.serialize();
     if (this.artists) json.artist = this.artists.serialize();
     if (this.authors) json.author = this.authors.serialize();

--- a/shared/src/publication/Metadata.ts
+++ b/shared/src/publication/Metadata.ts
@@ -287,7 +287,7 @@ export class Metadata {
     if (this.identifier !== undefined) json.identifier = this.identifier;
     if (this.altIdentifier) json.altIdentifier = this.altIdentifier.serialize();
     if (this.subtitle) json.subtitle = this.subtitle.serialize();
-    if (this.sortAs) json.sortAs = this.sortAs.getTranslation();
+    if (this.sortAs) json.sortAs = this.sortAs.serialize();
     if (this.editors) json.editor = this.editors.serialize();
     if (this.artists) json.artist = this.artists.serialize();
     if (this.authors) json.author = this.authors.serialize();


### PR DESCRIPTION
I discovered that when calling Manifest.serialize() it did not return correctly for sortAs in metadata and that undefined language did not use a correct BCP-47 tag. This PR should fix it.