### PR TITLE
Fix preference editors

### DIFF
--- a/navigator/CHANGELOG.MD
+++ b/navigator/CHANGELOG.MD
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.2] – 2026-08-03
+
+### Fixed
+
+- `AudioPreferencesEditor`, `WebPubPreferencesEditor`, and `EpubPreferencesEditor` now clone the preferences passed to their constructor instead of aliasing the navigator's live preferences object, so staged edits no longer mutate navigator state before `submitPreferences()` is called
+- `clear()` on all three preferences editors now resets every field to an explicit `null` instead of leaving it `undefined`, so it actually takes effect when submitted through `submitPreferences()`
+
 ## [2.8.1] – 2026-07-29
 
 ### Fixed

--- a/navigator/package.json
+++ b/navigator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "type": "module",
   "description": "Next generation SDK for publications in Web Apps",
   "author": "readium",

--- a/navigator/src/audio/preferences/AudioPreferencesEditor.ts
+++ b/navigator/src/audio/preferences/AudioPreferencesEditor.ts
@@ -13,12 +13,21 @@ export class AudioPreferencesEditor implements IPreferencesEditor {
   private settings: AudioSettings;
 
   constructor(initialPreferences: AudioPreferences, settings: AudioSettings) {
-    this.preferences = initialPreferences;
+    this.preferences = new AudioPreferences({ ...initialPreferences });
     this.settings = settings;
   }
 
   clear(): void {
-    this.preferences = new AudioPreferences();
+    this.preferences = new AudioPreferences({
+      volume: null,
+      playbackRate: null,
+      preservePitch: null,
+      skipBackwardInterval: null,
+      skipForwardInterval: null,
+      pollInterval: null,
+      autoPlay: null,
+      enableMediaSession: null
+    });
   }
 
   private updatePreference<K extends keyof AudioPreferences>(key: K, value: AudioPreferences[K]) {

--- a/navigator/src/epub/preferences/EpubPreferencesEditor.ts
+++ b/navigator/src/epub/preferences/EpubPreferencesEditor.ts
@@ -59,7 +59,7 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
       maximalLineLength: null,
       minimalLineLength: null,
       noRuby: null,
-      optimalLineLength: 65,
+      optimalLineLength: null,
       pageGutter: null,
       paragraphIndent: null,
       paragraphSpacing: null,

--- a/navigator/src/epub/preferences/EpubPreferencesEditor.ts
+++ b/navigator/src/epub/preferences/EpubPreferencesEditor.ts
@@ -27,14 +27,55 @@ export class EpubPreferencesEditor implements IPreferencesEditor {
   private layout: Layout;
 
   constructor(initialPreferences: EpubPreferences, settings: EpubSettings, metadata: Metadata) {
-    this.preferences = initialPreferences;
+    this.preferences = new EpubPreferences({ ...initialPreferences });
     this.settings = settings;
     this.metadata = metadata;
     this.layout = this.metadata?.effectiveLayout || Layout.reflowable;
   }
 
   clear() {
-    this.preferences = new EpubPreferences({ optimalLineLength: 65 });
+    this.preferences = new EpubPreferences({
+      backgroundColor: null,
+      blendFilter: null,
+      columnCount: null,
+      constraint: null,
+      darkenFilter: null,
+      deprecatedFontSize: null,
+      fontFamily: null,
+      fontSize: null,
+      fontSizeNormalize: null,
+      fontOpticalSizing: null,
+      fontWeight: null,
+      fontWidth: null,
+      hyphens: null,
+      invertFilter: null,
+      invertGaijiFilter: null,
+      iOSPatch: null,
+      iPadOSPatch: null,
+      letterSpacing: null,
+      ligatures: null,
+      lineHeight: null,
+      linkColor: null,
+      maximalLineLength: null,
+      minimalLineLength: null,
+      noRuby: null,
+      optimalLineLength: 65,
+      pageGutter: null,
+      paragraphIndent: null,
+      paragraphSpacing: null,
+      scroll: null,
+      scrollPaddingTop: null,
+      scrollPaddingBottom: null,
+      scrollPaddingLeft: null,
+      scrollPaddingRight: null,
+      selectionBackgroundColor: null,
+      selectionTextColor: null,
+      textAlign: null,
+      textColor: null,
+      textNormalization: null,
+      visitedColor: null,
+      wordSpacing: null
+    });
   }
 
   private updatePreference<K extends keyof EpubPreferences>(key: K, value: EpubPreferences[K]) {

--- a/navigator/src/webpub/preferences/WebPubPreferencesEditor.ts
+++ b/navigator/src/webpub/preferences/WebPubPreferencesEditor.ts
@@ -20,13 +20,29 @@ export class WebPubPreferencesEditor implements IPreferencesEditor {
   private metadata: Metadata | null;
 
   constructor(initialPreferences: WebPubPreferences, settings: WebPubSettings, metadata: Metadata) {
-    this.preferences = initialPreferences;
+    this.preferences = new WebPubPreferences({ ...initialPreferences });
     this.settings = settings;
     this.metadata = metadata;
   }
 
   clear() {
-    this.preferences = new WebPubPreferences({});
+    this.preferences = new WebPubPreferences({
+      fontFamily: null,
+      fontWeight: null,
+      hyphens: null,
+      iOSPatch: null,
+      iPadOSPatch: null,
+      letterSpacing: null,
+      ligatures: null,
+      lineHeight: null,
+      noRuby: null,
+      paragraphIndent: null,
+      paragraphSpacing: null,
+      textAlign: null,
+      textNormalization: null,
+      wordSpacing: null,
+      zoom: null
+    });
   }
 
   private updatePreference<K extends keyof WebPubPreferences>(key: K, value: WebPubPreferences[K]) {


### PR DESCRIPTION
- `AudioPreferencesEditor`, `WebPubPreferencesEditor`, and `EpubPreferencesEditor` now clone the preferences passed to their constructor instead of aliasing the navigator's live preferences object, so staged edits no longer mutate navigator state before `submitPreferences()` is called
- `clear()` on all three preferences editors now resets every field to an explicit `null` instead of leaving it `undefined`, so it actually takes effect when submitted through `submitPreferences()`