### PR TITLE
Fix webpub context menu

### DIFF
--- a/navigator/CHANGELOG.MD
+++ b/navigator/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] – 2026–03–19
+
+### Fixed
+
+- Fixed context menu event propagation in WebPub Navigator ([#201](https://github.com/readium/ts-toolkit/pull/201))
+
 ## [2.3.0] – 2026-02-24
 
 ### Added

--- a/navigator/package.json
+++ b/navigator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "type": "module",
   "description": "Next generation SDK for publications in Web Apps",
   "author": "readium",

--- a/navigator/src/protection/DevToolsDetector.ts
+++ b/navigator/src/protection/DevToolsDetector.ts
@@ -282,6 +282,7 @@ export class DevToolsDetector {
         // Cleanup Web Worker
         if (this.workerConsole) {
             this.workerConsole.destroy();
+            this.workerConsole = undefined;
         }
         
         this.isOpen = false;

--- a/navigator/src/webpub/WebPubNavigator.ts
+++ b/navigator/src/webpub/WebPubNavigator.ts
@@ -129,8 +129,12 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
             
             // Listen for custom events from NavigatorProtector
             this._suspiciousActivityListener = (event: Event) => {
-                const customEvent = event as CustomEvent;
-                this.listeners.contentProtection(customEvent.detail.type, customEvent.detail);
+                const { type, ...activity } = (event as CustomEvent).detail;
+                if (type === "context_menu") {
+                    this.listeners.contextMenu(activity as ContextMenuEvent);
+                } else {
+                    this.listeners.contentProtection(type, activity);
+                }
             };
             window.addEventListener(NAVIGATOR_SUSPICIOUS_ACTIVITY_EVENT, this._suspiciousActivityListener);
         }


### PR DESCRIPTION
This adds the missing web pub context menu event in the parent window – sorry for this oversight. 

It also makes sure to reset the dev console worker when disconnecting it. 