### PR TITLE
Enable scroll padding left and right

### DIFF
--- a/navigator/docs/epub/ConfiguringEpubNavigator.md
+++ b/navigator/docs/epub/ConfiguringEpubNavigator.md
@@ -112,6 +112,7 @@ EPUB comes in two very different flavors: reflowable which allows a lot of custo
 | hyphens                  | ✅         |              |
 | invertFilter             | ✅         | WIP          |
 | invertGaijiFilter        | ✅         |              |
+| iOSPatch                 | ✅         |              |
 | iPadOSPatch              | ✅         |              |
 | letterSpacing            | ✅         |              |
 | ligatures                | ✅         |              |
@@ -125,6 +126,10 @@ EPUB comes in two very different flavors: reflowable which allows a lot of custo
 | paragraphIndent          | ✅         |              |
 | paragraphSpacing         | ✅         |              |
 | scroll                   | ✅         |              |
+| scrollPaddingTop         | ✅         |              |
+| scrollPaddingBottom      | ✅         |              |
+| scrollPaddingLeft        | ✅         |              |
+| scrollPaddingRight       | ✅         |              |
 | selectionBackgroundColor | ✅         |              |
 | selectionTextColor       | ✅         |              |
 | textAlign                | ✅         |              |
@@ -142,8 +147,20 @@ There is no `lineLength` preference because the effective line length is calcula
 
 The `columnCount` preference is available only when in paginated mode (`scroll = false`).
 
+Padding is applied differently depending on the mode:
+
+- In paginated mode, `pageGutter` is used.
+- In scroll mode, `scrollPaddingLeft` and `scrollPaddingRight` are used.
+
 ### Language specific preferences
 
 - `hyphens` is available only for Left-to-Right languages.
-- `ligature` is available only when the publication language is Arabic or Persian.
+- `ligatures` is disabled for Chinese, Japanese, Korean, and Traditional Mongolian languages.
 - `noRuby` is available only when the publication language is Japanese.
+
+### Patches
+
+- `iOSPatch` is designed to get around an issue with `zoom` on iOS.
+- `iPadOSPatch` is designed to get around an issue with `zoom` on iPadOS.
+
+Both are handled automatically by the Preferences API, but their values can be overridden if needed.

--- a/navigator/package.json
+++ b/navigator/package.json
@@ -50,8 +50,7 @@
     "generate:css-selector": "node scripts/generate-css-selector.js"
   },
   "devDependencies": {
-    "@laynezh/vite-plugin-lib-assets": "^2.1.3",
-    "@readium/css": "2.0.0-beta.24",
+    "@readium/css": "2.0.0-beta.25",
     "@readium/navigator-html-injectables": "workspace:*",
     "@readium/shared": "workspace:*",
     "@types/path-browserify": "^1.0.3",

--- a/navigator/package.json
+++ b/navigator/package.json
@@ -50,7 +50,7 @@
     "generate:css-selector": "node scripts/generate-css-selector.js"
   },
   "devDependencies": {
-    "@readium/css": "2.0.0-beta.25",
+    "@readium/css": "^2.0.0",
     "@readium/navigator-html-injectables": "workspace:*",
     "@readium/shared": "workspace:*",
     "@types/path-browserify": "^1.0.3",

--- a/navigator/src/epub/EpubNavigator.ts
+++ b/navigator/src/epub/EpubNavigator.ts
@@ -98,7 +98,9 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
                 optimalChars: this._settings.optimalLineLength,
                 minChars: this._settings.minimalLineLength,
                 maxChars: this._settings.maximalLineLength,
-                pageGutter: this._settings.pageGutter,
+                padding: this._settings.scroll 
+                    ? (this._settings.scrollPaddingLeft || 0) + (this._settings.scrollPaddingRight || 0)
+                    : (this._settings.pageGutter || 0) * 2,
                 fontFace: this._settings.fontFamily,
                 letterSpacing: this._settings.letterSpacing,
                 wordSpacing: this._settings.wordSpacing,

--- a/navigator/src/epub/css/Properties.ts
+++ b/navigator/src/epub/css/Properties.ts
@@ -203,8 +203,8 @@ export interface IRSProperties {
   sansSerifJaV?: string | null;
   sansTf?: string | null;
   scrollPaddingBottom?: number | null;
-  // scrollPaddingLeft?: number | null;
-  // scrollPaddingRight?: number | null;
+  scrollPaddingLeft?: number | null;
+  scrollPaddingRight?: number | null;
   scrollPaddingTop?: number | null;
   secondaryColor?: string | null;
   selectionBackgroundColor?: string | null;
@@ -248,8 +248,8 @@ export class RSProperties extends Properties {
   sansSerifJaV: string | null;
   sansTf: string | null;
   scrollPaddingBottom: number | null;
-  // scrollPaddingLeft: number | null;
-  // scrollPaddingRight: number | null;
+  scrollPaddingLeft: number | null;
+  scrollPaddingRight: number | null;
   scrollPaddingTop: number | null;
   secondaryColor: string | null;
   selectionBackgroundColor: string | null;
@@ -290,8 +290,8 @@ export class RSProperties extends Properties {
     this.paraSpacing = props.paraSpacing ?? null;
     this.primaryColor = props.primaryColor ?? null;
     this.scrollPaddingBottom = props.scrollPaddingBottom ?? null;
-    // this.scrollPaddingLeft = props.scrollPaddingLeft ?? null;
-    // this.scrollPaddingRight = props.scrollPaddingRight ?? null;
+    this.scrollPaddingLeft = props.scrollPaddingLeft ?? null;
+    this.scrollPaddingRight = props.scrollPaddingRight ?? null;
     this.scrollPaddingTop = props.scrollPaddingTop ?? null;
     this.sansSerifJa = props.sansSerifJa ?? null;
     this.sansSerifJaV = props.sansSerifJaV ?? null;
@@ -340,8 +340,8 @@ export class RSProperties extends Properties {
     if (this.sansSerifJaV) cssProperties["--RS__sans-serif-ja-v"] = this.sansSerifJaV;
     if (this.sansTf) cssProperties["--RS__sansTf"] = this.sansTf;
     if (this.scrollPaddingBottom != null) cssProperties["--RS__scrollPaddingBottom"] = this.toPx(this.scrollPaddingBottom);
-    // if (this.scrollPaddingLeft != null) cssProperties["--RS__scrollPaddingLeft"] = this.toPx(this.scrollPaddingLeft);
-    // if (this.scrollPaddingRight != null) cssProperties["--RS__scrollPaddingRight"] = this.toPx(this.scrollPaddingRight);
+    if (this.scrollPaddingLeft != null) cssProperties["--RS__scrollPaddingLeft"] = this.toPx(this.scrollPaddingLeft);
+    if (this.scrollPaddingRight != null) cssProperties["--RS__scrollPaddingRight"] = this.toPx(this.scrollPaddingRight);
     if (this.scrollPaddingTop != null) cssProperties["--RS__scrollPaddingTop"] = this.toPx(this.scrollPaddingTop);
     if (this.secondaryColor) cssProperties["--RS__secondaryColor"] = this.secondaryColor;
     if (this.selectionBackgroundColor) cssProperties["--RS__selectionBackgroundColor"] = this.selectionBackgroundColor;

--- a/navigator/src/epub/css/ReadiumCSS.ts
+++ b/navigator/src/epub/css/ReadiumCSS.ts
@@ -45,11 +45,11 @@ export class ReadiumCSS {
     if (settings.scrollPaddingBottom !== this.rsProperties.scrollPaddingBottom)
       this.rsProperties.scrollPaddingBottom = settings.scrollPaddingBottom;
 
-    // if (settings.scrollPaddingLeft !== this.rsProperties.scrollPaddingLeft)
-    //   this.rsProperties.scrollPaddingLeft = settings.scrollPaddingLeft;
+    if (settings.scrollPaddingLeft !== this.rsProperties.scrollPaddingLeft)
+      this.rsProperties.scrollPaddingLeft = settings.scrollPaddingLeft;
 
-    // if (settings.scrollPaddingRight !== this.rsProperties.scrollPaddingRight)
-    //   this.rsProperties.scrollPaddingRight = settings.scrollPaddingRight;
+    if (settings.scrollPaddingRight !== this.rsProperties.scrollPaddingRight)
+      this.rsProperties.scrollPaddingRight = settings.scrollPaddingRight;
 
     if (settings.scrollPaddingTop !== this.rsProperties.scrollPaddingTop)
       this.rsProperties.scrollPaddingTop = settings.scrollPaddingTop;
@@ -62,7 +62,9 @@ export class ReadiumCSS {
     this.lineLengths.update({
       fontFace: settings.fontFamily,
       letterSpacing: settings.letterSpacing,
-      pageGutter: settings.pageGutter,
+      padding: settings.scroll 
+        ? (settings.scrollPaddingLeft || 0) + (settings.scrollPaddingRight || 0)
+        : (settings.pageGutter || 0) * 2,
       wordSpacing: settings.wordSpacing,
       optimalChars: settings.optimalLineLength,
       minChars: settings.minimalLineLength,

--- a/navigator/src/epub/preferences/EpubDefaults.ts
+++ b/navigator/src/epub/preferences/EpubDefaults.ts
@@ -53,8 +53,8 @@ export interface IEpubDefaults {
   scroll?: boolean | null,
   scrollPaddingTop?: number | null,
   scrollPaddingBottom?: number | null,
-  // scrollPaddingLeft?: number | null,
-  // scrollPaddingRight?: number | null,
+  scrollPaddingLeft?: number | null,
+  scrollPaddingRight?: number | null,
   selectionBackgroundColor?: string | null,
   selectionTextColor?: string | null,
   textAlign?: TextAlignment | null,
@@ -97,8 +97,8 @@ export class EpubDefaults {
   scroll: boolean | null;
   scrollPaddingTop: number | null;
   scrollPaddingBottom: number | null;
-  // scrollPaddingLeft: number | null;
-  // scrollPaddingRight: number | null;
+  scrollPaddingLeft: number | null;
+  scrollPaddingRight: number | null;
   selectionBackgroundColor: string | null;
   selectionTextColor: string | null;
   textAlign: TextAlignment | null;
@@ -144,8 +144,8 @@ export class EpubDefaults {
     this.scroll = ensureBoolean(defaults.scroll) ?? false;
     this.scrollPaddingTop = ensureNonNegative(defaults.scrollPaddingTop) ?? null;
     this.scrollPaddingBottom = ensureNonNegative(defaults.scrollPaddingBottom) ?? null;
-    // this.scrollPaddingLeft = ensureNonNegative(defaults.scrollPaddingLeft) ?? null;
-    // this.scrollPaddingRight = ensureNonNegative(defaults.scrollPaddingRight) ?? null;
+    this.scrollPaddingLeft = ensureNonNegative(defaults.scrollPaddingLeft) ?? null;
+    this.scrollPaddingRight = ensureNonNegative(defaults.scrollPaddingRight) ?? null;
     this.selectionBackgroundColor = ensureString(defaults.selectionBackgroundColor) || null;
     this.selectionTextColor = ensureString(defaults.selectionTextColor) || null;
     this.textAlign = ensureEnumValue<TextAlignment>(defaults.textAlign, TextAlignment) || null;

--- a/navigator/src/epub/preferences/EpubPreferences.ts
+++ b/navigator/src/epub/preferences/EpubPreferences.ts
@@ -48,8 +48,8 @@ export interface IEpubPreferences {
   scroll?: boolean | null,
   scrollPaddingTop?: number | null,
   scrollPaddingBottom?: number | null,
-  // scrollPaddingLeft?: number | null,
-  // scrollPaddingRight?: number | null,
+  scrollPaddingLeft?: number | null,
+  scrollPaddingRight?: number | null,
   selectionBackgroundColor?: string | null,
   selectionTextColor?: string | null,
   textAlign?: TextAlignment | null,
@@ -91,8 +91,8 @@ export class EpubPreferences implements ConfigurablePreferences {
   scroll?: boolean | null;
   scrollPaddingTop?: number | null;
   scrollPaddingBottom?: number | null;
-  // scrollPaddingLeft?: number | null;
-  // scrollPaddingRight?: number | null;
+  scrollPaddingLeft?: number | null;
+  scrollPaddingRight?: number | null;
   selectionBackgroundColor?: string | null;
   selectionTextColor?: string | null;
   textAlign?: TextAlignment | null;
@@ -130,8 +130,8 @@ export class EpubPreferences implements ConfigurablePreferences {
     this.scroll = ensureBoolean(preferences.scroll);
     this.scrollPaddingTop = ensureNonNegative(preferences.scrollPaddingTop);
     this.scrollPaddingBottom = ensureNonNegative(preferences.scrollPaddingBottom);
-    // this.scrollPaddingLeft = ensureNonNegative(preferences.scrollPaddingLeft);
-    // this.scrollPaddingRight = ensureNonNegative(preferences.scrollPaddingRight);
+    this.scrollPaddingLeft = ensureNonNegative(preferences.scrollPaddingLeft);
+    this.scrollPaddingRight = ensureNonNegative(preferences.scrollPaddingRight);
     this.selectionBackgroundColor = ensureString(preferences.selectionBackgroundColor);
     this.selectionTextColor = ensureString(preferences.selectionTextColor);
     this.textAlign = ensureEnumValue<TextAlignment>(preferences.textAlign, TextAlignment);

--- a/navigator/src/epub/preferences/EpubPreferencesEditor.ts
+++ b/navigator/src/epub/preferences/EpubPreferencesEditor.ts
@@ -364,7 +364,7 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
     return new Preference<number>({
       initialValue: this.preferences.pageGutter,
       effectiveValue: this.settings.pageGutter,
-      isEffective: this.layout !== Layout.fixed,
+      isEffective: this.layout !== Layout.fixed && !this.settings.scroll,
       onChange: (newValue: number | null | undefined) => {
         this.updatePreference("pageGutter", newValue || null);
       }
@@ -430,7 +430,6 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
     });
   }
 
-  /* 
   get scrollPaddingLeft(): Preference<number> {
     return new Preference<number>({
       initialValue: this.preferences.scrollPaddingLeft,
@@ -452,7 +451,6 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
       }
     });
   } 
-  */
 
   get selectionBackgroundColor(): Preference<string> {
     return new Preference<string>({

--- a/navigator/src/epub/preferences/EpubSettings.ts
+++ b/navigator/src/epub/preferences/EpubSettings.ts
@@ -37,8 +37,8 @@ export interface IEpubSettings {
   scroll?: boolean | null,
   scrollPaddingTop?: number | null,
   scrollPaddingBottom?: number | null,
-  // scrollPaddingLeft?: number | null,
-  // scrollPaddingRight?: number | null,
+  scrollPaddingLeft?: number | null,
+  scrollPaddingRight?: number | null,
   selectionBackgroundColor?: string | null,
   selectionTextColor?: string | null,
   textAlign?: TextAlignment | null,
@@ -81,8 +81,8 @@ export class EpubSettings implements ConfigurableSettings {
   scroll: boolean | null;
   scrollPaddingTop: number | null;
   scrollPaddingBottom: number | null;
-  // scrollPaddingLeft: number | null;
-  // scrollPaddingRight: number | null;
+  scrollPaddingLeft: number | null;
+  scrollPaddingRight: number | null;
   selectionBackgroundColor: string | null;
   selectionTextColor: string | null;
   textAlign: TextAlignment | null;
@@ -205,8 +205,7 @@ export class EpubSettings implements ConfigurableSettings {
       ? preferences.scrollPaddingBottom 
       : defaults.scrollPaddingBottom !== undefined 
         ? defaults.scrollPaddingBottom 
-        : null;
-    /* 
+        : null; 
     this.scrollPaddingLeft = preferences.scrollPaddingLeft !== undefined 
       ? preferences.scrollPaddingLeft 
       : defaults.scrollPaddingLeft !== undefined 
@@ -217,7 +216,6 @@ export class EpubSettings implements ConfigurableSettings {
       : defaults.scrollPaddingRight !== undefined 
         ? defaults.scrollPaddingRight 
         : null;
-    */
     this.selectionBackgroundColor = preferences.selectionBackgroundColor || defaults.selectionBackgroundColor || null;
     this.selectionTextColor = preferences.selectionTextColor || defaults.selectionTextColor || null;
     this.textAlign = preferences.textAlign || defaults.textAlign || null;

--- a/navigator/src/helpers/lineLength.ts
+++ b/navigator/src/helpers/lineLength.ts
@@ -11,7 +11,7 @@ export interface ILineLengthsConfig {
   maxChars?: number | null;
   baseFontSize?: number | null;
   sample?: string | null;
-  pageGutter?: number | null;
+  padding?: number | null;
   fontFace?: string | ICustomFontFace | null;
   letterSpacing?: number | null;
   wordSpacing?: number | null;
@@ -51,13 +51,12 @@ export class LineLengths {
   private _baseFontSize: number;
   private _fontFace: string | ICustomFontFace;
   private _sample: string | null;
-  private _pageGutter: number;
+  private _padding: number;
   private _letterSpacing: number;
   private _wordSpacing: number;
   private _isCJK: boolean;
   private _getRelative: boolean;
   
-  private _padding: number;
   private _minDivider: number | null;
   private _maxMultiplier: number | null;
   private _approximatedWordSpaces: number;
@@ -72,7 +71,7 @@ export class LineLengths {
     this._baseFontSize = config.baseFontSize || DEFAULT_FONT_SIZE;
     this._fontFace = config.fontFace || DEFAULT_FONT_FACE;
     this._sample = config.sample || null;
-    this._pageGutter = config.pageGutter || 0;
+    this._padding = config.padding ?? 0;
     this._letterSpacing = config.letterSpacing 
       ? Math.round(config.letterSpacing * this._baseFontSize) 
       : 0;
@@ -81,7 +80,6 @@ export class LineLengths {
       : 0;
     this._isCJK = config.isCJK || false;
     this._getRelative = config.getRelative || false;
-    this._padding = this._pageGutter * 2;
     this._minDivider = this._minChars && this._minChars < this._optimalChars 
       ? this._optimalChars / this._minChars 
       : this._minChars === null 
@@ -121,7 +119,7 @@ export class LineLengths {
     if (props.letterSpacing) this._letterSpacing = props.letterSpacing;
     if (props.wordSpacing) this._wordSpacing = props.wordSpacing;
     if (props.isCJK != null) this._isCJK = props.isCJK;
-    if (props.pageGutter) this._pageGutter = props.pageGutter;
+    if (props.padding !== undefined) this._padding = props.padding ?? 0;
     if (props.getRelative) this._getRelative = props.getRelative;
 
     if (props.sample) {

--- a/navigator/vite.config.js
+++ b/navigator/vite.config.js
@@ -4,12 +4,6 @@ import libAssetsPlugin from "@laynezh/vite-plugin-lib-assets";
 import packageJson from "./package.json";
 
 export default defineConfig({
-  plugins: [
-    libAssetsPlugin({
-      extensions: [".jpg", ".png", ".svg", ".otf", ".ttf", ".woff", ".woff2"],
-      name: "[name].[ext]"
-    })
-  ],
   build: {
     lib: {
       entry: resolve(__dirname, "src/index.ts"),

--- a/navigator/vite.config.js
+++ b/navigator/vite.config.js
@@ -1,6 +1,5 @@
 import { resolve } from "path";
 import { defineConfig } from "vite";
-import libAssetsPlugin from "@laynezh/vite-plugin-lib-assets";
 import packageJson from "./package.json";
 
 export default defineConfig({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,12 +20,9 @@ importers:
 
   navigator:
     devDependencies:
-      '@laynezh/vite-plugin-lib-assets':
-        specifier: ^2.1.3
-        version: 2.1.3(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(less@4.5.1)(sass@1.97.2)(stylus@0.62.0))
       '@readium/css':
-        specifier: 2.0.0-beta.24
-        version: 2.0.0-beta.24
+        specifier: 2.0.0-beta.25
+        version: 2.0.0-beta.25
       '@readium/navigator-html-injectables':
         specifier: workspace:*
         version: link:../navigator-html-injectables
@@ -1009,11 +1006,6 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@laynezh/vite-plugin-lib-assets@2.1.3':
-    resolution: {integrity: sha512-HZIFWKwzW9rqFnqXbMMzf8LnhHJvEzvG1eHbVH6vK5Ux1maqWLd00WBtLf7CgeMwmuQP0uTZU2muKSsRcC++Qw==}
-    peerDependencies:
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -1113,8 +1105,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@readium/css@2.0.0-beta.24':
-    resolution: {integrity: sha512-vBI5Sw6JwlbTuDBvcD/ahJZqw2NGe1CDGQ7msAByc/491Q8V76baCkYIMFWyj5gPS1GS9oltlmIAWZAzxx3djg==}
+  '@readium/css@2.0.0-beta.25':
+    resolution: {integrity: sha512-ZlcDtCigX+E+K9y4L1LOzMFNNg7Tn75KIrf914PVarS/8zolMLHIz80AkDVVS5FKcOsMoCJwZ6FtRxCD8abcJw==}
 
   '@rollup/rollup-android-arm-eabi@4.55.2':
     resolution: {integrity: sha512-21J6xzayjy3O6NdnlO6aXi/urvSRjm6nCI6+nF6ra2YofKruGixN9kfT+dt55HVNwfDmpDHJcaS3JuP/boNnlA==}
@@ -1678,10 +1670,6 @@ packages:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
 
-  escape-string-regexp@4.0.0:
-    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
-    engines: {node: '>=10'}
-
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -2058,10 +2046,6 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  loader-utils@3.3.1:
-    resolution: {integrity: sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==}
-    engines: {node: '>= 12.13.0'}
-
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -2132,10 +2116,6 @@ packages:
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  mrmime@1.0.1:
-    resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
-    engines: {node: '>=10'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3790,14 +3770,6 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@laynezh/vite-plugin-lib-assets@2.1.3(vite@7.3.1(@types/node@25.0.9)(jiti@2.6.1)(less@4.5.1)(sass@1.97.2)(stylus@0.62.0))':
-    dependencies:
-      escape-string-regexp: 4.0.0
-      loader-utils: 3.3.1
-      mrmime: 1.0.1
-      semver: 7.7.3
-      vite: 7.3.1(@types/node@25.0.9)(jiti@2.6.1)(less@4.5.1)(sass@1.97.2)(stylus@0.62.0)
-
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.8.1
@@ -3871,7 +3843,7 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@readium/css@2.0.0-beta.24': {}
+  '@readium/css@2.0.0-beta.25': {}
 
   '@rollup/rollup-android-arm-eabi@4.55.2':
     optional: true
@@ -4353,8 +4325,6 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@2.0.0: {}
-
-  escape-string-regexp@4.0.0: {}
 
   esprima@4.0.1: {}
 
@@ -4907,8 +4877,6 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  loader-utils@3.3.1: {}
-
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -4970,8 +4938,6 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
-
-  mrmime@1.0.1: {}
 
   ms@2.1.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
   navigator:
     devDependencies:
       '@readium/css':
-        specifier: 2.0.0-beta.25
-        version: 2.0.0-beta.25
+        specifier: ^2.0.0
+        version: 2.0.0
       '@readium/navigator-html-injectables':
         specifier: workspace:*
         version: link:../navigator-html-injectables
@@ -1105,8 +1105,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@readium/css@2.0.0-beta.25':
-    resolution: {integrity: sha512-ZlcDtCigX+E+K9y4L1LOzMFNNg7Tn75KIrf914PVarS/8zolMLHIz80AkDVVS5FKcOsMoCJwZ6FtRxCD8abcJw==}
+  '@readium/css@2.0.0':
+    resolution: {integrity: sha512-Cr+AlHf5JqdwWPQ3ihw4HzsN3BkYyhOnD/fx6/+Y1QrTr1cIj1/xpGmixYyxn3kfLME00CX+OfhJeScYB1ANIw==}
 
   '@rollup/rollup-android-arm-eabi@4.55.2':
     resolution: {integrity: sha512-21J6xzayjy3O6NdnlO6aXi/urvSRjm6nCI6+nF6ra2YofKruGixN9kfT+dt55HVNwfDmpDHJcaS3JuP/boNnlA==}
@@ -3843,7 +3843,7 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@readium/css@2.0.0-beta.25': {}
+  '@readium/css@2.0.0': {}
 
   '@rollup/rollup-android-arm-eabi@4.55.2':
     optional: true


### PR DESCRIPTION
Following resolution in ReadiumCSS, `pageGutter` only applies in pagination, `scrollPaddingLeft` and `scrollPaddingRight` in scroll. LineLength helper now has to take padding directly since scroll can have different values, unlike `pageGutter`.

Since Fonts are no longer distributed through ReadiumCSS, the build has also been simplified as we do not need to copy these fonts in Navigator’s package any longer.

Will be in draft until Readium CSS version `2.0.0` (stable) is released so that we do not have to do a subsequent update. 