### PR TITLE
Fix subcollections

### DIFF
--- a/shared/src/publication/Manifest.ts
+++ b/shared/src/publication/Manifest.ts
@@ -19,7 +19,7 @@ export class Manifest {
 
   public readonly metadata: Metadata;
 
-  public readonly links: Links;
+  public readonly links?: Links;
 
   /** Identifies a list of resources in reading order for the publication. */
   public readonly readingOrder: Links;
@@ -35,7 +35,7 @@ export class Manifest {
   constructor(values: {
     context?: Array<string>;
     metadata: Metadata;
-    links: Links;
+    links?: Links;
     readingOrder: Links;
     resources?: Links;
     toc?: Links;
@@ -65,13 +65,17 @@ export class Manifest {
 
     const links = Links.deserialize(json.links);
 
-    if (!links) return;
-
     const readingOrder = Links.deserialize(
       json.readingOrder ? json.readingOrder : json.spine
     );
 
     if (!readingOrder) return;
+
+    const knownKeys = new Set(['@context', 'metadata', 'links', 'readingOrder', 'spine', 'resources', 'toc']);
+    const remaining: Record<string, unknown> = {};
+    Object.keys(json).forEach(key => {
+      if (!knownKeys.has(key)) remaining[key] = json[key];
+    });
 
     return new Manifest({
       context: arrayfromJSONorString(json['@context']),
@@ -80,9 +84,7 @@ export class Manifest {
       readingOrder,
       resources: Links.deserialize(json.resources),
       toc: Links.deserialize(json.toc),
-      subcollections: PublicationCollection.deserializeCollections({
-        sub: json.sub,
-      }),
+      subcollections: PublicationCollection.deserializeCollections(remaining),
     });
   }
 
@@ -93,7 +95,7 @@ export class Manifest {
     const json: any = {};
     if (this.context !== undefined) json['@context'] = this.context;
     json.metadata = this.metadata.serialize();
-    json.links = this.links.serialize();
+    if (this.links !== undefined) json.links = this.links.serialize();
     json.readingOrder = this.readingOrder.serialize();
     if (this.resources) json.resources = this.resources.serialize();
     if (this.toc) json.toc = this.toc.serialize();
@@ -108,7 +110,9 @@ export class Manifest {
     if (this.resources) {
       links.push(this.resources);
     }
-    links.push(this.links);
+    if (this.links) {
+      links.push(this.links);
+    }
 
     let result: Link | undefined;
 
@@ -129,7 +133,9 @@ export class Manifest {
     if (this.resources) {
       result.push(this.resources.filterByRel(rel));
     }
-    result.push(this.links.filterByRel(rel));
+    if (this.links) {
+      result.push(this.links.filterByRel(rel));
+    }
 
     return result.reduce((acc, val) => acc.concat(val), []);
   }
@@ -197,7 +203,9 @@ export class Manifest {
     if (this.resources) {
       links.push(this.resources);
     }
-    links.push(this.links);
+    if (this.links) {
+      links.push(this.links);
+    }
 
     const link = find(links);
 
@@ -218,7 +226,7 @@ export class Manifest {
    *  e.g. https://provider.com/pub1293/manifest.json gives https://provider.com/pub1293/
    */
   public get baseURL(): string | undefined {
-    const selfLink = this.links.items.find(
+    const selfLink = this.links?.items.find(
       el => el.rels && el.rels.has('self')
     );
     if (selfLink) {
@@ -242,10 +250,11 @@ export class Manifest {
    * Sets the URL where this [Publication]'s RWPM manifest is served.
    */
   public setSelfLink(href: string): void {
-    this.links.items = this.links.items.filter(
+    if (!this.links) (this as any).links = new Links([]);
+    this.links!.items = this.links!.items.filter(
       x => x.rels === undefined || !x.rels?.has('self')
     );
-    this.links.items.push(
+    this.links!.items.push(
       new Link({
         href,
         type: MediaType.READIUM_WEBPUB_MANIFEST.string,

--- a/shared/src/publication/Publication.ts
+++ b/shared/src/publication/Publication.ts
@@ -26,7 +26,7 @@ export class Publication {
   // Shortcuts to manifest properties
   public readonly context?: Array<string>;
   public readonly metadata: Metadata;
-  public readonly links: Links;
+  public readonly links?: Links;
   /** Identifies a list of resources in reading order for the publication. */
   public readonly readingOrder: Links;
   /** Identifies resources that are necessary for rendering the publication. */
@@ -121,7 +121,7 @@ export class Publication {
   }
 
   public async positionsFromManifest(): Promise<Locator[]> {
-    const positionListLink = this.manifest.links.findWithMediaType(
+    const positionListLink = this.manifest.links?.findWithMediaType(
       'application/vnd.readium.position-list+json'
     );
     if (positionListLink === undefined) return [];
@@ -152,7 +152,7 @@ export class Publication {
 
     if(!guidedNavigationLink) {
       // Still unable to find a guided navigation link, try to use the manifest's global document
-      guidedNavigationLink = this.manifest.links.findWithMediaType(
+      guidedNavigationLink = this.manifest.links?.findWithMediaType(
         'application/guided-navigation+json'
       );
     }

--- a/shared/test/Manifest.test.ts
+++ b/shared/test/Manifest.test.ts
@@ -36,9 +36,7 @@ describe('Manifest Tests', () => {
           href: '',
           children: [{ href: '/chap2.html' }, { href: '/chap3.html' }],
         }],
-        sub: {
-          links: [{ href: '/sublink' }],
-        },
+        pageList: [{ href: '/page1.html' }],
       })
     ).toEqual(
       new Manifest({
@@ -64,13 +62,29 @@ describe('Manifest Tests', () => {
         ]),
         subcollections: new Map([
           [
-            'sub',
+            'pageList',
             [
               new PublicationCollection({
-                links: new Links([new Link({ href: '/sublink' })]),
+                links: new Links([new Link({ href: '/page1.html' })]),
               }),
             ],
           ],
+        ]),
+      })
+    );
+  });
+
+  it('parse JSON without {links}', () => {
+    expect(
+      Manifest.deserialize({
+        metadata: { title: 'Title' },
+        readingOrder: [{ href: '/chap1.html', type: 'text/html' }],
+      })
+    ).toEqual(
+      new Manifest({
+        metadata: new Metadata({ title: new LocalizedString('Title') }),
+        readingOrder: new Links([
+          new Link({ href: '/chap1.html', type: 'text/html' }),
         ]),
       })
     );
@@ -166,10 +180,10 @@ describe('Manifest Tests', () => {
         ]),
         subcollections: new Map([
           [
-            'sub',
+            'pageList',
             [
               new PublicationCollection({
-                links: new Links([new Link({ href: '/sublink' })]),
+                links: new Links([new Link({ href: '/page1.html' })]),
               }),
             ],
           ],
@@ -182,12 +196,12 @@ describe('Manifest Tests', () => {
       readingOrder: [{ href: '/chap1.html', type: 'text/html' }],
       resources: [{ href: '/image.png', type: 'image/png' }],
       toc: [
-        { href: '/cover.html' }, 
-        { href: '/chap1.html' }, 
+        { href: '/cover.html' },
+        { href: '/chap1.html' },
         { href: '', children: [{ href: '/chap2.html' }, { href: '/chap3.html' }] },
       ],
-      sub: {
-        links: [{ href: '/sublink' }],
+      pageList: {
+        links: [{ href: '/page1.html' }],
       },
     });
   });

--- a/shared/test/epub/PublicationTest.test.ts
+++ b/shared/test/epub/PublicationTest.test.ts
@@ -1,105 +1,92 @@
-import {
-  Link,
-  Links,
-  LocalizedString,
-  Manifest,
-  Metadata,
-  Publication,
-  PublicationCollection,
-} from '../../src';
+import '../../src/publication/epub/Publication.ts';
+import { Manifest, Publication } from '../../src';
+
+const manifestJSON = {
+  '@context': 'https://readium.org/webpub-manifest/context.jsonld',
+  metadata: {
+    author: 'Various',
+    conformsTo: 'https://readium.org/webpub-manifest/profiles/epub',
+    identifier: 'code.google.com.epub-samples.georgia-pls-ssml',
+    language: 'en-US',
+    modified: '2012-02-07T16:38:35Z',
+    title: 'Georgia',
+  },
+  readingOrder: [{ href: 'EPUB/georgia.xhtml', type: 'application/xhtml+xml' }],
+  resources: [
+    { href: 'EPUB/cover.xhtml', type: 'application/xhtml+xml' },
+    { href: 'EPUB/nav.xhtml', rel: 'contents', type: 'application/xhtml+xml' },
+    { href: 'EPUB/css/epub.css', type: 'text/css' },
+    { href: 'EPUB/images/cover.png', rel: 'cover', type: 'image/png' },
+    { href: 'EPUB/toc.ncx', type: 'application/x-dtbncx+xml' },
+  ],
+  toc: [{ href: 'EPUB/georgia.xhtml#d10e42', title: 'GEORGIA' }],
+  landmarks: [{ href: 'EPUB/cover.xhtml', title: 'cover' }],
+  pageList: [
+    { href: 'EPUB/georgia.xhtml#page752', title: '752' },
+    { href: 'EPUB/georgia.xhtml#page753', title: '753' },
+    { href: 'EPUB/georgia.xhtml#page754', title: '754' },
+    { href: 'EPUB/georgia.xhtml#page755', title: '755' },
+    { href: 'EPUB/georgia.xhtml#page756', title: '756' },
+    { href: 'EPUB/georgia.xhtml#page757', title: '757' },
+    { href: 'EPUB/georgia.xhtml#page758', title: '758' },
+  ],
+  loa: [{ href: 'EPUB/audio.mp3', title: 'Audio clip' }],
+  loi: [{ href: 'EPUB/images/figure1.png', title: 'Figure 1' }],
+  lot: [{ href: 'EPUB/table1.xhtml', title: 'Table 1' }],
+  lov: [{ href: 'EPUB/video.mp4', title: 'Video clip' }],
+};
 
 describe('Epub Publication Tests', () => {
-  function createPublication(
-    subcollections: Map<string, Array<PublicationCollection>> = new Map<
-      string,
-      Array<PublicationCollection>
-    >()
-  ): Publication {
-    return new Publication({
-      manifest: new Manifest({
-        metadata: new Metadata({ title: new LocalizedString('Title') }),
-        links: new Links([]),
-        readingOrder: new Links([]),
-        subcollections,
-      }),
-    });
-  }
+  let publication: Publication;
 
-  it('get {pageList}', () => {
-    const links = new Links([new Link({ href: '/page1.html' })]);
-    expect(
-      createPublication(
-        new Map([['pageList', [new PublicationCollection({ links })]]])
-      ).getPageList()
-    ).toEqual(links);
+  beforeEach(() => {
+    const manifest = Manifest.deserialize(manifestJSON);
+    expect(manifest).toBeDefined();
+    publication = new Publication({ manifest: manifest! });
   });
 
-  it('get {pageList} when missing', () => {
-    expect(createPublication().getPageList()).toBeUndefined();
+  it('get {pageList}', () => {
+    const pageList = publication.getPageList();
+    expect(pageList?.items).toHaveLength(7);
+    expect(pageList?.items[0].href).toBe('EPUB/georgia.xhtml#page752');
+    expect(pageList?.items[6].href).toBe('EPUB/georgia.xhtml#page758');
   });
 
   it('get {landmarks}', () => {
-    const links = new Links([new Link({ href: '/landmark.html' })]);
-    expect(
-      createPublication(
-        new Map([['landmarks', [new PublicationCollection({ links })]]])
-      ).getLandmarks()
-    ).toEqual(links);
-  });
-
-  it('get {landmarks} when missing', () => {
-    expect(createPublication().getLandmarks()).toBeUndefined();
+    const landmarks = publication.getLandmarks();
+    expect(landmarks?.items).toHaveLength(1);
+    expect(landmarks?.items[0].href).toBe('EPUB/cover.xhtml');
+    expect(landmarks?.items[0].title).toBe('cover');
   });
 
   it('get {listOfAudioClips}', () => {
-    const links = new Links([new Link({ href: '/audio.mp3' })]);
-    expect(
-      createPublication(
-        new Map([['loa', [new PublicationCollection({ links })]]])
-      ).getListOfAudioClips()
-    ).toEqual(links);
-  });
-
-  it('get {listOfAudioClips} when missing', () => {
-    expect(createPublication().getListOfAudioClips()).toBeUndefined();
+    const loa = publication.getListOfAudioClips();
+    expect(loa?.items).toHaveLength(1);
+    expect(loa?.items[0].href).toBe('EPUB/audio.mp3');
   });
 
   it('get {listOfIllustrations}', () => {
-    const links = new Links([new Link({ href: '/image.jpg' })]);
-    expect(
-      createPublication(
-        new Map([['loi', [new PublicationCollection({ links })]]])
-      ).getListOfIllustrations()
-    ).toEqual(links);
-  });
-
-  it('get {listOfIllustrations} when missing', () => {
-    expect(createPublication().getListOfIllustrations()).toBeUndefined();
+    const loi = publication.getListOfIllustrations();
+    expect(loi?.items).toHaveLength(1);
+    expect(loi?.items[0].href).toBe('EPUB/images/figure1.png');
   });
 
   it('get {listOfTables}', () => {
-    const links = new Links([new Link({ href: '/table.html' })]);
-    expect(
-      createPublication(
-        new Map([['lot', [new PublicationCollection({ links })]]])
-      ).getListOfTables()
-    ).toEqual(links);
-  });
-
-  it('get {listOfTables} when missing', () => {
-    expect(createPublication().getListOfTables()).toBeUndefined();
+    const lot = publication.getListOfTables();
+    expect(lot?.items).toHaveLength(1);
+    expect(lot?.items[0].href).toBe('EPUB/table1.xhtml');
   });
 
   it('get {listOfVideoClips}', () => {
-    const links = new Links([new Link({ href: '/video.mov' })]);
-    expect(
-      createPublication(
-        new Map([['lov', [new PublicationCollection({ links })]]])
-      ).getListOfVideoClips()
-    ).toEqual(links);
+    const lov = publication.getListOfVideoClips();
+    expect(lov?.items).toHaveLength(1);
+    expect(lov?.items[0].href).toBe('EPUB/video.mp4');
   });
 
-  it('get {listOfVideoClips} when missing', () => {
-    expect(createPublication().getListOfVideoClips()).toBeUndefined();
+  it('subcollections contains only the expected roles', () => {
+    expect(Array.from(publication.subcollections?.keys() ?? [])).toEqual(
+      expect.arrayContaining(['pageList', 'landmarks', 'loa', 'loi', 'lot', 'lov'])
+    );
+    expect(publication.subcollections?.size).toBe(6);
   });
 });


### PR DESCRIPTION
Makes `Publication.links` optional, corrects deserialization of subcollections. 

Closes #223 