### PR TITLE
Fix blank iframe after remount by setting iframe.src on load

### DIFF
--- a/navigator/src/epub/frame/FrameManager.ts
+++ b/navigator/src/epub/frame/FrameManager.ts
@@ -66,7 +66,7 @@ export class FrameManager {
             this.frame.onerror = (err) => {
                 try { rej(err); } catch (error) {}
             }
-            this.frame.contentWindow!.location.replace(this.source);
+            this.frame.src = this.source;
         });
     }
 

--- a/navigator/src/epub/fxl/FXLFrameManager.ts
+++ b/navigator/src/epub/fxl/FXLFrameManager.ts
@@ -99,7 +99,7 @@ export class FXLFrameManager {
                 try { rej(e.error); this.loadPromise = undefined; } catch (error) {};
             }, { once: true });
             this.frame.style.removeProperty("display");
-            this.frame.contentWindow!.location.replace(this.source);
+            this.frame.src = this.source;
         });
         return this.loadPromise;
     }
@@ -187,7 +187,7 @@ export class FXLFrameManager {
                 try { this.showPromise = undefined; rej(e.error); } catch (error) {};
             }, { once: true });
             this.source = "about:blank";
-            this.frame.contentWindow!.location.replace("about:blank");
+            this.frame.src = this.source;
             this.frame.style.display = "none";
         });
     }

--- a/navigator/src/webpub/WebPubFrameManager.ts
+++ b/navigator/src/webpub/WebPubFrameManager.ts
@@ -64,7 +64,7 @@ export class WebPubFrameManager {
             this.frame.onerror = (err) => {
                 try { rej(err); } catch (error) {}
             }
-            this.frame.contentWindow!.location.replace(this.source);
+            this.frame.src = this.source;
         });
     }
 


### PR DESCRIPTION
This fixes #238

The frame managers loaded blob content with `contentWindow.location.replace()` and never set `iframe.src`, so the attribute stayed at `about:blank`, provoking later for remount/reparent to restore a blank document while the iframe stayed in the DOM.

This fixes it via setting `iframe.src = source` in FrameManager, FXLFrameManager and WebPubFrameManager.