### PR TITLE
feat: add highlight ID attribute to decoration items

### DIFF
--- a/navigator-html-injectables/src/modules/Decorator.ts
+++ b/navigator-html-injectables/src/modules/Decorator.ts
@@ -209,6 +209,7 @@ class DecorationGroup {
 
         const itemContainer = this.wnd.document.createElement("div");
         itemContainer.setAttribute("id", item.id);
+        itemContainer.dataset.highlightId = item.decoration.id;
         // itemContainer.dataset.style = item.decoration.style; // TODO style
         itemContainer.style.setProperty("pointer-events", "none");
 


### PR DESCRIPTION
In the previous version of Readium (ReadiumJs) there was a highlights plugin in which, in addition to adding, editing, and deleting, it was possible to register events when a highlight was clicked or hovered.

Currently, this can be implemented manually by retrieving the boundingRects using the readium-highlight class and manually capturing events in the iframe (although it would be great to implement all of this in the library).

However, what cannot be done is detecting which highlight the selected HTML element refers to, because these elements are empty. Therefore, I propose **adding to the highlight element’s dataset the identifier that the user passes to the method, as an attribute of the highlight.**
