### PR TITLE
Drop synthethic keyboard events

### DIFF
--- a/navigator-html-injectables/src/keyboard/KeyCombinationManager.ts
+++ b/navigator-html-injectables/src/keyboard/KeyCombinationManager.ts
@@ -146,6 +146,7 @@ export class KeyCombinationManager {
         const handlers = this.createKeyboardHandlers(targetFrameSrc, shortcuts, dispatcher, wnd);
 
         return (event: KeyboardEvent) => {
+            if (!event.isTrusted) return;
             for (const handlerConfig of handlers) {
                 if (this.match(event, [handlerConfig])) {
                     const suppress = handlerConfig.suppressOnInteractiveElement;


### PR DESCRIPTION
This adds a condition that checks for trusted events in KeyCombinationHandler so that Navigator does not receive synthetic keydowns (e.g. a script triggering key combinations within EPUB/Webpub).