### PR TITLE
Fix peripheral breaking on iframe loading

### DIFF
--- a/navigator-html-injectables/src/helpers/dom.ts
+++ b/navigator-html-injectables/src/helpers/dom.ts
@@ -79,6 +79,10 @@ export function isInteractiveElement(element: Element | null): boolean {
     // Check for interactive roles
     if (element.role && interactiveRoles.includes(element.role)) return true;
 
+    // An iframe element is a separate browsing context — its focused content cannot be inspected
+    // cross-origin, so the iframe container itself must not be treated as interactive.
+    if (element.tagName.toLowerCase() === "iframe") return false;
+
     if ((element as HTMLElement).tabIndex >= 0) return true;
     
     // Use existing interactive tags logic

--- a/navigator-html-injectables/src/modules/Peripherals.ts
+++ b/navigator-html-injectables/src/modules/Peripherals.ts
@@ -537,6 +537,15 @@ export class Peripherals extends Module {
             ack(true);
         });
 
+        // Disable keyboard handler when frame is unfocused so that stale focus
+        // inside a hidden/off-screen iframe doesn't silently swallow key events
+        // through a halted comms channel. The handler is re-established on the
+        // next show() cycle via the keyboard_peripherals message below.
+        this.comms?.register("unfocus", Peripherals.moduleName, (_, ack) => {
+            this.disableKeyboardPeripherals();
+            ack(true);
+        });
+
         // Separate handler for keyboard peripherals
         this.comms?.register("keyboard_peripherals", Peripherals.moduleName, (data: unknown, ack) => {
             const keyboardPeripherals = data as KeyboardPeripheral[];

--- a/navigator/src/epub/EpubNavigator.ts
+++ b/navigator/src/epub/EpubNavigator.ts
@@ -81,6 +81,7 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
     private _css: ReadiumCSS;
     private _preferencesEditor: EpubPreferencesEditor | null = null;
     private _injector: Injector | null = null;
+    private _navigating = false;
     private readonly _readiumRulesPromise: Promise<IInjectableRule[]>;
     private readonly _injectablesConfig: IInjectablesConfig;
     private readonly _contentProtection: IContentProtectionConfig;
@@ -758,33 +759,45 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
     }
 
     public goBackward(_: boolean, cb: (ok: boolean) => void): void {
+        if(this._navigating) { cb(false); return; }
+        this._navigating = true;
         if(this._layout === Layout.fixed) {
-            this.changeResource(-1);
-            cb(true);
+            this.changeResource(-1).then((ok) => {
+                this._navigating = false;
+                cb(ok);
+            });
         } else {
             this._cframes[0]?.msg?.send("go_prev", undefined, async (ack) => {
-                if(ack)
-                    // OK
+                if(ack) {
+                    this._navigating = false;
                     cb(true);
-                else
-                    // Need to change resources because we're at the beginning of the current one
-                    cb(await this.changeResource(-1));
+                } else {
+                    const ok = await this.changeResource(-1);
+                    this._navigating = false;
+                    cb(ok);
+                }
             });
         }
     }
 
     public goForward(_: boolean, cb: (ok: boolean) => void): void {
+        if(this._navigating) { cb(false); return; }
+        this._navigating = true;
         if(this._layout === Layout.fixed) {
-            this.changeResource(1);
-            cb(true);
+            this.changeResource(1).then((ok) => {
+                this._navigating = false;
+                cb(ok);
+            });
         } else {
             this._cframes[0]?.msg?.send("go_next", undefined, async (ack) => {
-                if(ack)
-                    // OK
+                if(ack) {
+                    this._navigating = false;
                     cb(true);
-                else
-                    // Need to change resources because we're at the end of the current one
-                    cb(await this.changeResource(1));
+                } else {
+                    const ok = await this.changeResource(1);
+                    this._navigating = false;
+                    cb(ok);
+                }
             });
         }
     }

--- a/navigator/src/epub/EpubNavigator.ts
+++ b/navigator/src/epub/EpubNavigator.ts
@@ -81,7 +81,7 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
     private _css: ReadiumCSS;
     private _preferencesEditor: EpubPreferencesEditor | null = null;
     private _injector: Injector | null = null;
-    private _navigating = false;
+    private _isNavigating = false;
     private readonly _readiumRulesPromise: Promise<IInjectableRule[]>;
     private readonly _injectablesConfig: IInjectablesConfig;
     private readonly _contentProtection: IContentProtectionConfig;
@@ -759,21 +759,21 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
     }
 
     public goBackward(_: boolean, cb: (ok: boolean) => void): void {
-        if(this._navigating) { cb(false); return; }
-        this._navigating = true;
+        if(this._isNavigating) { cb(false); return; }
+        this._isNavigating = true;
         if(this._layout === Layout.fixed) {
             this.changeResource(-1).then((ok) => {
-                this._navigating = false;
+                this._isNavigating = false;
                 cb(ok);
             });
         } else {
             this._cframes[0]?.msg?.send("go_prev", undefined, async (ack) => {
                 if(ack) {
-                    this._navigating = false;
+                    this._isNavigating = false;
                     cb(true);
                 } else {
                     const ok = await this.changeResource(-1);
-                    this._navigating = false;
+                    this._isNavigating = false;
                     cb(ok);
                 }
             });
@@ -781,21 +781,21 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
     }
 
     public goForward(_: boolean, cb: (ok: boolean) => void): void {
-        if(this._navigating) { cb(false); return; }
-        this._navigating = true;
+        if(this._isNavigating) { cb(false); return; }
+        this._isNavigating = true;
         if(this._layout === Layout.fixed) {
             this.changeResource(1).then((ok) => {
-                this._navigating = false;
+                this._isNavigating = false;
                 cb(ok);
             });
         } else {
             this._cframes[0]?.msg?.send("go_next", undefined, async (ack) => {
                 if(ack) {
-                    this._navigating = false;
+                    this._isNavigating = false;
                     cb(true);
                 } else {
                     const ok = await this.changeResource(1);
-                    this._navigating = false;
+                    this._isNavigating = false;
                     cb(ok);
                 }
             });

--- a/navigator/src/epub/EpubNavigator.ts
+++ b/navigator/src/epub/EpubNavigator.ts
@@ -920,12 +920,12 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
             return cb(this.listeners.handleLocator(locator));
         }
 
-        if(this._navigating) { cb(false); return; }
-        this._navigating = true;
+        if(this._isNavigating) { cb(false); return; }
+        this._isNavigating = true;
 
         this.currentLocation = this.positions.find(p => p.href === link!.href)!;
         this.apply().then(() => this.loadLocator(locator, (ok) => {
-            this._navigating = false;
+            this._isNavigating = false;
             cb(ok);
         })).then(() => {
             // Now that we've gone to the right locator, we can attach the listeners.

--- a/navigator/src/epub/EpubNavigator.ts
+++ b/navigator/src/epub/EpubNavigator.ts
@@ -920,8 +920,14 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
             return cb(this.listeners.handleLocator(locator));
         }
 
+        if(this._navigating) { cb(false); return; }
+        this._navigating = true;
+
         this.currentLocation = this.positions.find(p => p.href === link!.href)!;
-        this.apply().then(() => this.loadLocator(locator, (ok) => cb(ok))).then(() => {
+        this.apply().then(() => this.loadLocator(locator, (ok) => {
+            this._navigating = false;
+            cb(ok);
+        })).then(() => {
             // Now that we've gone to the right locator, we can attach the listeners.
             // Doing this only at this stage reduces janky UI with multiple locator updates.
             this.attachListener();

--- a/navigator/src/epub/frame/FrameManager.ts
+++ b/navigator/src/epub/frame/FrameManager.ts
@@ -115,6 +115,9 @@ export class FrameManager {
         this.frame.style.opacity = "0";
         this.frame.style.pointerEvents = "none";
         this.hidden = true;
+        // Return focus to the parent document so keyboard events aren't silently
+        // swallowed by a hidden iframe whose comms channel has been halted.
+        this.frame.blur();
         if(this.frame.parentElement) {
             if(this.comms === undefined || !this.comms.ready) return;
             return new Promise((res, _) => {

--- a/navigator/src/epub/fxl/FXLFrameManager.ts
+++ b/navigator/src/epub/fxl/FXLFrameManager.ts
@@ -199,6 +199,9 @@ export class FXLFrameManager {
     async unfocus(): Promise<void> {
         if(this.frame.parentElement) {
             if(this.comms === undefined) return;
+            // Return focus to the parent document so keyboard events aren't silently
+            // swallowed by an off-screen iframe whose comms channel has been halted.
+            this.frame.blur();
             return new Promise((res, _) => {
                 this.comms?.send("unfocus", undefined, (_: boolean) => {
                     this.comms?.halt();

--- a/navigator/src/webpub/WebPubNavigator.ts
+++ b/navigator/src/webpub/WebPubNavigator.ts
@@ -588,8 +588,14 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
             this.currentIndex = index;
         }
 
+        if(this._isNavigating) { cb(false); return; }
+        this._isNavigating = true;
+
         this.currentLocation = this.createCurrentLocator();
-        this.apply().then(() => this.loadLocator(locator, (ok) => cb(ok))).then(() => {
+        this.apply().then(() => this.loadLocator(locator, (ok) => {
+            this._isNavigating = false;
+            cb(ok);
+        })).then(() => {
             // Now that we've gone to the right locator, we can attach the listeners.
             // Doing this only at this stage reduces janky UI with multiple locator updates.
             this.attachListener();

--- a/navigator/src/webpub/WebPubNavigator.ts
+++ b/navigator/src/webpub/WebPubNavigator.ts
@@ -72,6 +72,7 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
     private _css: WebPubCSS;
     private _preferencesEditor: WebPubPreferencesEditor | null = null;
     private readonly _injector: Injector | null = null;
+    private _isNavigating = false;
     private readonly _contentProtection: IContentProtectionConfig;
     private readonly _keyboardPeripherals: IKeyboardPeripheralsConfig;
     private readonly _navigatorProtector: NavigatorProtector | null = null;
@@ -463,14 +464,20 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
     }
 
     goBackward(_animated: boolean, cb: (ok: boolean) => void): void {
-        this.changeResource(-1).then((success) => {
-            cb(success);
+        if(this._isNavigating) { cb(false); return; }
+        this._isNavigating = true;
+        this.changeResource(-1).then((ok) => {
+            this._isNavigating = false;
+            cb(ok);
         });
     }
 
     goForward(_animated: boolean, cb: (ok: boolean) => void): void {
-        this.changeResource(1).then((success) => {
-            cb(success);
+        if(this._isNavigating) { cb(false); return; }
+        this._isNavigating = true;
+        this.changeResource(1).then((ok) => {
+            this._isNavigating = false;
+            cb(ok);
         });
     }
 


### PR DESCRIPTION
Fixes #221 

Resolves #190 

To explain the bugs that have surfaced here: 

- on iframe hiding, focus is kept in the now unfocused iframe, so we blur it to give focus back to the parent element
- removing listeners on unfocus to prevent them from swallowing the event
- excluded iframe from interactive element since it has a default tab index of `0`
- rapid navigation can break the appending of listeners so added a navigation lock – it also broke navigation so killing two birds with one stone

Admittedly, focus could be handled smartly, e.g. if the previous iframe has the focus, then give it to the current one. In practice it is not necessarily that trivial because we would need to keep track of what is focused within the iframe, then derive if it is what is focused in the context of the entire page, etc. and do not have the plumbing at the moment. 