### PR TITLE
Fix multilingual sortAs

### DIFF
--- a/shared/CHANGELOG.MD
+++ b/shared/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] – 2025–12–18
+
+### Fixed
+
+- Corrected `sortAs` property in `Contributor` and `Subject` to be a `LocalizedString` instead of a plain `string`. ([#182](https://github.com/readium/ts-toolkit/issues/182))
+
 ## [2.1.1] – 2025–09–10
 
 ### Fixed

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/shared",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "type": "module",
   "description": "Shared models to be used across other Readium projects and implementations in Typescript",
   "author": "readium",

--- a/shared/src/publication/Contributor.ts
+++ b/shared/src/publication/Contributor.ts
@@ -21,7 +21,7 @@ export class Contributor {
   public readonly name: LocalizedString;
 
   /** The string used to sort the name of the contributor. */
-  public readonly sortAs?: string;
+  public readonly sortAs?: LocalizedString;
 
   /** An unambiguous reference to this contributor. */
   public readonly identifier?: string;
@@ -43,7 +43,7 @@ export class Contributor {
    */
   constructor(values: {
     name: LocalizedString;
-    sortAs?: string;
+    sortAs?: LocalizedString;
     identifier?: string;
     altIdentifiers?: Set<AltIdentifier>;
     roles?: Set<string>;
@@ -74,7 +74,7 @@ export class Contributor {
       if (!json.name) return;
       return new Contributor({
         name: LocalizedString.deserialize(json.name) as LocalizedString,
-        sortAs: json.sortAs,
+        sortAs: LocalizedString.deserialize(json.sortAs),
         identifier: json.identifier,
         altIdentifiers: json.altIdentifier
           ? (Array.isArray(json.altIdentifier)
@@ -98,7 +98,7 @@ export class Contributor {
    */
   public serialize(): any {
     const json: any = { name: this.name.serialize() };
-    if (this.sortAs !== undefined) json.sortAs = this.sortAs;
+    if (this.sortAs !== undefined) json.sortAs = this.sortAs.serialize();
     if (this.identifier !== undefined) json.identifier = this.identifier;
     if (this.altIdentifiers) json.altIdentifier = setToArray(this.altIdentifiers).map(altId => altId.serialize());
     if (this.roles) json.role = setToArray(this.roles);

--- a/shared/src/publication/Subject.ts
+++ b/shared/src/publication/Subject.ts
@@ -14,7 +14,7 @@ export class Subject {
   public readonly name: LocalizedString;
 
   /** Provides a string that a machine can sort. */
-  public readonly sortAs?: string;
+  public readonly sortAs?: LocalizedString;
 
   /** EPUB 3.1 opf:term. */
   public readonly code?: string;
@@ -28,7 +28,7 @@ export class Subject {
   /** Creates a [Subject]. */
   constructor(values: {
     name: LocalizedString;
-    sortAs?: string;
+    sortAs?: LocalizedString;
     code?: string;
     scheme?: string;
     links?: Links;
@@ -56,7 +56,7 @@ export class Subject {
       if (!json.name) return;
       return new Subject({
         name: LocalizedString.deserialize(json.name) as LocalizedString,
-        sortAs: json.sortAs,
+        sortAs: json.sortAs ? LocalizedString.deserialize(json.sortAs) : undefined,
         code: json.code,
         scheme: json.scheme,
         links: Links.deserialize(json.links),
@@ -69,7 +69,7 @@ export class Subject {
    */
   public serialize(): any {
     const json: any = { name: this.name.serialize() };
-    if (this.sortAs !== undefined) json.sortAs = this.sortAs;
+    if (this.sortAs !== undefined) json.sortAs = this.sortAs.serialize();
     if (this.code !== undefined) json.code = this.code;
     if (this.scheme !== undefined) json.scheme = this.scheme;
     if (this.links) json.links = this.links.serialize();

--- a/shared/test/Contributor.test.ts
+++ b/shared/test/Contributor.test.ts
@@ -38,7 +38,7 @@ describe('Contributor Tests', () => {
     ).toEqual(
       new Contributor({
         name: new LocalizedString('Colin Greenwood'),
-        sortAs: 'greenwood',
+        sortAs: new LocalizedString('greenwood'),
         identifier: 'colin',
         altIdentifiers: new Set<AltIdentifier>([
           new AltIdentifier({
@@ -171,7 +171,7 @@ describe('Contributor Tests', () => {
     expect(
       new Contributor({
         name: new LocalizedString('Colin Greenwood'),
-        sortAs: 'greenwood',
+        sortAs: new LocalizedString('greenwood'),
         identifier: 'colin',
         altIdentifiers: new Set<AltIdentifier>([
           new AltIdentifier({
@@ -188,7 +188,7 @@ describe('Contributor Tests', () => {
       }).serialize()
     ).toEqual({
       name: { undefined: 'Colin Greenwood' },
-      sortAs: 'greenwood',
+      sortAs: { undefined: 'greenwood' },
       identifier: 'colin',
       altIdentifier: [{ scheme: 'http://example.com/author-id', value: 'author-22222' }],
       role: ['bassist'],

--- a/shared/test/Subject.test.ts
+++ b/shared/test/Subject.test.ts
@@ -29,7 +29,7 @@ describe('Subject Tests', () => {
     ).toEqual(
       new Subject({
         name: new LocalizedString('Science Fiction'),
-        sortAs: 'science-fiction',
+        sortAs: new LocalizedString('science-fiction'),
         scheme: 'http://scheme',
         code: 'CODE',
         links: new Links([
@@ -132,7 +132,7 @@ describe('Subject Tests', () => {
     expect(
       new Subject({
         name: new LocalizedString('Science Fiction'),
-        sortAs: 'science-fiction',
+        sortAs: new LocalizedString('science-fiction'),
         scheme: 'http://scheme',
         code: 'CODE',
         links: new Links([
@@ -142,7 +142,7 @@ describe('Subject Tests', () => {
       }).serialize()
     ).toEqual({
       name: { undefined: 'Science Fiction' },
-      sortAs: 'science-fiction',
+      sortAs: { undefined: 'science-fiction' },
       scheme: 'http://scheme',
       code: 'CODE',
       links: [{ href: 'pub1' }, { href: 'pub2' }],


### PR DESCRIPTION
This closes #182 

In shared models, `sortAs` was not consistent across classes: it was a `LocalizedString` in `Metadata` but a `string` in `Contributor` and `Subject`. This surfaced while reviewing #178, and we became aware the schema had not been fully updated after [this proposal was accepted](https://github.com/readium/webpub-manifest/blob/master/proposals/001-multilingual-sortAs.md).

The PR addresses this issue early, before the schema correction, and impacts #178 as a result. 