### PR TITLE
Timeline improvements

### DIFF
--- a/navigator-html-injectables/CHANGELOG.MD
+++ b/navigator-html-injectables/CHANGELOG.MD
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.6.3] – 2026-07-23
 
-### Fixed
+### Changed
 
-- Snappers' rect-based fallback now also checks whether a fragment currently overlaps the center band, matching `IntersectionObserver`'s `intersectionRatio`, before falling back to "last fragment scrolled past" — keeping the two current-fragment resolution paths in sync ([#244](https://github.com/readium/ts-toolkit/pull/244))
+- Scroll-based tracking of the reader's position no longer relies on `IntersectionObserver` at all — current position and everything currently visible are now computed directly from live scroll position instead. As a result, every part of a resource currently on screen can now be reported, not just a single current spot ([#244](https://github.com/readium/ts-toolkit/pull/244))
 
 ## [2.6.2] – 2026-07-22
 

--- a/navigator-html-injectables/CHANGELOG.MD
+++ b/navigator-html-injectables/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.3] – 2026-07-23
+
+### Fixed
+
+- Snappers' rect-based fallback now also checks whether a fragment currently overlaps the center band, matching `IntersectionObserver`'s `intersectionRatio`, before falling back to "last fragment scrolled past" — keeping the two current-fragment resolution paths in sync ([#244](https://github.com/readium/ts-toolkit/pull/244))
+
 ## [2.6.2] – 2026-07-22
 
 ### Fixed

--- a/navigator-html-injectables/package.json
+++ b/navigator-html-injectables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator-html-injectables",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "type": "module",
   "description": "An embeddable solution for connecting frames of HTML publications with a Readium Navigator",
   "author": "readium",

--- a/navigator-html-injectables/src/modules/snapper/CJKVerticalSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/CJKVerticalSnapper.ts
@@ -81,6 +81,28 @@ export class CJKVerticalSnapper extends Snapper {
         return this.verticalLR ? rect.right <= center + tolerance : rect.left >= center - tolerance;
     }
 
+    /**
+     * Overlap as a fraction of the element's own width, matching IntersectionObserver's
+     * intersectionRatio — a plain overlap test would keep a large wrapping element "in
+     * band" for its entire on-screen span, masking smaller fragments nested inside it.
+     * Direction-agnostic (unlike `hasScrolledPast`): overlap ratio is the same question
+     * regardless of vertical-lr/vertical-rl.
+     */
+    protected inCenterBand(el: Element): boolean {
+        const rect = el.getBoundingClientRect();
+        const center = this.wnd.innerWidth / 2;
+        const tolerance = this.wnd.innerWidth * Snapper.CENTER_TOLERANCE;
+        const bandLeft = center - tolerance;
+        const bandRight = center + tolerance;
+        if (rect.width === 0) {
+            // Zero-area landmark: ratio is undefined (0/0) by spec, same case
+            // `isVisibleEntry` handles for the observer path — fall back to a point check.
+            return rect.left <= bandRight && rect.left >= bandLeft;
+        }
+        const overlap = Math.max(0, Math.min(rect.right, bandRight) - Math.max(rect.left, bandLeft));
+        return overlap / rect.width >= Snapper.CENTER_TOLERANCE;
+    }
+
     private reportProgress(forcedFragmentId?: string) {
         if (!this.comms.ready) return;
         const scrollWidth = this.doc().scrollWidth;

--- a/navigator-html-injectables/src/modules/snapper/CJKVerticalSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/CJKVerticalSnapper.ts
@@ -390,6 +390,9 @@ export class CJKVerticalSnapper extends Snapper {
         }
 
         this.timelineEntries.clear();
+        this.cachedFragmentIds = [];
+        this.sortedFragmentIds = [];
+        this.cachedFragmentStarts.clear();
 
         comms.log("CJKVerticalSnapper Unmounted");
         return true;

--- a/navigator-html-injectables/src/modules/snapper/CJKVerticalSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/CJKVerticalSnapper.ts
@@ -71,8 +71,7 @@ export class CJKVerticalSnapper extends Snapper {
     protected hasScrolledPast(el: Element): boolean {
         // go_id/go_text center the target in the viewport, not scroll it to the edge —
         // so "reached" has to mean "crossed the viewport's horizontal center", the same
-        // line navigation scrolls to, not the leading edge. The tolerance matches
-        // setupTimelineObserver's rootMargin so both agree even with scrollLeft rounding.
+        // line navigation scrolls to, not the leading edge.
         const rect = el.getBoundingClientRect();
         const center = this.wnd.innerWidth / 2;
         const tolerance = this.wnd.innerWidth * Snapper.CENTER_TOLERANCE;
@@ -95,12 +94,24 @@ export class CJKVerticalSnapper extends Snapper {
         const bandLeft = center - tolerance;
         const bandRight = center + tolerance;
         if (rect.width === 0) {
-            // Zero-area landmark: ratio is undefined (0/0) by spec, same case
-            // `isVisibleEntry` handles for the observer path — fall back to a point check.
+            // Zero-area landmark: ratio is undefined (0/0) by spec — fall back to a point check.
             return rect.left <= bandRight && rect.left >= bandLeft;
         }
         const overlap = Math.max(0, Math.min(rect.right, bandRight) - Math.max(rect.left, bandLeft));
         return overlap / rect.width >= Snapper.CENTER_TOLERANCE;
+    }
+
+    /**
+     * Document-absolute (scrollLeft-independent) leading-edge position. Uses the same
+     * `Math.abs(scrollLeft)` normalization as `reportProgress` so this stays in the same
+     * coordinate space as the live scroll position regardless of vertical-lr/rl sign.
+     */
+    protected fragmentStart(el: Element): number {
+        return el.getBoundingClientRect().left + Math.abs(this.doc().scrollLeft);
+    }
+
+    protected currentScrollExtent(): { pos: number; size: number } {
+        return { pos: Math.abs(this.doc().scrollLeft), size: this.wnd.innerWidth };
     }
 
     private reportProgress(forcedFragmentId?: string) {
@@ -118,7 +129,8 @@ export class CJKVerticalSnapper extends Snapper {
         this.comms.send("progress", {
             start: progress,
             end: viewportEnd,
-            fragmentId: forcedFragmentId !== undefined ? forcedFragmentId : this.currentTimelineFragment()
+            fragmentId: forcedFragmentId !== undefined ? forcedFragmentId : this.currentTimelineFragment(),
+            visibleFragmentIds: this.sortedVisibleFragmentIds()
         });
     }
 
@@ -186,7 +198,6 @@ export class CJKVerticalSnapper extends Snapper {
     mount(wnd: ReadiumWindow, comms: Comms): boolean {
         this.wnd = wnd;
         this.comms = comms;
-        this.setupTimelineObserver("horizontal");
 
         this.initialScrollHandled = false;
         this.lastScrollLeft = 0;
@@ -225,6 +236,7 @@ export class CJKVerticalSnapper extends Snapper {
             this.resizeDebounce = this.wnd.setTimeout(() => {
                 this.isResizing = false;
                 this.resizeDebounce = null;
+                this.refreshFragmentStarts();
                 this.reportProgress();
             }, 50);
         });
@@ -377,9 +389,6 @@ export class CJKVerticalSnapper extends Snapper {
             this.isScrollProtectionEnabled = false;
         }
 
-        this.timelineObserver?.disconnect();
-        this.timelineObserver = null;
-        this.visibleFragmentIds.clear();
         this.timelineEntries.clear();
 
         comms.log("CJKVerticalSnapper Unmounted");

--- a/navigator-html-injectables/src/modules/snapper/ColumnSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ColumnSnapper.ts
@@ -105,6 +105,18 @@ export class ColumnSnapper extends Snapper {
         return result;
     }
 
+    /**
+     * Tests each fragment's rect directly against the current column viewport, returning
+     * every one actually on screen rather than only the last one to have started.
+     */
+    protected sortedVisibleFragmentIds(): string[] {
+        const vw = this.wnd.innerWidth;
+        return this.sortedFragmentIds.filter(id => {
+            const rect = this.timelineEntries.get(id)!.getBoundingClientRect();
+            return this.rtl ? (rect.left < vw && rect.right > 0) : (rect.right > 0 && rect.left < vw);
+        });
+    }
+
     reportProgress(forcedFragmentId?: string) {
         const scrollWidth = this.cachedScrollWidth;
         const viewportWidth = this.wnd.innerWidth;
@@ -117,7 +129,8 @@ export class ColumnSnapper extends Snapper {
         this.comms.send("progress", {
             start: progress,
             end: viewportEnd,
-            fragmentId: forcedFragmentId !== undefined ? forcedFragmentId : this.currentTimelineFragment()
+            fragmentId: forcedFragmentId !== undefined ? forcedFragmentId : this.currentTimelineFragment(),
+            visibleFragmentIds: this.sortedVisibleFragmentIds()
         });
     }
 

--- a/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
@@ -40,8 +40,7 @@ export class ScrollSnapper extends Snapper {
     protected hasScrolledPast(el: Element): boolean {
         // go_id/go_text center the target in the viewport, not scroll it to the top —
         // so "reached" has to mean "crossed the viewport's vertical center", the same
-        // line navigation scrolls to, not the top/bottom edge. The tolerance matches
-        // setupTimelineObserver's rootMargin so both agree even with scrollTop rounding.
+        // line navigation scrolls to, not the top/bottom edge.
         const center = this.wnd.innerHeight / 2;
         return el.getBoundingClientRect().top <= center + this.wnd.innerHeight * Snapper.CENTER_TOLERANCE;
     }
@@ -58,12 +57,20 @@ export class ScrollSnapper extends Snapper {
         const bandTop = center - tolerance;
         const bandBottom = center + tolerance;
         if (rect.height === 0) {
-            // Zero-area landmark: ratio is undefined (0/0) by spec, same case
-            // `isVisibleEntry` handles for the observer path — fall back to a point check.
+            // Zero-area landmark: ratio is undefined (0/0) by spec — fall back to a point check.
             return rect.top <= bandBottom && rect.top >= bandTop;
         }
         const overlap = Math.max(0, Math.min(rect.bottom, bandBottom) - Math.max(rect.top, bandTop));
         return overlap / rect.height >= Snapper.CENTER_TOLERANCE;
+    }
+
+    /** Document-absolute (scrollTop-independent) leading-edge position. */
+    protected fragmentStart(el: Element): number {
+        return el.getBoundingClientRect().top + this.doc().scrollTop;
+    }
+
+    protected currentScrollExtent(): { pos: number; size: number } {
+        return { pos: this.doc().scrollTop, size: this.wnd.innerHeight };
     }
 
     private reportProgress(forcedFragmentId?: string) {
@@ -80,7 +87,8 @@ export class ScrollSnapper extends Snapper {
         this.comms.send("progress", {
             start: progress,
             end: viewportEnd,
-            fragmentId: forcedFragmentId !== undefined ? forcedFragmentId : this.currentTimelineFragment()
+            fragmentId: forcedFragmentId !== undefined ? forcedFragmentId : this.currentTimelineFragment(),
+            visibleFragmentIds: this.sortedVisibleFragmentIds()
         });
     }
 
@@ -154,7 +162,6 @@ export class ScrollSnapper extends Snapper {
     mount(wnd: ReadiumWindow, comms: Comms): boolean {
         this.wnd = wnd;
         this.comms = comms;
-        this.setupTimelineObserver();
 
         this.initialScrollHandled = false;
         this.lastScrollTop = 0;
@@ -193,6 +200,7 @@ export class ScrollSnapper extends Snapper {
             this.resizeDebounce = this.wnd.setTimeout(() => {
                 this.isResizing = false;
                 this.resizeDebounce = null;
+                this.refreshFragmentStarts();
                 this.reportProgress();
             }, 50);
         });
@@ -342,9 +350,6 @@ export class ScrollSnapper extends Snapper {
         this.resizeObserver.disconnect();
         if (this.handleScroll) wnd.removeEventListener("scroll", this.handleScroll);
         wnd.document.getElementById(SCROLL_SNAPPER_STYLE_ID)?.remove();
-        this.timelineObserver?.disconnect();
-        this.timelineObserver = null;
-        this.visibleFragmentIds.clear();
         this.timelineEntries.clear();
 
         if (this.patternAnalyzer) {

--- a/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
@@ -351,6 +351,9 @@ export class ScrollSnapper extends Snapper {
         if (this.handleScroll) wnd.removeEventListener("scroll", this.handleScroll);
         wnd.document.getElementById(SCROLL_SNAPPER_STYLE_ID)?.remove();
         this.timelineEntries.clear();
+        this.cachedFragmentIds = [];
+        this.sortedFragmentIds = [];
+        this.cachedFragmentStarts.clear();
 
         if (this.patternAnalyzer) {
             this.patternAnalyzer.clear();

--- a/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/ScrollSnapper.ts
@@ -46,6 +46,26 @@ export class ScrollSnapper extends Snapper {
         return el.getBoundingClientRect().top <= center + this.wnd.innerHeight * Snapper.CENTER_TOLERANCE;
     }
 
+    /**
+     * Overlap as a fraction of the element's own height, matching IntersectionObserver's
+     * intersectionRatio — a plain overlap test would keep a large wrapping element "in
+     * band" for its entire on-screen span, masking smaller fragments nested inside it.
+     */
+    protected inCenterBand(el: Element): boolean {
+        const rect = el.getBoundingClientRect();
+        const center = this.wnd.innerHeight / 2;
+        const tolerance = this.wnd.innerHeight * Snapper.CENTER_TOLERANCE;
+        const bandTop = center - tolerance;
+        const bandBottom = center + tolerance;
+        if (rect.height === 0) {
+            // Zero-area landmark: ratio is undefined (0/0) by spec, same case
+            // `isVisibleEntry` handles for the observer path — fall back to a point check.
+            return rect.top <= bandBottom && rect.top >= bandTop;
+        }
+        const overlap = Math.max(0, Math.min(rect.bottom, bandBottom) - Math.max(rect.top, bandTop));
+        return overlap / rect.height >= Snapper.CENTER_TOLERANCE;
+    }
+
     private reportProgress(forcedFragmentId?: string) {
         if (!this.comms.ready) return;
         // We have to round up the scroll position because

--- a/navigator-html-injectables/src/modules/snapper/Snapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/Snapper.ts
@@ -44,6 +44,7 @@ export abstract class Snapper extends Module {
     protected updateTimelineEntries(ids: string[], wnd: ReadiumWindow): void {
         this.cachedFragmentIds = ids;
         this.timelineEntries.clear();
+        this.cachedFragmentStarts.clear();
         for (const id of ids) {
             const el = wnd.document.getElementById(id);
             if (el) this.timelineEntries.set(id, el);
@@ -222,6 +223,11 @@ export abstract class Snapper extends Module {
 
     unmount(wnd: ReadiumWindow, comms: Comms): boolean {
         wnd.document.getElementById(SNAPPER_STYLE_ID)?.remove();
+
+        this.timelineEntries.clear();
+        this.cachedFragmentIds = [];
+        this.sortedFragmentIds = [];
+        this.cachedFragmentStarts.clear();
 
         comms.log("Snapper Unmounted");
         return true;

--- a/navigator-html-injectables/src/modules/snapper/Snapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/Snapper.ts
@@ -8,21 +8,24 @@ const SNAPPER_STYLE_ID = "readium-snapper-style";
 export abstract class Snapper extends Module {
     static readonly moduleName: ModuleName = "snapper";
 
-    // Shared by the observer's rootMargin and every hasScrolledPast implementation so both
-    // stay pinned to the exact same boundary. Sized to comfortably exceed realistic
-    // scrollTop-rounding error (~1px) while still reading as "the center", not a wide band.
+    // Shared by every hasScrolledPast/inCenterBand implementation so they stay pinned to the
+    // exact same boundary. Sized to comfortably exceed realistic scrollTop-rounding error
+    // (~1px) while still reading as "the center", not a wide band.
     protected static readonly CENTER_TOLERANCE = 0.01;
 
     private protected = false;
 
     // Timeline fragment tracking
-    protected timelineObserver: IntersectionObserver | null = null;
     protected timelineEntries: Map<string, Element> = new Map();
-    protected visibleFragmentIds: Set<string> = new Set();
     protected cachedFragmentIds: string[] = [];
     // DOM-order-sorted fragment ids, recomputed only when entries are (re)populated —
     // sorting on every progress report (i.e. every scroll frame) is wasted work.
     protected sortedFragmentIds: string[] = [];
+    // Document-absolute leading-edge position per fragment, refreshed on (re)population and
+    // resize only, never per scroll frame. A single point, not a start/end range: some TOC
+    // ids sit on wrapping elements that contain everything after them (a whole chapter's
+    // <section>), so an element's own height isn't a trustworthy measure of where it ends.
+    protected cachedFragmentStarts: Map<string, number> = new Map();
 
     private static inDomOrder(entries: Map<string, Element>, a: string, b: string): number {
         const ea = entries.get(a);
@@ -33,76 +36,55 @@ export abstract class Snapper extends Module {
     }
 
     /**
-     * A zero-area target (e.g. an empty `<a id="…">` landmark) always has
-     * intersectionRatio 0 by spec, so `isIntersecting` can never become true for it —
-     * no threshold value changes that. For those entries, fall back to a geometric
-     * containment check against `rootBounds` instead of trusting `isIntersecting`.
-     */
-    private static isVisibleEntry(entry: IntersectionObserverEntry): boolean {
-        const rect = entry.boundingClientRect;
-        // Element has real width and height: isIntersecting is spec-correct, trust it as-is.
-        if (rect.width > 0 && rect.height > 0) return entry.isIntersecting;
-        // Zero-width or zero-height element: isIntersecting is stuck at false (ratio is
-        // area / 0, defined as 0), so it can't be trusted. Do our own overlap check instead.
-        const root = entry.rootBounds;
-        if (!root) return entry.isIntersecting;
-        return rect.left <= root.right && rect.right >= root.left &&
-            rect.top <= root.bottom && rect.bottom >= root.top;
-    }
-
-    /**
-     * Collapses the observer's root to a thin band around the same center line
-     * `hasScrolledPast` tests against (go_id/go_text navigate by centering the target, not by
-     * aligning it to an edge), so "intersecting" and "scrolled past" can't disagree about
-     * where "current" is. A literal zero-height root would make every intersection area zero
-     * — isIntersecting would never fire — so CENTER_TOLERANCE leaves it a real, if thin, band.
-     * Percentage-based margins track viewport resizes automatically, no re-setup needed.
-     */
-    protected setupTimelineObserver(axis: "vertical" | "horizontal" = "vertical"): void {
-        if (this.timelineObserver) this.timelineObserver.disconnect();
-        const inset = `-${50 - Snapper.CENTER_TOLERANCE * 100}%`;
-        this.timelineObserver = new IntersectionObserver(
-            (entries) => {
-                for (const entry of entries) {
-                    if (Snapper.isVisibleEntry(entry))
-                        this.visibleFragmentIds.add((entry.target as HTMLElement).id);
-                    else
-                        this.visibleFragmentIds.delete((entry.target as HTMLElement).id);
-                }
-            },
-            {
-                threshold: [0.01],
-                rootMargin: axis === "vertical" ? `${inset} 0px ${inset} 0px` : `0px ${inset} 0px ${inset}`
-            }
-        );
-    }
-
-    /**
-     * Populates `timelineEntries`/`sortedFragmentIds` from a fresh id list, and
-     * (re)starts IntersectionObserver-based visibility tracking for subclasses that use it.
-     * Shared by all snappers' `timeline_entries` comms handler so DOM-order sorting and
-     * observer bookkeeping only happen once per (re)population, not per report.
+     * Populates `timelineEntries`/`sortedFragmentIds` from a fresh id list, and refreshes
+     * `cachedFragmentStarts` for the new elements. Shared by all snappers' `timeline_entries`
+     * comms handler so DOM-order sorting and position caching only happen once per
+     * (re)population, not per report.
      */
     protected updateTimelineEntries(ids: string[], wnd: ReadiumWindow): void {
         this.cachedFragmentIds = ids;
-        this.timelineObserver?.disconnect();
-        this.visibleFragmentIds.clear();
         this.timelineEntries.clear();
         for (const id of ids) {
             const el = wnd.document.getElementById(id);
-            if (el) {
-                this.timelineEntries.set(id, el);
-                this.timelineObserver?.observe(el);
-            }
+            if (el) this.timelineEntries.set(id, el);
         }
         this.sortedFragmentIds = Array.from(this.timelineEntries.keys())
             .sort((a, b) => Snapper.inDomOrder(this.timelineEntries, a, b));
+        this.refreshFragmentStarts();
+    }
+
+    /**
+     * Recomputes `cachedFragmentStarts` for every tracked fragment. Call whenever layout may
+     * have changed — on (re)population here, and from each snapper's own resize handler.
+     */
+    protected refreshFragmentStarts(): void {
+        for (const [id, el] of this.timelineEntries) {
+            this.cachedFragmentStarts.set(id, this.fragmentStart(el));
+        }
+    }
+
+    /**
+     * Axis-appropriate, document-absolute leading-edge position of `el`. Subclasses with a
+     * scroll axis override this; `ColumnSnapper` doesn't use the cache (it has its own
+     * rect-based visibility test) so keeps this no-op default.
+     */
+    protected fragmentStart(_el: Element): number {
+        return 0;
+    }
+
+    /**
+     * The current viewport's position and size along the scroll axis, in the same
+     * document-absolute coordinate space as `fragmentStart`. Paired with it to test
+     * on-screen-ness without any per-frame geometry read.
+     */
+    protected currentScrollExtent(): { pos: number; size: number } {
+        return { pos: 0, size: 0 };
     }
 
     /**
      * Returns the nearest fragment at or before `node` in DOM (reading) order, with no
      * dependency on rendered geometry — safe to call for programmatic navigation where the
-     * target is already known, regardless of whether layout/IntersectionObserver has settled.
+     * target is already known, regardless of whether layout has settled.
      */
     protected nearestPrecedingTimelineEntry(node: Node): string | undefined {
         let nearestId: string | undefined;
@@ -118,11 +100,10 @@ export abstract class Snapper extends Module {
     }
 
     /**
-     * Rect-based scan, used only as a fallback while IntersectionObserver hasn't reported
-     * anything yet. Mirrors the observer's own tie-break so the two can't disagree: first
-     * checks for a fragment currently in the center band (same "first in DOM order" rule as
-     * `currentTimelineFragment`'s primary path), and only if none is currently in the band
-     * falls back to the last fragment whose leading edge has been scrolled past.
+     * Rect-based scan for an accurate one-off read right after a programmatic jump
+     * (go_id/go_text), before the next scroll event would otherwise refresh things: first
+     * checks for a fragment currently in the center band, and only if none is currently in
+     * the band falls back to the last fragment whose leading edge has been scrolled past.
      */
     protected fragmentFromGeometry(): string | undefined {
         for (const id of this.sortedFragmentIds) {
@@ -154,20 +135,43 @@ export abstract class Snapper extends Module {
     }
 
     /**
-     * Returns the ID of the currently active timeline fragment:
-     * 1. Primary — IntersectionObserver: returns the first visible element in DOM (reading) order.
-     *    This is direction-agnostic; works for LTR, RTL, and vertical writing modes. Reliable for
-     *    continuous, gradual scrolling.
-     * 2. Fallback — rect scan (`fragmentFromGeometry`): used when IntersectionObserver hasn't
-     *    fired yet. Not reliable right after an instantaneous programmatic jump — callers that
-     *    know the target (goTo-style navigation) should bypass this method entirely.
+     * Returns the ID of the currently active timeline fragment: the last fragment in DOM
+     * order whose cached leading edge is at or before the viewport's center point — the same
+     * center line `hasScrolledPast`/`go_id`/`go_text` navigate to.
      */
     protected currentTimelineFragment(): string | undefined {
-        if (this.visibleFragmentIds.size > 0) {
-            return Array.from(this.visibleFragmentIds)
-                .sort((a, b) => Snapper.inDomOrder(this.timelineEntries, a, b))[0];
+        const { pos, size } = this.currentScrollExtent();
+        const center = pos + size / 2;
+        let nearestId: string | undefined;
+        for (const id of this.sortedFragmentIds) {
+            const start = this.cachedFragmentStarts.get(id);
+            if (start === undefined) continue;
+            if (start <= center) nearestId = id;
+            else break;
         }
-        return this.fragmentFromGeometry();
+        return nearestId;
+    }
+
+    /**
+     * Every timeline fragment currently on screen, in DOM order — not just the single one
+     * `currentTimelineFragment` picks. Since fragments are ordered points, not ranges, "on
+     * screen" means the run of fragments whose leading edges fall between whichever one
+     * governs the viewport's top edge and whichever falls before its bottom edge.
+     */
+    protected sortedVisibleFragmentIds(): string[] {
+        const { pos, size } = this.currentScrollExtent();
+        const bottom = pos + size;
+        let from = -1;
+        let to = -1;
+        for (let i = 0; i < this.sortedFragmentIds.length; i++) {
+            const start = this.cachedFragmentStarts.get(this.sortedFragmentIds[i]);
+            if (start === undefined) continue;
+            if (start <= pos) from = i;
+            if (start < bottom) to = i;
+        }
+        if (from < 0) from = 0;
+        if (to < from) return [];
+        return this.sortedFragmentIds.slice(from, to + 1);
     }
 
     /**
@@ -178,9 +182,9 @@ export abstract class Snapper extends Module {
     protected abstract hasScrolledPast(el: Element): boolean;
 
     /**
-     * Whether the element currently overlaps `setupTimelineObserver`'s center band, not
-     * merely "already scrolled past" it. Defaults to `false` for subclasses with no
-     * center-line concept (e.g. paginated `ColumnSnapper`).
+     * Whether the element currently overlaps the viewport's center band, not merely
+     * "already scrolled past" it. Defaults to `false` for subclasses with no center-line
+     * concept (e.g. paginated `ColumnSnapper`).
      */
     protected inCenterBand(_el: Element): boolean {
         return false;

--- a/navigator-html-injectables/src/modules/snapper/Snapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/Snapper.ts
@@ -118,12 +118,18 @@ export abstract class Snapper extends Module {
     }
 
     /**
-     * Rect-based scan: last element in DOM order whose leading edge has already been
-     * scrolled past. Subclasses implement `hasScrolledPast` for their layout/axis.
-     * Exposed so callers can force an accurate one-off geometry check (e.g. right after
-     * a `go_progression` jump) instead of trusting a possibly-stale visibility cache.
+     * Rect-based scan, used only as a fallback while IntersectionObserver hasn't reported
+     * anything yet. Mirrors the observer's own tie-break so the two can't disagree: first
+     * checks for a fragment currently in the center band (same "first in DOM order" rule as
+     * `currentTimelineFragment`'s primary path), and only if none is currently in the band
+     * falls back to the last fragment whose leading edge has been scrolled past.
      */
     protected fragmentFromGeometry(): string | undefined {
+        for (const id of this.sortedFragmentIds) {
+            const el = this.timelineEntries.get(id)!;
+            if (this.inCenterBand(el)) return id;
+        }
+
         let nearestId: string | undefined;
         for (const id of this.sortedFragmentIds) {
             const el = this.timelineEntries.get(id)!;
@@ -170,6 +176,15 @@ export abstract class Snapper extends Module {
      * Subclasses implement this for their specific scroll axis and reading direction.
      */
     protected abstract hasScrolledPast(el: Element): boolean;
+
+    /**
+     * Whether the element currently overlaps `setupTimelineObserver`'s center band, not
+     * merely "already scrolled past" it. Defaults to `false` for subclasses with no
+     * center-line concept (e.g. paginated `ColumnSnapper`).
+     */
+    protected inCenterBand(_el: Element): boolean {
+        return false;
+    }
 
     buildStyles() {
         return `

--- a/navigator-html-injectables/src/modules/snapper/WebPubSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/WebPubSnapper.ts
@@ -34,8 +34,7 @@ export class WebPubSnapper extends Snapper {
     protected hasScrolledPast(el: Element): boolean {
         // go_id/go_text center the target in the viewport, not scroll it to the top —
         // so "reached" has to mean "crossed the viewport's vertical center", the same
-        // line navigation scrolls to, not the top/bottom edge. The tolerance matches
-        // setupTimelineObserver's rootMargin so both agree even with scrollTop rounding.
+        // line navigation scrolls to, not the top/bottom edge.
         const center = this.wnd.innerHeight / 2;
         return el.getBoundingClientRect().top <= center + this.wnd.innerHeight * Snapper.CENTER_TOLERANCE;
     }
@@ -52,12 +51,20 @@ export class WebPubSnapper extends Snapper {
         const bandTop = center - tolerance;
         const bandBottom = center + tolerance;
         if (rect.height === 0) {
-            // Zero-area landmark: ratio is undefined (0/0) by spec, same case
-            // `isVisibleEntry` handles for the observer path — fall back to a point check.
+            // Zero-area landmark: ratio is undefined (0/0) by spec — fall back to a point check.
             return rect.top <= bandBottom && rect.top >= bandTop;
         }
         const overlap = Math.max(0, Math.min(rect.bottom, bandBottom) - Math.max(rect.top, bandTop));
         return overlap / rect.height >= Snapper.CENTER_TOLERANCE;
+    }
+
+    /** Document-absolute (scrollTop-independent) leading-edge position. */
+    protected fragmentStart(el: Element): number {
+        return el.getBoundingClientRect().top + this.doc().scrollTop;
+    }
+
+    protected currentScrollExtent(): { pos: number; size: number } {
+        return { pos: this.doc().scrollTop, size: this.wnd.innerHeight };
     }
 
     private reportProgress(forcedFragmentId?: string) {
@@ -72,7 +79,8 @@ export class WebPubSnapper extends Snapper {
         this.comms.send("progress", {
             start: progress,
             end: viewportEnd,
-            fragmentId: forcedFragmentId !== undefined ? forcedFragmentId : this.currentTimelineFragment()
+            fragmentId: forcedFragmentId !== undefined ? forcedFragmentId : this.currentTimelineFragment(),
+            visibleFragmentIds: this.sortedVisibleFragmentIds()
         });
     }
 
@@ -145,7 +153,6 @@ export class WebPubSnapper extends Snapper {
     mount(wnd: ReadiumWindow, comms: Comms): boolean {
         this.wnd = wnd;
         this.comms = comms;
-        this.setupTimelineObserver();
 
         this.initialScrollHandled = false;
         this.lastScrollTop = 0;
@@ -165,6 +172,7 @@ export class WebPubSnapper extends Snapper {
             this.resizeDebounce = this.wnd.setTimeout(() => {
                 this.isResizing = false;
                 this.resizeDebounce = null;
+                this.refreshFragmentStarts();
                 this.reportProgress();
             }, 50);
         });
@@ -318,9 +326,6 @@ export class WebPubSnapper extends Snapper {
             this.isScrollProtectionEnabled = false;
         }
 
-        this.timelineObserver?.disconnect();
-        this.timelineObserver = null;
-        this.visibleFragmentIds.clear();
         this.timelineEntries.clear();
 
         comms.log("WebPubSnapper Unmounted");

--- a/navigator-html-injectables/src/modules/snapper/WebPubSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/WebPubSnapper.ts
@@ -327,6 +327,9 @@ export class WebPubSnapper extends Snapper {
         }
 
         this.timelineEntries.clear();
+        this.cachedFragmentIds = [];
+        this.sortedFragmentIds = [];
+        this.cachedFragmentStarts.clear();
 
         comms.log("WebPubSnapper Unmounted");
         return true;

--- a/navigator-html-injectables/src/modules/snapper/WebPubSnapper.ts
+++ b/navigator-html-injectables/src/modules/snapper/WebPubSnapper.ts
@@ -40,6 +40,26 @@ export class WebPubSnapper extends Snapper {
         return el.getBoundingClientRect().top <= center + this.wnd.innerHeight * Snapper.CENTER_TOLERANCE;
     }
 
+    /**
+     * Overlap as a fraction of the element's own height, matching IntersectionObserver's
+     * intersectionRatio — a plain overlap test would keep a large wrapping element "in
+     * band" for its entire on-screen span, masking smaller fragments nested inside it.
+     */
+    protected inCenterBand(el: Element): boolean {
+        const rect = el.getBoundingClientRect();
+        const center = this.wnd.innerHeight / 2;
+        const tolerance = this.wnd.innerHeight * Snapper.CENTER_TOLERANCE;
+        const bandTop = center - tolerance;
+        const bandBottom = center + tolerance;
+        if (rect.height === 0) {
+            // Zero-area landmark: ratio is undefined (0/0) by spec, same case
+            // `isVisibleEntry` handles for the observer path — fall back to a point check.
+            return rect.top <= bandBottom && rect.top >= bandTop;
+        }
+        const overlap = Math.max(0, Math.min(rect.bottom, bandBottom) - Math.max(rect.top, bandTop));
+        return overlap / rect.height >= Snapper.CENTER_TOLERANCE;
+    }
+
     private reportProgress(forcedFragmentId?: string) {
         if (!this.comms.ready) return;
 

--- a/navigator/CHANGELOG.MD
+++ b/navigator/CHANGELOG.MD
@@ -13,8 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `EpubNavigator`/`WebPubNavigator` now bind `timeline.navigableFrom()` so that when the current fragment is at its own resource's start, navigation steps from the resource's top-level item instead of resolving back to the same item ([#244](https://github.com/readium/ts-toolkit/pull/244))
-- Snappers (via `@readium/navigator-html-injectables`) now align their rect-based fallback with `IntersectionObserver`'s center-band check, keeping `timeline` in sync when the observer hasn't reported yet ([#244](https://github.com/readium/ts-toolkit/pull/244))
+- `EpubNavigator`/`WebPubNavigator` now bind `timeline.navigableFrom()` so that `previous`/`next` skip every fragment currently visible on screen — not just the single resolved current item — anchoring on the ends of that visible run and, at a resource's actual scroll start, on the outermost ancestor still within that resource ([#244](https://github.com/readium/ts-toolkit/pull/244))
 
 ## [2.7.3] – 2026-07-22
 

--- a/navigator/CHANGELOG.MD
+++ b/navigator/CHANGELOG.MD
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.4] – 2026-07-23
+
+### Changed
+
+- **Breaking:** `Timeline.adjacentTo()` (via `@readium/shared`) has been renamed to `navigableFrom()` ([#244](https://github.com/readium/ts-toolkit/pull/244))
+
+### Fixed
+
+- `EpubNavigator`/`WebPubNavigator` now bind `timeline.navigableFrom()` so that when the current fragment is at its own resource's start, navigation steps from the resource's top-level item instead of resolving back to the same item ([#244](https://github.com/readium/ts-toolkit/pull/244))
+- Snappers (via `@readium/navigator-html-injectables`) now align their rect-based fallback with `IntersectionObserver`'s center-band check, keeping `timeline` in sync when the observer hasn't reported yet ([#244](https://github.com/readium/ts-toolkit/pull/244))
+
 ## [2.7.3] – 2026-07-22
 
 ### Fixed

--- a/navigator/CHANGELOG.MD
+++ b/navigator/CHANGELOG.MD
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.7.4] – 2026-07-23
+## [2.8.0] – 2026-07-23
 
 ### Changed
 

--- a/navigator/docs/Timeline.md
+++ b/navigator/docs/Timeline.md
@@ -147,12 +147,12 @@ progressBar.addEventListener('mousemove', (e) => {
 });
 ```
 
-### `adjacentTo(item)`
+### `navigableFrom(item)`
 
 Returns `{ previous, next }` relative to the given item in the flattened timeline. Both values are `undefined` at the boundaries.
 
 ```ts
-const { previous, next } = navigator.timeline.adjacentTo(currentItem);
+const { previous, next } = navigator.timeline.navigableFrom(currentItem);
 prevButton.disabled = !previous;
 nextButton.disabled = !next;
 prevLabel.textContent = previous?.title ?? '';
@@ -258,7 +258,7 @@ const listeners = {
     currentItem = item;
     if (!item) return;
 
-    const { previous, next } = navigator.timeline.adjacentTo(item);
+    const { previous, next } = navigator.timeline.navigableFrom(item);
     prevChapterButton.disabled = !previous;
     nextChapterButton.disabled = !next;
     prevChapterLabel.textContent = previous?.title ?? '';
@@ -268,7 +268,7 @@ const listeners = {
 
 prevChapterButton.addEventListener('click', () => {
   if (!currentItem) return;
-  const { previous } = navigator.timeline.adjacentTo(currentItem);
+  const { previous } = navigator.timeline.navigableFrom(currentItem);
   if (!previous) return;
   const link = navigator.timeline.linkFor(previous);
   if (link) navigator.go(publication.locatorFromLink(link));
@@ -392,7 +392,7 @@ const listeners: EpubNavigatorListeners = {
     if (!item) return;
 
     // Previous / Next labels
-    const { previous, next } = navigator.timeline.adjacentTo(item);
+    const { previous, next } = navigator.timeline.navigableFrom(item);
     (document.getElementById('prev-chapter') as HTMLButtonElement).disabled = !previous;
     (document.getElementById('next-chapter') as HTMLButtonElement).disabled = !next;
     document.getElementById('prev-label')!.textContent = previous?.title ?? '';
@@ -412,7 +412,7 @@ const navigator = new EpubNavigator(container, publication, listeners, positions
 // Chapter navigation
 document.getElementById('prev-chapter')!.addEventListener('click', () => {
   if (!currentItem) return;
-  const { previous } = navigator.timeline.adjacentTo(currentItem);
+  const { previous } = navigator.timeline.navigableFrom(currentItem);
   if (!previous) return;
   const link = navigator.timeline.linkFor(previous);
   if (link) navigator.go(publication.locatorFromLink(link));
@@ -420,7 +420,7 @@ document.getElementById('prev-chapter')!.addEventListener('click', () => {
 
 document.getElementById('next-chapter')!.addEventListener('click', () => {
   if (!currentItem) return;
-  const { next } = navigator.timeline.adjacentTo(currentItem);
+  const { next } = navigator.timeline.navigableFrom(currentItem);
   if (!next) return;
   const link = navigator.timeline.linkFor(next);
   if (link) navigator.go(publication.locatorFromLink(link));
@@ -451,7 +451,7 @@ const listeners: AudioNavigatorListeners = {
     document.getElementById('chapter-title')!.textContent = item?.title ?? '';
 
     if (!item) return;
-    const { previous, next } = navigator.timeline.adjacentTo(item);
+    const { previous, next } = navigator.timeline.navigableFrom(item);
     document.getElementById('prev-label')!.textContent = previous?.title ?? '';
     document.getElementById('next-label')!.textContent = next?.title ?? '';
   },

--- a/navigator/docs/Timeline.md
+++ b/navigator/docs/Timeline.md
@@ -149,7 +149,9 @@ progressBar.addEventListener('mousemove', (e) => {
 
 ### `navigableFrom(item)`
 
-Returns `{ previous, next }` relative to the given item in the flattened timeline. Both values are `undefined` at the boundaries.
+Returns `{ previous, next }` relative to the given item. Both values are `undefined` at the boundaries.
+
+In `EpubNavigator`/`WebPubNavigator`, `navigator.timeline.navigableFrom()` is visibility-aware: rather than the item's immediate neighbors, it skips over the whole run of items currently visible on screen, anchoring `previous`/`next` on the ends of that visible run. `publication.timeline.navigableFrom()` is unaffected and always returns the item's immediate neighbors in the flattened timeline.
 
 ```ts
 const { previous, next } = navigator.timeline.navigableFrom(currentItem);

--- a/navigator/docs/audio/CustomizingListeners.md
+++ b/navigator/docs/audio/CustomizingListeners.md
@@ -69,7 +69,7 @@ const listeners = {
     chapterTitle.textContent = item?.title ?? '';
 
     if (item) {
-      const { previous, next } = publication.timeline.adjacentTo(item);
+      const { previous, next } = publication.timeline.navigableFrom(item);
       prevButton.disabled = !previous;
       nextButton.disabled = !next;
     }

--- a/navigator/package.json
+++ b/navigator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "type": "module",
   "description": "Next generation SDK for publications in Web Apps",
   "author": "readium",

--- a/navigator/package.json
+++ b/navigator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator",
-  "version": "2.7.4",
+  "version": "2.8.0",
   "type": "module",
   "description": "Next generation SDK for publications in Web Apps",
   "author": "readium",

--- a/navigator/src/Navigator.ts
+++ b/navigator/src/Navigator.ts
@@ -25,6 +25,7 @@ export interface ProgressionRange {
     start: number;
     end: number;
     fragmentId?: string;  // DOM element ID of the currently active timeline anchor
+    visibleFragmentIds?: string[];  // DOM-order IDs of every timeline anchor currently on screen
 }
 
 export interface VisualNavigatorViewport {

--- a/navigator/src/epub/EpubNavigator.ts
+++ b/navigator/src/epub/EpubNavigator.ts
@@ -1150,19 +1150,19 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
                 };
             });
 
-            // adjacentTo() can't tell whether we're already at the resource's own start —
+            // navigableFrom() can't tell whether we're already at the resource's own start —
             // that's live scroll state, not TOC structure — so step from the resource's
             // top-level item instead of `item` when we are, to skip past it rather than
             // land back where we already are.
-            const originalAdjacentTo = t.adjacentTo.bind(t);
-            t.adjacentTo = (item: TimelineItem) => {
+            const originalNavigableFrom = t.navigableFrom.bind(t);
+            t.navigableFrom = (item: TimelineItem) => {
                 const href = item.references[0]?.split("#")[0];
                 const atResourceStart = href !== undefined &&
                     this.viewport.progressions.get(href)?.start === 0;
                 const stepFrom = atResourceStart
                     ? t.items.find(i => i.references[0]?.split("#")[0] === href) ?? item
                     : item;
-                return originalAdjacentTo(stepFrom);
+                return originalNavigableFrom(stepFrom);
             };
 
             this._timelineAugmented = true;

--- a/navigator/src/epub/EpubNavigator.ts
+++ b/navigator/src/epub/EpubNavigator.ts
@@ -68,6 +68,10 @@ const defaultListeners = (listeners: EpubNavigatorListeners): EpubNavigatorListe
     peripheral: listeners.peripheral || (() => {}),
 })
 
+function sameTimelineItems(a: TimelineItem[], b: TimelineItem[]): boolean {
+    return a.length === b.length && a.every((item, i) => item === b[i]);
+}
+
 export class EpubNavigator extends VisualNavigator implements Configurable<ConfigurableSettings, EpubPreferences>, DecorableNavigator {
     private readonly pub: Publication;
     private readonly container: HTMLElement;
@@ -76,6 +80,8 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
     private positions!: Locator[];
     private currentLocation!: Locator;
     private _currentTimelineItem: TimelineItem | undefined;
+    private _visibleTimelineItems: TimelineItem[] = [];
+    private _notifiedVisibleTimelineItems: TimelineItem[] = [];
     private _timelineAugmented = false;
     private lastLocationInView: Locator | undefined;
     private currentProgression: ReadingProgression;
@@ -1006,6 +1012,11 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
         const locatorForTimeline = progression.fragmentId
             ? this.currentLocation.copyWithLocations({ fragments: [`#${progression.fragmentId}`] })
             : this.currentLocation;
+        const resolvedVisible = (progression.visibleFragmentIds ?? [])
+            .map(id => ({ id, item: this.pub.timeline.locate(this.currentLocation.copyWithLocations({ fragments: [`#${id}`] })) }));
+        this._visibleTimelineItems = resolvedVisible
+            .map(r => r.item)
+            .filter((item): item is TimelineItem => item !== undefined);
         this._notifyTimelineChange(locatorForTimeline);
         await this.framePool.update(this.pub, this.currentLocation, this.determineModules());
     }
@@ -1150,19 +1161,25 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
                 };
             });
 
-            // navigableFrom() can't tell whether we're already at the resource's own start —
-            // that's live scroll state, not TOC structure — so step from the resource's
-            // top-level item instead of `item` when we are, to skip past it rather than
-            // land back where we already are.
+            // Fragments on screen are always contiguous in the flattened timeline, so anchor
+            // previous/next on the two ends of the visible run instead of on `item` itself.
             const originalNavigableFrom = t.navigableFrom.bind(t);
             t.navigableFrom = (item: TimelineItem) => {
-                const href = item.references[0]?.split("#")[0];
-                const atResourceStart = href !== undefined &&
-                    this.viewport.progressions.get(href)?.start === 0;
-                const stepFrom = atResourceStart
-                    ? t.items.find(i => i.references[0]?.split("#")[0] === href) ?? item
-                    : item;
-                return originalNavigableFrom(stepFrom);
+                const visible = this._visibleTimelineItems.length ? this._visibleTimelineItems : [item];
+                let first = visible[0];
+                // The current resource's own bare-href container(s) have no DOM anchor, so
+                // they never appear in _visibleTimelineItems. Only when scrollTop is actually
+                // 0 (untracked content can precede the first fragment, and scrolling past it
+                // must leave "back to resource start" reachable) walk out to the outermost
+                // ancestor still within this resource, so previous is anchored past all of
+                // them at once rather than one guessed step back.
+                if (this.isScrollStart) {
+                    const outermost = t.ancestors(first).find(a => a.references.includes(this.currentLocation.href));
+                    if (outermost) first = outermost;
+                }
+                const previous = originalNavigableFrom(first).previous;
+                const next = originalNavigableFrom(visible[visible.length - 1]).next;
+                return { previous, next };
             };
 
             this._timelineAugmented = true;
@@ -1253,8 +1270,10 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
 
     private _notifyTimelineChange(locator: Locator): void {
         const item = this.timeline.locate(locator);
-        if (item !== this._currentTimelineItem) {
+        const visibleChanged = !sameTimelineItems(this._visibleTimelineItems, this._notifiedVisibleTimelineItems);
+        if (item !== this._currentTimelineItem || visibleChanged) {
             this._currentTimelineItem = item;
+            this._notifiedVisibleTimelineItems = this._visibleTimelineItems;
             this.listeners.timelineItemChanged(item);
         }
     }

--- a/navigator/src/epub/EpubNavigator.ts
+++ b/navigator/src/epub/EpubNavigator.ts
@@ -83,6 +83,7 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
     private _visibleFragmentIds: string[] = [];
     private _notifiedVisibleFragmentIds: string[] = [];
     private _timelineAugmented = false;
+    private _wrappedTimeline: Timeline | undefined;
     private lastLocationInView: Locator | undefined;
     private currentProgression: ReadingProgression;
     private _layout: Layout;
@@ -1157,35 +1158,49 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
                 };
             });
 
-            // Fragments on screen are always contiguous in the flattened timeline, so anchor
-            // previous/next on the two ends of the visible run instead of on `item` itself.
-            const originalNavigableFrom = t.navigableFrom.bind(t);
-            t.navigableFrom = (item: TimelineItem) => {
-                // Resolved lazily, here, rather than eagerly on every scroll frame in
-                // syncLocation: navigableFrom() is called on demand (e.g. building prev/next
-                // UI), far less often than progress reports, and only the two ends are ever
-                // used — Timeline.locate() is an O(n) scan, not worth paying per fragment.
-                const ids = this._visibleFragmentIds;
-                let first = (ids.length ? t.locate(this.currentLocation.copyWithLocations({ fragments: [`#${ids[0]}`] })) : undefined) ?? item;
-                const last = (ids.length ? t.locate(this.currentLocation.copyWithLocations({ fragments: [`#${ids[ids.length - 1]}`] })) : undefined) ?? item;
-                // The current resource's own bare-href container(s) have no DOM anchor, so
-                // they never appear among visible fragment ids. Only when scrollTop is actually
-                // 0 (untracked content can precede the first fragment, and scrolling past it
-                // must leave "back to resource start" reachable) walk out to the outermost
-                // ancestor still within this resource, so previous is anchored past all of
-                // them at once rather than one guessed step back.
-                if (this.isScrollStart) {
-                    const outermost = t.ancestors(first).find(a => a.references.includes(this.currentLocation.href));
-                    if (outermost) first = outermost;
-                }
-                const previous = originalNavigableFrom(first).previous;
-                const next = originalNavigableFrom(last).next;
-                return { previous, next };
-            };
-
             this._timelineAugmented = true;
         }
-        return t;
+
+        if (!this._wrappedTimeline) {
+            // Wraps the real, shared Timeline rather than mutating it — publication.timeline
+            // stays plain for every consumer; only navigator.timeline answers navigableFrom()
+            // with visible-range-aware previous/next. Every other member (locate, ancestors,
+            // augment, etc.) passes straight through to the real instance untouched.
+            this._wrappedTimeline = new Proxy(t, {
+                get: (target, prop) => {
+                    if (prop !== 'navigableFrom') {
+                        // Resolve strictly against `target`, never the proxy: Timeline's own
+                        // getters (flat, items) lazily cache onto `this` on first access, and
+                        // forwarding the proxy as receiver would make that caching target the
+                        // wrong object instead of the real Timeline.
+                        const value = Reflect.get(target, prop, target);
+                        return typeof value === 'function' ? value.bind(target) : value;
+                    }
+                    return (item: TimelineItem) => {
+                        // Fragments on screen are always contiguous in the flattened timeline,
+                        // so anchor previous/next on the two ends of the visible run instead of
+                        // on `item` itself.
+                        const ids = this._visibleFragmentIds;
+                        let first = (ids.length ? target.locate(this.currentLocation.copyWithLocations({ fragments: [`#${ids[0]}`] })) : undefined) ?? item;
+                        const last = (ids.length ? target.locate(this.currentLocation.copyWithLocations({ fragments: [`#${ids[ids.length - 1]}`] })) : undefined) ?? item;
+                        // The current resource's own bare-href container(s) have no DOM anchor,
+                        // so they never appear among visible fragment ids. Only when scrollTop is
+                        // actually 0 (untracked content can precede the first fragment, and
+                        // scrolling past it must leave "back to resource start" reachable) walk
+                        // out to the outermost ancestor still within this resource, so previous
+                        // is anchored past all of them at once rather than one guessed step back.
+                        if (this.isScrollStart) {
+                            const outermost = target.ancestors(first).find(a => a.references.includes(this.currentLocation.href));
+                            if (outermost) first = outermost;
+                        }
+                        const previous = target.navigableFrom(first).previous;
+                        const next = target.navigableFrom(last).next;
+                        return { previous, next };
+                    };
+                }
+            });
+        }
+        return this._wrappedTimeline;
     }
 
     private async loadLocator(locator: Locator, cb: (ok: boolean) => void) {

--- a/navigator/src/epub/EpubNavigator.ts
+++ b/navigator/src/epub/EpubNavigator.ts
@@ -68,8 +68,8 @@ const defaultListeners = (listeners: EpubNavigatorListeners): EpubNavigatorListe
     peripheral: listeners.peripheral || (() => {}),
 })
 
-function sameTimelineItems(a: TimelineItem[], b: TimelineItem[]): boolean {
-    return a.length === b.length && a.every((item, i) => item === b[i]);
+function sameIds(a: string[], b: string[]): boolean {
+    return a.length === b.length && a.every((id, i) => id === b[i]);
 }
 
 export class EpubNavigator extends VisualNavigator implements Configurable<ConfigurableSettings, EpubPreferences>, DecorableNavigator {
@@ -80,8 +80,8 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
     private positions!: Locator[];
     private currentLocation!: Locator;
     private _currentTimelineItem: TimelineItem | undefined;
-    private _visibleTimelineItems: TimelineItem[] = [];
-    private _notifiedVisibleTimelineItems: TimelineItem[] = [];
+    private _visibleFragmentIds: string[] = [];
+    private _notifiedVisibleFragmentIds: string[] = [];
     private _timelineAugmented = false;
     private lastLocationInView: Locator | undefined;
     private currentProgression: ReadingProgression;
@@ -1012,11 +1012,7 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
         const locatorForTimeline = progression.fragmentId
             ? this.currentLocation.copyWithLocations({ fragments: [`#${progression.fragmentId}`] })
             : this.currentLocation;
-        const resolvedVisible = (progression.visibleFragmentIds ?? [])
-            .map(id => ({ id, item: this.pub.timeline.locate(this.currentLocation.copyWithLocations({ fragments: [`#${id}`] })) }));
-        this._visibleTimelineItems = resolvedVisible
-            .map(r => r.item)
-            .filter((item): item is TimelineItem => item !== undefined);
+        this._visibleFragmentIds = progression.visibleFragmentIds ?? [];
         this._notifyTimelineChange(locatorForTimeline);
         await this.framePool.update(this.pub, this.currentLocation, this.determineModules());
     }
@@ -1165,10 +1161,15 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
             // previous/next on the two ends of the visible run instead of on `item` itself.
             const originalNavigableFrom = t.navigableFrom.bind(t);
             t.navigableFrom = (item: TimelineItem) => {
-                const visible = this._visibleTimelineItems.length ? this._visibleTimelineItems : [item];
-                let first = visible[0];
+                // Resolved lazily, here, rather than eagerly on every scroll frame in
+                // syncLocation: navigableFrom() is called on demand (e.g. building prev/next
+                // UI), far less often than progress reports, and only the two ends are ever
+                // used — Timeline.locate() is an O(n) scan, not worth paying per fragment.
+                const ids = this._visibleFragmentIds;
+                let first = (ids.length ? t.locate(this.currentLocation.copyWithLocations({ fragments: [`#${ids[0]}`] })) : undefined) ?? item;
+                const last = (ids.length ? t.locate(this.currentLocation.copyWithLocations({ fragments: [`#${ids[ids.length - 1]}`] })) : undefined) ?? item;
                 // The current resource's own bare-href container(s) have no DOM anchor, so
-                // they never appear in _visibleTimelineItems. Only when scrollTop is actually
+                // they never appear among visible fragment ids. Only when scrollTop is actually
                 // 0 (untracked content can precede the first fragment, and scrolling past it
                 // must leave "back to resource start" reachable) walk out to the outermost
                 // ancestor still within this resource, so previous is anchored past all of
@@ -1178,7 +1179,7 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
                     if (outermost) first = outermost;
                 }
                 const previous = originalNavigableFrom(first).previous;
-                const next = originalNavigableFrom(visible[visible.length - 1]).next;
+                const next = originalNavigableFrom(last).next;
                 return { previous, next };
             };
 
@@ -1270,10 +1271,10 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
 
     private _notifyTimelineChange(locator: Locator): void {
         const item = this.timeline.locate(locator);
-        const visibleChanged = !sameTimelineItems(this._visibleTimelineItems, this._notifiedVisibleTimelineItems);
+        const visibleChanged = !sameIds(this._visibleFragmentIds, this._notifiedVisibleFragmentIds);
         if (item !== this._currentTimelineItem || visibleChanged) {
             this._currentTimelineItem = item;
-            this._notifiedVisibleTimelineItems = this._visibleTimelineItems;
+            this._notifiedVisibleFragmentIds = this._visibleFragmentIds;
             this.listeners.timelineItemChanged(item);
         }
     }

--- a/navigator/src/epub/EpubNavigator.ts
+++ b/navigator/src/epub/EpubNavigator.ts
@@ -1149,6 +1149,22 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
                     scroll: atFragment?.locations.progression,
                 };
             });
+
+            // adjacentTo() can't tell whether we're already at the resource's own start —
+            // that's live scroll state, not TOC structure — so step from the resource's
+            // top-level item instead of `item` when we are, to skip past it rather than
+            // land back where we already are.
+            const originalAdjacentTo = t.adjacentTo.bind(t);
+            t.adjacentTo = (item: TimelineItem) => {
+                const href = item.references[0]?.split("#")[0];
+                const atResourceStart = href !== undefined &&
+                    this.viewport.progressions.get(href)?.start === 0;
+                const stepFrom = atResourceStart
+                    ? t.items.find(i => i.references[0]?.split("#")[0] === href) ?? item
+                    : item;
+                return originalAdjacentTo(stepFrom);
+            };
+
             this._timelineAugmented = true;
         }
         return t;

--- a/navigator/src/webpub/WebPubNavigator.ts
+++ b/navigator/src/webpub/WebPubNavigator.ts
@@ -62,8 +62,8 @@ const defaultListeners = (listeners: WebPubNavigatorListeners): WebPubNavigatorL
     peripheral: listeners.peripheral || (() => {})
 })
 
-function sameTimelineItems(a: TimelineItem[], b: TimelineItem[]): boolean {
-    return a.length === b.length && a.every((item, i) => item === b[i]);
+function sameIds(a: string[], b: string[]): boolean {
+    return a.length === b.length && a.every((id, i) => id === b[i]);
 }
 
 export class WebPubNavigator extends VisualNavigator implements Configurable<WebPubSettings, WebPubPreferences>, DecorableNavigator {
@@ -74,8 +74,8 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
     private currentIndex: number = 0;
     private currentLocation: Locator;
     private _currentTimelineItem: TimelineItem | undefined;
-    private _visibleTimelineItems: TimelineItem[] = [];
-    private _notifiedVisibleTimelineItems: TimelineItem[] = [];
+    private _visibleFragmentIds: string[] = [];
+    private _notifiedVisibleFragmentIds: string[] = [];
     private _timelineAdjacentToWrapped = false;
 
     private _preferences: WebPubPreferences;
@@ -679,9 +679,7 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
         const locatorForTimeline = progression.fragmentId
             ? this.currentLocation.copyWithLocations({ fragments: [`#${progression.fragmentId}`] })
             : this.currentLocation;
-        this._visibleTimelineItems = (progression.visibleFragmentIds ?? [])
-            .map(id => this.pub.timeline.locate(this.currentLocation.copyWithLocations({ fragments: [`#${id}`] })))
-            .filter((item): item is TimelineItem => item !== undefined);
+        this._visibleFragmentIds = progression.visibleFragmentIds ?? [];
         this._notifyTimelineChange(locatorForTimeline);
         await this.framePool.update(this.pub, this.currentLocation, this.determineModules());
     }
@@ -749,10 +747,15 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
             // previous/next on the two ends of the visible run instead of on `item` itself.
             const originalNavigableFrom = t.navigableFrom.bind(t);
             t.navigableFrom = (item: TimelineItem) => {
-                const visible = this._visibleTimelineItems.length ? this._visibleTimelineItems : [item];
-                let first = visible[0];
+                // Resolved lazily, here, rather than eagerly on every scroll frame in
+                // syncLocation: navigableFrom() is called on demand (e.g. building prev/next
+                // UI), far less often than progress reports, and only the two ends are ever
+                // used — Timeline.locate() is an O(n) scan, not worth paying per fragment.
+                const ids = this._visibleFragmentIds;
+                let first = (ids.length ? t.locate(this.currentLocation.copyWithLocations({ fragments: [`#${ids[0]}`] })) : undefined) ?? item;
+                const last = (ids.length ? t.locate(this.currentLocation.copyWithLocations({ fragments: [`#${ids[ids.length - 1]}`] })) : undefined) ?? item;
                 // The current resource's own bare-href container(s) have no DOM anchor, so
-                // they never appear in _visibleTimelineItems. Only when scrollTop is actually
+                // they never appear among visible fragment ids. Only when scrollTop is actually
                 // 0 (untracked content can precede the first fragment, and scrolling past it
                 // must leave "back to resource start" reachable) walk out to the outermost
                 // ancestor still within this resource, so previous is anchored past all of
@@ -762,7 +765,7 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
                     if (outermost) first = outermost;
                 }
                 const previous = originalNavigableFrom(first).previous;
-                const next = originalNavigableFrom(visible[visible.length - 1]).next;
+                const next = originalNavigableFrom(last).next;
                 return { previous, next };
             };
             this._timelineAdjacentToWrapped = true;
@@ -888,10 +891,10 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
 
     private _notifyTimelineChange(locator: Locator): void {
         const item = this.timeline.locate(locator);
-        const visibleChanged = !sameTimelineItems(this._visibleTimelineItems, this._notifiedVisibleTimelineItems);
+        const visibleChanged = !sameIds(this._visibleFragmentIds, this._notifiedVisibleFragmentIds);
         if (item !== this._currentTimelineItem || visibleChanged) {
             this._currentTimelineItem = item;
-            this._notifiedVisibleTimelineItems = this._visibleTimelineItems;
+            this._notifiedVisibleFragmentIds = this._visibleFragmentIds;
             this.listeners.timelineItemChanged(item);
         }
     }

--- a/navigator/src/webpub/WebPubNavigator.ts
+++ b/navigator/src/webpub/WebPubNavigator.ts
@@ -76,7 +76,7 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
     private _currentTimelineItem: TimelineItem | undefined;
     private _visibleFragmentIds: string[] = [];
     private _notifiedVisibleFragmentIds: string[] = [];
-    private _timelineAdjacentToWrapped = false;
+    private _wrappedTimeline: Timeline | undefined;
 
     private _preferences: WebPubPreferences;
     private _defaults: WebPubDefaults;
@@ -742,35 +742,46 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
 
     get timeline(): Timeline {
         const t = this.pub.timeline;
-        if (!this._timelineAdjacentToWrapped) {
-            // Fragments on screen are always contiguous in the flattened timeline, so anchor
-            // previous/next on the two ends of the visible run instead of on `item` itself.
-            const originalNavigableFrom = t.navigableFrom.bind(t);
-            t.navigableFrom = (item: TimelineItem) => {
-                // Resolved lazily, here, rather than eagerly on every scroll frame in
-                // syncLocation: navigableFrom() is called on demand (e.g. building prev/next
-                // UI), far less often than progress reports, and only the two ends are ever
-                // used — Timeline.locate() is an O(n) scan, not worth paying per fragment.
-                const ids = this._visibleFragmentIds;
-                let first = (ids.length ? t.locate(this.currentLocation.copyWithLocations({ fragments: [`#${ids[0]}`] })) : undefined) ?? item;
-                const last = (ids.length ? t.locate(this.currentLocation.copyWithLocations({ fragments: [`#${ids[ids.length - 1]}`] })) : undefined) ?? item;
-                // The current resource's own bare-href container(s) have no DOM anchor, so
-                // they never appear among visible fragment ids. Only when scrollTop is actually
-                // 0 (untracked content can precede the first fragment, and scrolling past it
-                // must leave "back to resource start" reachable) walk out to the outermost
-                // ancestor still within this resource, so previous is anchored past all of
-                // them at once rather than one guessed step back.
-                if (this.isScrollStart) {
-                    const outermost = t.ancestors(first).find(a => a.references.includes(this.currentLocation.href));
-                    if (outermost) first = outermost;
+        if (!this._wrappedTimeline) {
+            // Wraps the real, shared Timeline rather than mutating it — publication.timeline
+            // stays plain for every consumer; only navigator.timeline answers navigableFrom()
+            // with visible-range-aware previous/next. Every other member (locate, ancestors,
+            // augment, etc.) passes straight through to the real instance untouched.
+            this._wrappedTimeline = new Proxy(t, {
+                get: (target, prop) => {
+                    if (prop !== 'navigableFrom') {
+                        // Resolve strictly against `target`, never the proxy: Timeline's own
+                        // getters (flat, items) lazily cache onto `this` on first access, and
+                        // forwarding the proxy as receiver would make that caching target the
+                        // wrong object instead of the real Timeline.
+                        const value = Reflect.get(target, prop, target);
+                        return typeof value === 'function' ? value.bind(target) : value;
+                    }
+                    return (item: TimelineItem) => {
+                        // Fragments on screen are always contiguous in the flattened timeline,
+                        // so anchor previous/next on the two ends of the visible run instead of
+                        // on `item` itself.
+                        const ids = this._visibleFragmentIds;
+                        let first = (ids.length ? target.locate(this.currentLocation.copyWithLocations({ fragments: [`#${ids[0]}`] })) : undefined) ?? item;
+                        const last = (ids.length ? target.locate(this.currentLocation.copyWithLocations({ fragments: [`#${ids[ids.length - 1]}`] })) : undefined) ?? item;
+                        // The current resource's own bare-href container(s) have no DOM anchor,
+                        // so they never appear among visible fragment ids. Only when scrollTop is
+                        // actually 0 (untracked content can precede the first fragment, and
+                        // scrolling past it must leave "back to resource start" reachable) walk
+                        // out to the outermost ancestor still within this resource, so previous
+                        // is anchored past all of them at once rather than one guessed step back.
+                        if (this.isScrollStart) {
+                            const outermost = target.ancestors(first).find(a => a.references.includes(this.currentLocation.href));
+                            if (outermost) first = outermost;
+                        }
+                        const previous = target.navigableFrom(first).previous;
+                        const next = target.navigableFrom(last).next;
+                        return { previous, next };
+                    };
                 }
-                const previous = originalNavigableFrom(first).previous;
-                const next = originalNavigableFrom(last).next;
-                return { previous, next };
-            };
-            this._timelineAdjacentToWrapped = true;
+            });
         }
-        return t;
+        return this._wrappedTimeline;
     }
 
     private async loadLocator(locator: Locator, cb: (ok: boolean) => void) {

--- a/navigator/src/webpub/WebPubNavigator.ts
+++ b/navigator/src/webpub/WebPubNavigator.ts
@@ -62,6 +62,10 @@ const defaultListeners = (listeners: WebPubNavigatorListeners): WebPubNavigatorL
     peripheral: listeners.peripheral || (() => {})
 })
 
+function sameTimelineItems(a: TimelineItem[], b: TimelineItem[]): boolean {
+    return a.length === b.length && a.every((item, i) => item === b[i]);
+}
+
 export class WebPubNavigator extends VisualNavigator implements Configurable<WebPubSettings, WebPubPreferences>, DecorableNavigator {
     private readonly pub: Publication;
     private readonly container: HTMLElement;
@@ -70,6 +74,8 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
     private currentIndex: number = 0;
     private currentLocation: Locator;
     private _currentTimelineItem: TimelineItem | undefined;
+    private _visibleTimelineItems: TimelineItem[] = [];
+    private _notifiedVisibleTimelineItems: TimelineItem[] = [];
     private _timelineAdjacentToWrapped = false;
 
     private _preferences: WebPubPreferences;
@@ -673,6 +679,9 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
         const locatorForTimeline = progression.fragmentId
             ? this.currentLocation.copyWithLocations({ fragments: [`#${progression.fragmentId}`] })
             : this.currentLocation;
+        this._visibleTimelineItems = (progression.visibleFragmentIds ?? [])
+            .map(id => this.pub.timeline.locate(this.currentLocation.copyWithLocations({ fragments: [`#${id}`] })))
+            .filter((item): item is TimelineItem => item !== undefined);
         this._notifyTimelineChange(locatorForTimeline);
         await this.framePool.update(this.pub, this.currentLocation, this.determineModules());
     }
@@ -736,19 +745,25 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
     get timeline(): Timeline {
         const t = this.pub.timeline;
         if (!this._timelineAdjacentToWrapped) {
-            // navigableFrom() can't tell whether we're already at the resource's own start —
-            // that's live scroll state, not TOC structure — so step from the resource's
-            // top-level item instead of `item` when we are, to skip past it rather than
-            // land back where we already are.
+            // Fragments on screen are always contiguous in the flattened timeline, so anchor
+            // previous/next on the two ends of the visible run instead of on `item` itself.
             const originalNavigableFrom = t.navigableFrom.bind(t);
             t.navigableFrom = (item: TimelineItem) => {
-                const href = item.references[0]?.split("#")[0];
-                const atResourceStart = href !== undefined &&
-                    this.viewport.progressions.get(href)?.start === 0;
-                const stepFrom = atResourceStart
-                    ? t.items.find(i => i.references[0]?.split("#")[0] === href) ?? item
-                    : item;
-                return originalNavigableFrom(stepFrom);
+                const visible = this._visibleTimelineItems.length ? this._visibleTimelineItems : [item];
+                let first = visible[0];
+                // The current resource's own bare-href container(s) have no DOM anchor, so
+                // they never appear in _visibleTimelineItems. Only when scrollTop is actually
+                // 0 (untracked content can precede the first fragment, and scrolling past it
+                // must leave "back to resource start" reachable) walk out to the outermost
+                // ancestor still within this resource, so previous is anchored past all of
+                // them at once rather than one guessed step back.
+                if (this.isScrollStart) {
+                    const outermost = t.ancestors(first).find(a => a.references.includes(this.currentLocation.href));
+                    if (outermost) first = outermost;
+                }
+                const previous = originalNavigableFrom(first).previous;
+                const next = originalNavigableFrom(visible[visible.length - 1]).next;
+                return { previous, next };
             };
             this._timelineAdjacentToWrapped = true;
         }
@@ -873,8 +888,10 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
 
     private _notifyTimelineChange(locator: Locator): void {
         const item = this.timeline.locate(locator);
-        if (item !== this._currentTimelineItem) {
+        const visibleChanged = !sameTimelineItems(this._visibleTimelineItems, this._notifiedVisibleTimelineItems);
+        if (item !== this._currentTimelineItem || visibleChanged) {
             this._currentTimelineItem = item;
+            this._notifiedVisibleTimelineItems = this._visibleTimelineItems;
             this.listeners.timelineItemChanged(item);
         }
     }

--- a/navigator/src/webpub/WebPubNavigator.ts
+++ b/navigator/src/webpub/WebPubNavigator.ts
@@ -70,6 +70,7 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
     private currentIndex: number = 0;
     private currentLocation: Locator;
     private _currentTimelineItem: TimelineItem | undefined;
+    private _timelineAdjacentToWrapped = false;
 
     private _preferences: WebPubPreferences;
     private _defaults: WebPubDefaults;
@@ -733,7 +734,25 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
     }
 
     get timeline(): Timeline {
-        return this.pub.timeline;
+        const t = this.pub.timeline;
+        if (!this._timelineAdjacentToWrapped) {
+            // adjacentTo() can't tell whether we're already at the resource's own start —
+            // that's live scroll state, not TOC structure — so step from the resource's
+            // top-level item instead of `item` when we are, to skip past it rather than
+            // land back where we already are.
+            const originalAdjacentTo = t.adjacentTo.bind(t);
+            t.adjacentTo = (item: TimelineItem) => {
+                const href = item.references[0]?.split("#")[0];
+                const atResourceStart = href !== undefined &&
+                    this.viewport.progressions.get(href)?.start === 0;
+                const stepFrom = atResourceStart
+                    ? t.items.find(i => i.references[0]?.split("#")[0] === href) ?? item
+                    : item;
+                return originalAdjacentTo(stepFrom);
+            };
+            this._timelineAdjacentToWrapped = true;
+        }
+        return t;
     }
 
     private async loadLocator(locator: Locator, cb: (ok: boolean) => void) {

--- a/navigator/src/webpub/WebPubNavigator.ts
+++ b/navigator/src/webpub/WebPubNavigator.ts
@@ -736,19 +736,19 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
     get timeline(): Timeline {
         const t = this.pub.timeline;
         if (!this._timelineAdjacentToWrapped) {
-            // adjacentTo() can't tell whether we're already at the resource's own start —
+            // navigableFrom() can't tell whether we're already at the resource's own start —
             // that's live scroll state, not TOC structure — so step from the resource's
             // top-level item instead of `item` when we are, to skip past it rather than
             // land back where we already are.
-            const originalAdjacentTo = t.adjacentTo.bind(t);
-            t.adjacentTo = (item: TimelineItem) => {
+            const originalNavigableFrom = t.navigableFrom.bind(t);
+            t.navigableFrom = (item: TimelineItem) => {
                 const href = item.references[0]?.split("#")[0];
                 const atResourceStart = href !== undefined &&
                     this.viewport.progressions.get(href)?.start === 0;
                 const stepFrom = atResourceStart
                     ? t.items.find(i => i.references[0]?.split("#")[0] === href) ?? item
                     : item;
-                return originalAdjacentTo(stepFrom);
+                return originalNavigableFrom(stepFrom);
             };
             this._timelineAdjacentToWrapped = true;
         }

--- a/shared/CHANGELOG.MD
+++ b/shared/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.3] – 2026-07-23
+
+### Changed
+
+- **Breaking:** `Timeline.adjacentTo()` has been renamed to `navigableFrom()` to better express its purpose ([#244](https://github.com/readium/ts-toolkit/pull/244))
+
 ## [2.3.2] – 2026-07-22
 
 ### Fixed

--- a/shared/CHANGELOG.MD
+++ b/shared/CHANGELOG.MD
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.3] – 2026-07-23
+## [2.4.0] – 2026-07-23
 
 ### Changed
 

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/shared",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "type": "module",
   "description": "Shared models to be used across other Readium projects and implementations in Typescript",
   "author": "readium",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/shared",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "type": "module",
   "description": "Shared models to be used across other Readium projects and implementations in Typescript",
   "author": "readium",

--- a/shared/src/publication/services/timeline/Timeline.ts
+++ b/shared/src/publication/services/timeline/Timeline.ts
@@ -228,7 +228,8 @@ export class Timeline {
         return this.flat.find(item => this.itemMatchesHref(item, href));
     }
 
-    adjacentTo(item: TimelineItem): { previous: TimelineItem | undefined; next: TimelineItem | undefined } {
+    /** The items navigable to/from `item`: its previous/next neighbors in the flattened timeline. */
+    navigableFrom(item: TimelineItem): { previous: TimelineItem | undefined; next: TimelineItem | undefined } {
         const index = this.flat.indexOf(item);
         return {
             previous: index > 0 ? this.flat[index - 1] : undefined,


### PR DESCRIPTION
This brings additional improvements to Timeline API:

- renames `adjacentTo()` to `navigableFrom()` to better express its purpose
- patches the method from navigator to resolve to navigable items, preventing being stuck when the first fragment is visible in the viewport at `scroll===0`, or when the next fragment is already visible in the viewport
- rewrites scroll fragment/id resolution