### PR TITLE
Fix location.time()

### DIFF
--- a/shared/src/publication/html/Locations.ts
+++ b/shared/src/publication/html/Locations.ts
@@ -113,7 +113,7 @@ LocatorLocations.prototype.page = function(): number | undefined {
 
 LocatorLocations.prototype.time = function(): number | undefined {
   // TODO more sophiticated parsing
-  const i = parseInt(this.fragmentParameters().get("t")!);
+  const i = parseFloat(this.fragmentParameters().get("t")!);
   if(!isNaN(i)) return i;
   return undefined;
 }

--- a/shared/src/publication/html/Locations.ts
+++ b/shared/src/publication/html/Locations.ts
@@ -1,5 +1,6 @@
 import { LocatorLocations } from '../Locator.ts';
 import { DomRange } from './DomRange.ts';
+import { parseNptTime } from '../../util/npt.ts';
 
 // HTML extensions for [Locations].
 // https://github.com/readium/architecture/blob/master/models/locators/extensions/html.md
@@ -112,10 +113,9 @@ LocatorLocations.prototype.page = function(): number | undefined {
 }
 
 LocatorLocations.prototype.time = function(): number | undefined {
-  // TODO more sophiticated parsing
-  const i = parseFloat(this.fragmentParameters().get("t")!);
-  if(!isNaN(i)) return i;
-  return undefined;
+  const raw = this.fragmentParameters().get("t");
+  if (!raw) return undefined;
+  return parseNptTime(raw);
 }
 
 LocatorLocations.prototype.space = function(): [number, number, number, number] | undefined {

--- a/shared/src/publication/services/timeline/Timeline.ts
+++ b/shared/src/publication/services/timeline/Timeline.ts
@@ -1,6 +1,7 @@
 import { Link, Links } from "../../Link.ts";
 import { Locator } from "../../Locator.ts";
 import { TimelineItem } from "./TimelineItem.ts";
+import { isNptStartOfResource, parseNptTime } from "../../../util/npt.ts";
 
 interface PublicationLike {
     toc?: Links;
@@ -271,15 +272,14 @@ export class Timeline {
 
     /**
      * A TOC href points to the start of its resource when it has no fragment,
-     * or when the fragment contains a parsable `t=` value of 0 (audio: explicit
-     * beginning of the file).  Accepts decimals and extra params, e.g. `t=0.0`
-     * or `foo=bar&t=0`.
+     * or when the fragment contains a parsable NPT `t=` value of 0 (audio:
+     * explicit beginning of the file).
      */
     private static isStartOfResource(href: string): boolean {
         const fragment = href.split("#")[1];
         if (!fragment) return true;
-        const match = fragment.match(/(?:^|&)t=(\d+(?:\.\d+)?)/);
-        return match !== null && parseFloat(match[1]) === 0;
+        const match = fragment.match(/(?:^|&)t=([^&]+)/);
+        return match !== null && isNptStartOfResource(match[1]);
     }
 
     // -------------------------------------------------------------------------
@@ -322,8 +322,8 @@ export class Timeline {
             const effectiveHref = refHref || this.bareHrefFromItem(item);
             if (effectiveHref !== href) continue;
             if (!refFragment) return undefined;
-            const match = refFragment.match(/(?:^|&)t=(\d+(?:\.\d+)?)/);
-            return match ? parseFloat(match[1]) : undefined;
+            const match = refFragment.match(/(?:^|&)t=([^&]+)/);
+            return match ? parseNptTime(match[1]) : undefined;
         }
         return undefined;
     }
@@ -337,8 +337,8 @@ export class Timeline {
         if (!ref) return undefined;
         const fragment = ref.split("#")[1];
         if (!fragment) return undefined;
-        const match = fragment.match(/(?:^|&)t=(\d+(?:\.\d+)?)/);
-        return match ? parseFloat(match[1]) : undefined;
+        const match = fragment.match(/(?:^|&)t=([^&]+)/);
+        return match ? parseNptTime(match[1]) : undefined;
     }
 
     private ancestorPath(items: TimelineItem[], target: TimelineItem): TimelineItem[] | null {

--- a/shared/src/util/index.ts
+++ b/shared/src/util/index.ts
@@ -1,5 +1,6 @@
 export * from './mediatype/index.ts';
 export * from './JSONParse.ts';
+export * from './npt.ts';
 export * from './URITemplate.ts';
 export * from './Language.ts';
 export * from './tokenizer/index.ts';

--- a/shared/src/util/npt.ts
+++ b/shared/src/util/npt.ts
@@ -1,0 +1,51 @@
+/**
+ * Parses a W3C Media Fragments NPT (Normal Play Time) temporal value and
+ * returns the corresponding time in seconds.
+ *
+ * Accepts the start of a range expression (e.g. "10,20" → 10).
+ * Handles the optional "npt:" prefix and all three clock formats:
+ *   - Seconds:       "1647.202"  or  "npt:1647.202"
+ *   - MM:SS:         "27:27.2"   or  "npt:27:27.2"
+ *   - HH:MM:SS:      "0:27:27.2" or  "npt:0:27:27.202"
+ *
+ * Returns `undefined` for any value that cannot be parsed.
+ *
+ * https://www.w3.org/TR/media-frags/#naming-time
+ */
+export function parseNptTime(raw: string): number | undefined {
+    const start = raw.split(",")[0].trim();
+    const normalizedStart = start.toLowerCase();
+    const s = normalizedStart.startsWith("npt:") ? start.slice(4) : start;
+    const parts = s.split(":");
+
+    if (parts.length === 1) {
+        const sec = parseFloat(parts[0]);
+        return isNaN(sec) ? undefined : sec;
+    }
+
+    if (parts.length === 2) {
+        const min = parseInt(parts[0], 10);
+        const sec = parseFloat(parts[1]);
+        if (isNaN(min) || isNaN(sec)) return undefined;
+        return min * 60 + sec;
+    }
+
+    if (parts.length === 3) {
+        const hr = parseInt(parts[0], 10);
+        const min = parseInt(parts[1], 10);
+        const sec = parseFloat(parts[2]);
+        if (isNaN(hr) || isNaN(min) || isNaN(sec)) return undefined;
+        return hr * 3600 + min * 60 + sec;
+    }
+
+    return undefined;
+}
+
+/**
+ * Returns true when the NPT time value represents the start of a resource
+ * (t=0, t=0.0, t=npt:0, t=npt:0:0:0, etc.).
+ */
+export function isNptStartOfResource(raw: string): boolean {
+    const t = parseNptTime(raw);
+    return t !== undefined && t === 0;
+}


### PR DESCRIPTION
Timeline was struggling to derive adjacent items in some publications because of decimals. This fixes the `LocatorLocations.time()` function.  

I also added parsing of `NPT` media fragments to be spec-compliant since the function was marked as `TODO`. 