### PR TITLE
Update Readium CSS

### DIFF
--- a/navigator/CHANGELOG.MD
+++ b/navigator/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.4] – 2026–05–13
+
+### Changed
+
+- Readium CSS update – it no longer uses `default` as JSON property
+
 ## [2.5.3] – 2026-05-11
 
 ### Fixed

--- a/navigator/package.json
+++ b/navigator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "type": "module",
   "description": "Next generation SDK for publications in Web Apps",
   "author": "readium",
@@ -50,7 +50,7 @@
     "generate:css-selector": "node scripts/generate-css-selector.js"
   },
   "devDependencies": {
-    "@readium/css": "^2.0.4",
+    "@readium/css": "^2.0.5",
     "@readium/navigator-html-injectables": "workspace:*",
     "@readium/shared": "workspace:*",
     "@types/path-browserify": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
   navigator:
     devDependencies:
       '@readium/css':
-        specifier: ^2.0.4
-        version: 2.0.4
+        specifier: ^2.0.5
+        version: 2.0.5
       '@readium/navigator-html-injectables':
         specifier: workspace:*
         version: link:../navigator-html-injectables
@@ -1105,8 +1105,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@readium/css@2.0.4':
-    resolution: {integrity: sha512-+WQoL7/GG0VECHtGd+XZlC5JyLBG6DiPEKDTz9QGg9CVaA7bZ0fcAVNB86MDHP+RGQ/DWDIuiw1stzpapylnrA==}
+  '@readium/css@2.0.5':
+    resolution: {integrity: sha512-rQWeDFSS9UfRTFFdWIhlko0jtkL9dOfNTqFjgMumlguromsyHC9/lGmbWDde7deEeE5ns+yBOSGKixMU0wqZ4A==}
 
   '@rollup/rollup-android-arm-eabi@4.55.2':
     resolution: {integrity: sha512-21J6xzayjy3O6NdnlO6aXi/urvSRjm6nCI6+nF6ra2YofKruGixN9kfT+dt55HVNwfDmpDHJcaS3JuP/boNnlA==}
@@ -3843,7 +3843,7 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@readium/css@2.0.4': {}
+  '@readium/css@2.0.5': {}
 
   '@rollup/rollup-android-arm-eabi@4.55.2':
     optional: true


### PR DESCRIPTION
This updates ReadiumCSS to latest. It no longer uses `default` as property in JSON. Some internal variables have consequently been renamed as well. 