### PR TITLE
fix: FXL last-page state not refreshing on revisit

### DIFF
--- a/navigator/src/epub/EpubNavigator.ts
+++ b/navigator/src/epub/EpubNavigator.ts
@@ -648,6 +648,11 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
                     }
                 }
             await this.apply();
+            // On the initial forward walk each fresh iframe load fires
+            // positionChanged via _pong; on back-then-forward to an
+            // already-loaded frame no _pong fires, so dispatch explicitly here.
+            // Redux dedupes the duplicate on the forward case.
+            this.listeners.positionChanged(this.currentLocation);
             return true;
         }
 


### PR DESCRIPTION
`positionChanged` was wired to only fire as a side effect of a page loading in, this fixes that so it always fires after every navigation.

encountered this when stresstesting Bookwalker's reader, we show a "last page reached" dialog upon reaching the last page, but it never gets shown again because Thorium's `atPublicationEnd` state became stuck, unless the user tried going back far enough that the last page gets evicted from the sliding window.

this possibly unblocks https://github.com/edrlab/thorium-web/issues/16.