### PR TITLE
Handle DOM Ranges and text fragments in Decorator

### DIFF
--- a/decorator/CHANGELOG.MD
+++ b/decorator/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] – 2026-09-08
+
+### Added
+
+- Decorations can now be positioned via a `Locator`'s `domRange` or a WICG text-fragment directive, in addition to `text.highlight`, via updated `@readium/navigator-html-injectables`/`@readium/shared` ([#249](https://github.com/readium/ts-toolkit/pull/249))
+
 ## [1.0.2] – 2026-07-29
 
 ### Fixed

--- a/decorator/README.md
+++ b/decorator/README.md
@@ -18,7 +18,11 @@ npm install @readium/decorator
 
 - **Comms**: `DecorationController` (your app logic) and `Decorator` (the DOM renderer) talk over a small message-passing interface, handled for you by `DirectCommsChannel` (below).
 - **Groups**: every decoration belongs to a `group` (an arbitrary string you choose — `"tts"`, `"search-results"`, `"annotations"`, etc). `applyDecorations` replaces *all* decorations for one group at a time, diffing against that group's previous state. Separate groups don't interfere with each other, and each can independently opt into activation (tap/click) and hover tracking depending on which callbacks its `DecorationObserver` declares.
-- **Locators**: each decoration's `locator` is a `Locator` instance from `@readium/shared`, identifying the text range (or other target) to decorate within a resource.
+- **Locators**: each decoration's `locator` is a `Locator` instance from `@readium/shared`, identifying the text range (or other target) to decorate within a resource. Resolving a `Locator` to an actual DOM range tries each of the following in order, falling through when a strategy is absent, invalid, or unresolvable:
+    1. `locations`' `domRange` — an exact node/offset selection
+    2. a WICG text-fragment directive (`:~:text=...`) found in `locations.fragments`
+    3. `text.highlight` — a quote search, disambiguated by `text.before`/`text.after`
+    4. `locations`' `cssSelector`, then an element id from `locations.fragments`
 
 ## Usage
 

--- a/decorator/package.json
+++ b/decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/decorator",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "type": "module",
   "description": "Standalone decoration controller and renderer for HTML content",
   "author": "readium",

--- a/helpers/CHANGELOG.MD
+++ b/helpers/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] – 2026-09-08
+
+### Added
+
+- `decodeTextFragmentDirective` parses WICG Text Fragment directive strings (`:~:text=...`), and a vendored `text-fragments-polyfill` is exposed for resolving them against a document (`processTextFragmentDirective`) or generating one from a `Range` (`generateFragmentFromRange`) ([#249](https://github.com/readium/ts-toolkit/pull/249))
+
 ## [1.0.0] – 2026-07-16
 
 ### Added

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -1,11 +1,11 @@
 # @readium/helpers
 
-General-purpose browser helpers for Readium packages: color parsing/contrast utilities and OS/browser detection.
+General-purpose browser helpers for Readium packages: color parsing/contrast utilities, OS/browser detection, and WICG Text Fragment parsing/resolution/generation.
 
 ## Installation
 
 ```ts
-import { colorToRgba, checkContrast, isDarkColor, isLightColor, getContrastingTextColor, adjustColorForContrast, getLuminance, sML, sMLWithRequest } from "@readium/helpers";
+import { colorToRgba, checkContrast, isDarkColor, isLightColor, getContrastingTextColor, adjustColorForContrast, getLuminance, sML, sMLWithRequest, decodeTextFragmentDirective, processTextFragmentDirective, generateFragmentFromRange } from "@readium/helpers";
 ```
 
 ## Color utilities
@@ -45,6 +45,24 @@ sMLWithRequest.iOSRequest // "mobile" | "desktop" | undefined — iPadOS "Reques
 
 `sML` is a bundled subset of [sML.js](https://github.com/satorumurmur/sML) by Satoru Matsushima, MIT licensed. Falls back safely when `navigator` is unavailable (SSR).
 
+## Text Fragments
+
+```ts
+// Parses a "text=[prefix-,]textStart[,textEnd][,-suffix]" directive out of a URL fragment/hash
+decodeTextFragmentDirective("#some-id:~:text=hello,world"): TextFragmentDirective | undefined
+
+// Resolves a TextFragmentDirective to zero or more Ranges in a document
+processTextFragmentDirective(directive, document, root?): Range[]
+
+// Generates a TextFragmentDirective that uniquely resolves back to the given Range
+generateFragmentFromRange(range): { status: GenerateFragmentStatusValue; fragment?: TextFragment }
+```
+
+`processTextFragmentDirective` and `generateFragmentFromRange` come from a vendored [text-fragments-polyfill](https://github.com/GoogleChromeLabs/text-fragments-polyfill) — see [Third-party licenses](#third-party-licenses).
+
 ## Third-party licenses
 
-This package is BSD-3-Clause, except for `src/sML.ts`, which vendors code from [sML.js](https://github.com/satorumurmur/sML), Copyright (c) Satoru Matsushima, licensed under the MIT license (see the header of that file for the full notice).
+This package is BSD-3-Clause, except for:
+
+- `src/sML.ts`, which vendors code from [sML.js](https://github.com/satorumurmur/sML), Copyright (c) Satoru Matsushima, licensed under the MIT license (see the header of that file for the full notice)
+- `src/vendor/text-fragments-polyfill/`, ported from [text-fragments-polyfill](https://github.com/GoogleChromeLabs/text-fragments-polyfill), licensed under the Apache License 2.0 (see that directory's `LICENSE` and `README.MD`)

--- a/helpers/package.json
+++ b/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/helpers",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "description": "General-purpose browser helpers for Readium packages",
   "author": "readium",

--- a/helpers/src/index.ts
+++ b/helpers/src/index.ts
@@ -1,2 +1,5 @@
 export * from "./color.ts";
 export * from "./sML.ts";
+export * from "./textFragmentDirective.ts";
+export * from "./vendor/text-fragments-polyfill/textFragmentMatcher.ts";
+export * from "./vendor/text-fragments-polyfill/textFragmentGenerator.ts";

--- a/helpers/src/textFragmentDirective.ts
+++ b/helpers/src/textFragmentDirective.ts
@@ -2,7 +2,7 @@
 // text=[prefix-,]textStart[,textEnd][,-suffix]
 // https://wicg.github.io/scroll-to-text-fragment/
 
-export const TEXT_DIRECTIVE_MARK = ":~:text=";
+const TEXT_DIRECTIVE_MARK = ":~:text=";
 
 export interface TextFragmentDirective {
   textStart: string;

--- a/helpers/src/textFragmentDirective.ts
+++ b/helpers/src/textFragmentDirective.ts
@@ -25,11 +25,11 @@ export function decodeTextFragmentDirective(textref: string | undefined): TextFr
     let parts = raw.split(",");
     const result: TextFragmentDirective = { textStart: "" };
 
-    if (parts[0]!.endsWith("-")) {
+    if (parts.length > 1 && parts[0]!.endsWith("-")) {
       result.prefix = decodeURIComponent(parts[0]!.slice(0, -1));
       parts = parts.slice(1);
     }
-    if (parts.length > 0 && parts[parts.length - 1]!.startsWith("-")) {
+    if (parts.length > 1 && parts[parts.length - 1]!.startsWith("-")) {
       result.suffix = decodeURIComponent(parts[parts.length - 1]!.slice(1));
       parts = parts.slice(0, -1);
     }

--- a/helpers/src/textFragmentDirective.ts
+++ b/helpers/src/textFragmentDirective.ts
@@ -1,0 +1,44 @@
+// Parses a WICG Text Fragment directive string:
+// text=[prefix-,]textStart[,textEnd][,-suffix]
+// https://wicg.github.io/scroll-to-text-fragment/
+
+export const TEXT_DIRECTIVE_MARK = ":~:text=";
+
+export interface TextFragmentDirective {
+  textStart: string;
+  textEnd?: string;
+  prefix?: string;
+  suffix?: string;
+}
+
+// Locates ":~:text=" anywhere in the input — it's a suffix appended onto
+// whatever fragment (e.g. an element id) already precedes it, never the
+// whole string.
+export function decodeTextFragmentDirective(textref: string | undefined): TextFragmentDirective | undefined {
+  if (!textref) return undefined;
+  const markIndex = textref.indexOf(TEXT_DIRECTIVE_MARK);
+  if (markIndex === -1) return undefined;
+  const raw = textref.slice(markIndex + TEXT_DIRECTIVE_MARK.length).split("&")[0];
+  if (!raw) return undefined;
+
+  try {
+    let parts = raw.split(",");
+    const result: TextFragmentDirective = { textStart: "" };
+
+    if (parts[0]!.endsWith("-")) {
+      result.prefix = decodeURIComponent(parts[0]!.slice(0, -1));
+      parts = parts.slice(1);
+    }
+    if (parts.length > 0 && parts[parts.length - 1]!.startsWith("-")) {
+      result.suffix = decodeURIComponent(parts[parts.length - 1]!.slice(1));
+      parts = parts.slice(0, -1);
+    }
+    if (parts.length === 0 || parts[0] === "") return undefined;
+
+    result.textStart = decodeURIComponent(parts[0]!);
+    if (parts.length > 1) result.textEnd = decodeURIComponent(parts[1]!);
+    return result;
+  } catch {
+    return undefined;
+  }
+}

--- a/helpers/src/vendor/text-fragments-polyfill/LICENSE
+++ b/helpers/src/vendor/text-fragments-polyfill/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/helpers/src/vendor/text-fragments-polyfill/README.MD
+++ b/helpers/src/vendor/text-fragments-polyfill/README.MD
@@ -1,0 +1,8 @@
+The code in this module has been ported from `text-fragments-polyfill@6.7.0` (https://github.com/GoogleChromeLabs/text-fragments-polyfill/tree/v6.7.0/src), released under the Apache License, Version 2.0.
+
+Two files, both converted from JSDoc-typed JavaScript to TypeScript:
+
+- `textFragmentMatcher.ts` (from `text-fragment-utils.js`): resolves a WICG text-fragment directive to `Range`s in a document (`processTextFragmentDirective`). Dropped only the live CSS highlighting/marking exports (not resolution-related) and the closure-compiler/`goog` module-id interop block, which is dead code in this build. The `internal`/`forTesting` export bundles are kept intact, since `textFragmentGenerator.ts` depends on `internal` directly.
+- `textFragmentGenerator.ts` (from `fragment-generation-utils.js`): the inverse direction — generates a WICG text-fragment directive from a `Range` (`generateFragmentFromRange`), verifying uniqueness by calling back into `textFragmentMatcher.ts`'s `processTextFragmentDirective`/`internal`. Dropped only its own `forTesting` bundle (test-only, per its own upstream comment) and the same `goog` interop block. Renamed its `setTimeout` export to `setFragmentGenerationTimeout` to avoid shadowing the global `setTimeout`.
+
+Both files are kept together deliberately: generation is not independent of matching — it calls directly into matching's internals to verify a candidate directive resolves unambiguously before returning it. Splitting them across packages would mean either duplicating matching's internals elsewhere or generation depending on an incomplete/trimmed copy of it.

--- a/helpers/src/vendor/text-fragments-polyfill/textFragmentGenerator.ts
+++ b/helpers/src/vendor/text-fragments-polyfill/textFragmentGenerator.ts
@@ -1,0 +1,1744 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Ported from text-fragments-polyfill@6.7.0
+// (https://github.com/GoogleChromeLabs/text-fragments-polyfill), converted
+// from JSDoc-typed JavaScript to TypeScript. See README.MD in this directory.
+
+import * as fragments from './textFragmentMatcher.ts';
+import type { TextFragment } from './textFragmentMatcher.ts';
+
+const MAX_EXACT_MATCH_LENGTH = 300;
+const MIN_LENGTH_WITHOUT_CONTEXT = 20;
+const ITERATIONS_BEFORE_ADDING_CONTEXT = 1;
+const WORDS_TO_ADD_FIRST_ITERATION = 3;
+const WORDS_TO_ADD_SUBSEQUENT_ITERATIONS = 1;
+const TRUNCATE_RANGE_CHECK_CHARS = 10000;
+const MAX_DEPTH = 500;
+
+// Desired max run time, in ms. Can be overwritten.
+let timeoutDurationMs: number | null = 500;
+let t0: number; // Start timestamp for fragment generation
+
+class FragmentTimeoutError extends Error {
+  readonly isTimeout = true;
+}
+
+/**
+ * Allows overriding the max runtime to specify a different interval. Fragment
+ * generation will halt and throw an error after this amount of time.
+ * @param newTimeoutDurationMs - the desired timeout length, in ms.
+ */
+export const setFragmentGenerationTimeout = (newTimeoutDurationMs: number | null): void => {
+  timeoutDurationMs = newTimeoutDurationMs;
+};
+
+/**
+ * Enum indicating the success, or failure reason, of generateFragment.
+ */
+export const GenerateFragmentStatus = {
+  SUCCESS: 0,            // A fragment was generated.
+  INVALID_SELECTION: 1,  // The selection provided could not be used.
+  AMBIGUOUS: 2,  // No unique fragment could be identified for this selection.
+  TIMEOUT: 3,    // Computation could not complete in time.
+  EXECUTION_FAILED: 4,  // An exception was raised during generation.
+} as const;
+
+export type GenerateFragmentStatusValue = typeof GenerateFragmentStatus[keyof typeof GenerateFragmentStatus];
+
+export interface GenerateFragmentResult {
+  status: GenerateFragmentStatusValue;
+  fragment?: TextFragment;
+}
+
+/**
+ * Attempts to generate a fragment, suitable for formatting and including in a
+ * URL, which will highlight the given selection upon opening.
+ * @param selection - a Selection object, the result of window.getSelection
+ * @param startTime - the time when generation began, for timeout purposes.
+ *     Defaults to current timestamp.
+ */
+export const generateFragment = (selection: Selection, startTime: number = Date.now()): GenerateFragmentResult => {
+  return doGenerateFragment(selection, startTime);
+};
+
+/**
+ * Attampts to generate a fragment using a given range. @see {@link generateFragment}
+ * @param startTime - the time when generation began, for timeout purposes.
+ *     Defaults to current timestamp.
+ */
+export const generateFragmentFromRange =
+    (range: Range, startTime: number = Date.now()): GenerateFragmentResult => {
+      try {
+        return doGenerateFragmentFromRange(range, startTime);
+      } catch (err) {
+        if (err instanceof FragmentTimeoutError) {
+          return {status: GenerateFragmentStatus.TIMEOUT};
+        } else {
+          return {status: GenerateFragmentStatus.EXECUTION_FAILED};
+        }
+      }
+    };
+
+/**
+ * Checks whether fragment generation can be attempted for a given range. This
+ * checks a handful of simple conditions: the range must be nonempty, not inside
+ * an <input>, etc. A true return is not a guarantee that fragment generation
+ * will succeed; instead, this is a way to quickly rule out generation in cases
+ * where a failure is predictable.
+ * @return true if fragment generation may proceed; false otherwise.
+ */
+// Not called by textFragmentGenerator.ts's own callers — its iframe/window.top
+// check assumes a live page, which doesn't apply to the detached documents
+// this is typically used against. Left as upstream for reference/future use.
+export const isValidRangeForFragmentGeneration = (range: Range): boolean => {
+  // Check that the range isn't just punctuation and whitespace. Only check the
+  // first |TRUNCATE_RANGE_CHECK_CHARS| to put an upper bound on runtime; ranges
+  // that start with (e.g.) thousands of periods should be rare.
+  // This also implicitly ensures the selection isn't in an input or textarea
+  // field, as document.selection contains an empty range in these cases.
+  if (!range.toString()
+           .substring(0, TRUNCATE_RANGE_CHECK_CHARS)
+           .match(fragments.internal.NON_BOUNDARY_CHARS)) {
+    return false;
+  }
+
+  // Check for iframe
+  try {
+    if ((range.startContainer.ownerDocument as Document).defaultView !== window.top) {
+      return false;
+    }
+  } catch {
+    // If accessing window.top throws an error, this is in a cross-origin
+    // iframe.
+    return false;
+  }
+
+  // Walk up the DOM to ensure that the range isn't inside an editable. Limit
+  // the search depth to |MAX_DEPTH| to constrain runtime.
+  let node: Node | null = range.commonAncestorContainer;
+  let numIterations = 0;
+  while (node) {
+    if (node.nodeType == Node.ELEMENT_NODE) {
+      const element = node as Element;
+      if (['TEXTAREA', 'INPUT'].includes(element.tagName.toUpperCase())) {
+        return false;
+      }
+
+      const editable = element.attributes.getNamedItem('contenteditable');
+      if (editable && editable.value !== 'false') {
+        return false;
+      }
+
+      // Cap the number of iterations at |MAX_PRECONDITION_DEPTH| to put an
+      // upper bound on runtime.
+      numIterations++;
+      if (numIterations >= MAX_DEPTH) {
+        return false;
+      }
+    }
+    node = node.parentNode;
+  }
+
+  return true;
+};
+
+/**
+ * @see {@link generateFragment} - this method wraps the error-throwing portions
+ *     of that method.
+ * @throws {Error} - Will throw if computation takes longer than the accepted
+ *     timeout length.
+ */
+const doGenerateFragment =
+    (selection: Selection, startTime: number): GenerateFragmentResult => {
+      let range: Range;
+      try {
+        range = selection.getRangeAt(0);
+      } catch {
+        return {status: GenerateFragmentStatus.INVALID_SELECTION};
+      }
+
+      return doGenerateFragmentFromRange(range, startTime);
+    };
+
+/**
+ * @see {@link doGenerateFragment}
+ */
+const doGenerateFragmentFromRange = (range: Range, startTime: number): GenerateFragmentResult => {
+  recordStartTime(startTime);
+  // Upstream derives all of this from the global `document`/`document.body`
+  // (the live page it's attached to). This is also used against arbitrary,
+  // often-detached parsed documents, so every document/root lookup below is
+  // derived from the range's own nodes.
+  const doc = range.startContainer.ownerDocument as Document;
+  const root = documentBody(doc);
+
+  expandRangeStartToWordBound(range);
+  expandRangeEndToWordBound(range);
+  // Keep a copy of the range before we try to shrink it to make it start and
+  // end in text nodes. We need to use the range edges as starting points
+  // for context term building, so it makes sense to start from the original
+  // edges instead of the edges after shrinking. This way we don't have to
+  // traverse all the non-text nodes that are between the edges after shrinking
+  // and the original ones.
+  const rangeBeforeShrinking = range.cloneRange();
+
+  moveRangeEdgesToTextNodes(range);
+
+  if (range.collapsed) {
+    return {status: GenerateFragmentStatus.INVALID_SELECTION};
+  }
+
+  let factory: FragmentFactory;
+
+  if (canUseExactMatch(range)) {
+    const exactText = fragments.internal.normalizeString(range.toString());
+    const fragment: TextFragment = {
+      textStart: exactText,
+    };
+    // If the exact text is long enough to be used on its own, try this and skip
+    // the longer process below.
+    if (exactText.length >= MIN_LENGTH_WITHOUT_CONTEXT &&
+        isUniquelyIdentifying(fragment, doc, root)) {
+      return {
+        status: GenerateFragmentStatus.SUCCESS,
+        fragment: fragment,
+      };
+    }
+
+    factory = new FragmentFactory(doc, root).setExactTextMatch(exactText);
+  } else {
+    // We have to use textStart and textEnd to identify a range. First, break
+    // the range up based on block boundaries, as textStart/textEnd can't cross
+    // these.
+    const startSearchSpace = getSearchSpaceForStart(range);
+    const endSearchSpace = getSearchSpaceForEnd(range);
+
+    if (startSearchSpace && endSearchSpace) {
+      // If the search spaces are truthy, then there's a block boundary between
+      // them.
+      factory = new FragmentFactory(doc, root).setStartAndEndSearchSpace(
+          startSearchSpace, endSearchSpace);
+    } else {
+      // If the search space was empty/undefined, it's because no block boundary
+      // was found. That means textStart and textEnd *share* a search space, so
+      // our approach must ensure the substrings chosen as candidates don't
+      // overlap.
+      factory = new FragmentFactory(doc, root)
+                    .setSharedSearchSpace(range.toString().trim());
+    }
+  }
+
+  const prefixRange = doc.createRange();
+  prefixRange.selectNodeContents(root);
+  const suffixRange = prefixRange.cloneRange();
+
+  prefixRange.setEnd(
+      rangeBeforeShrinking.startContainer, rangeBeforeShrinking.startOffset);
+  suffixRange.setStart(
+      rangeBeforeShrinking.endContainer, rangeBeforeShrinking.endOffset);
+
+  const prefixSearchSpace = getSearchSpaceForEnd(prefixRange);
+  const suffixSearchSpace = getSearchSpaceForStart(suffixRange);
+
+  if (prefixSearchSpace || suffixSearchSpace) {
+    factory.setPrefixAndSuffixSearchSpace(prefixSearchSpace, suffixSearchSpace);
+  }
+
+  factory.useSegmenter(fragments.internal.makeNewSegmenter(doc));
+
+  let didEmbiggen = false;
+  do {
+    checkTimeout();
+    didEmbiggen = factory.embiggen();
+    const fragment = factory.tryToMakeUniqueFragment();
+    if (fragment != null) {
+      return {
+        status: GenerateFragmentStatus.SUCCESS,
+        fragment: fragment,
+      };
+    }
+  } while (didEmbiggen);
+
+  return {status: GenerateFragmentStatus.AMBIGUOUS};
+};
+
+/**
+ * @throws {Error} - if the timeout duration has been exceeded, an error will
+ *     be thrown so that execution can be halted.
+ */
+// docRoot.body can return a synthesized, still-empty node under some
+// parsers' still-in-progress HTML5 tree construction for a body-less
+// fragment — querying for the real, content-bearing <body> in document
+// order sidesteps that.
+const documentBody = (doc: Document): Element => doc.querySelector('body') ?? doc.documentElement;
+
+const checkTimeout = (): void => {
+  // disable check when no timeout duration specified
+  if (timeoutDurationMs === null) {
+    return;
+  }
+  const delta = Date.now() - t0;
+  if (delta > timeoutDurationMs) {
+    throw new FragmentTimeoutError(`Fragment generation timed out after ${delta} ms.`);
+  }
+};
+
+/**
+ * Call at the start of fragment generation to set the baseline for timeout
+ * checking.
+ * @param newStartTime - the timestamp when fragment generation began
+ */
+const recordStartTime = (newStartTime: number): void => {
+  t0 = newStartTime;
+};
+
+/**
+ * Finds the search space for parameters when using range or suffix match.
+ * This is the text from the start of the range to the first block boundary,
+ * trimmed to remove any leading/trailing whitespace characters.
+ * @param range - the range which will be highlighted.
+ * @return the text which may be used for constructing a textStart parameter
+ *     identifying this range. Will return undefined if no block boundaries
+ *     are found inside this range, or if all the candidate ranges were empty
+ *     (or included only whitespace characters).
+ */
+const getSearchSpaceForStart = (range: Range): string | undefined => {
+  let node: Node | null = getFirstNodeForBlockSearch(range);
+  const walker = makeWalkerForNode(node, range.endContainer);
+  if (!walker) {
+    return undefined;
+  }
+
+  const finishedSubtrees = new Set<Node>();
+  // If the range starts after the last child of an element node
+  // don't visit its subtree because it's not included in the range.
+  if (range.startContainer.nodeType === Node.ELEMENT_NODE &&
+      range.startOffset === range.startContainer.childNodes.length) {
+    finishedSubtrees.add(range.startContainer);
+  }
+  const origin = node;
+  const textAccumulator = new BlockTextAccumulator(range, true);
+  // tempRange monitors whether we've exhausted our search space yet.
+  const tempRange = range.cloneRange();
+  while (!tempRange.collapsed && node != null) {
+    checkTimeout();
+    // Depending on whether |node| is an ancestor of the start of our
+    // search, we use either its leading or trailing edge as our start.
+    if ((node as Element).contains?.(origin)) {
+      tempRange.setStartAfter(node);
+    } else {
+      tempRange.setStartBefore(node);
+    }
+    // Add node to accumulator to keep track of text inside the current block
+    // boundaries
+    textAccumulator.appendNode(node);
+
+    // If the accumulator found a non empty block boundary we've got our search
+    // space.
+    if (textAccumulator.textInBlock !== null) {
+      return textAccumulator.textInBlock;
+    }
+    node = fragments.internal.forwardTraverse(walker, finishedSubtrees);
+  }
+  return undefined;
+};
+
+/**
+ * Finds the search space for parameters when using range or prefix match.
+ * This is the text from the last block boundary to the end of the range,
+ * trimmed to remove any leading/trailing whitespace characters.
+ * @param range - the range which will be highlighted.
+ * @return the text which may be used for constructing a textEnd parameter
+ *     identifying this range. Will return undefined if no block boundaries
+ *     are found inside this range, or if all the candidate ranges were empty
+ *     (or included only whitespace characters).
+ */
+const getSearchSpaceForEnd = (range: Range): string | undefined => {
+  let node: Node | null = getLastNodeForBlockSearch(range);
+  const walker = makeWalkerForNode(node, range.startContainer);
+  if (!walker) {
+    return undefined;
+  }
+  const finishedSubtrees = new Set<Node>();
+  // If the range ends before the first child of an element node
+  // don't visit its subtree because it's not included in the range.
+  if (range.endContainer.nodeType === Node.ELEMENT_NODE &&
+      range.endOffset === 0) {
+    finishedSubtrees.add(range.endContainer);
+  }
+
+  const origin = node;
+  const textAccumulator = new BlockTextAccumulator(range, false);
+
+  // tempRange monitors whether we've exhausted our search space yet.
+  const tempRange = range.cloneRange();
+  while (!tempRange.collapsed && node != null) {
+    checkTimeout();
+    // Depending on whether |node| is an ancestor of the start of our
+    // search, we use either its leading or trailing edge as our end.
+    if ((node as Element).contains?.(origin)) {
+      tempRange.setEnd(node, 0);
+    } else {
+      tempRange.setEndAfter(node);
+    }
+
+    // Add node to accumulator to keep track of text inside the current block
+    // boundaries.
+    textAccumulator.appendNode(node);
+
+    // If the accumulator found a non empty block boundary we've got our search
+    // space.
+    if (textAccumulator.textInBlock !== null) {
+      return textAccumulator.textInBlock;
+    }
+
+    node = fragments.internal.backwardTraverse(walker, finishedSubtrees);
+  }
+  return undefined;
+};
+
+const FactoryMode = {
+  ALL_PARTS: 1,
+  SHARED_START_AND_END: 2,
+  CONTEXT_ONLY: 3,
+} as const;
+type FactoryModeValue = typeof FactoryMode[keyof typeof FactoryMode];
+
+/**
+ * Helper class for constructing range-based fragments for selections that cross
+ * block boundaries.
+ */
+class FragmentFactory {
+  private readonly doc: Document;
+  private readonly root: Element;
+  private readonly Mode = FactoryMode;
+
+  private mode?: FactoryModeValue;
+
+  private startOffset: number | null = null;
+  private endOffset: number | null = null;
+  private prefixOffset: number | null = null;
+  private suffixOffset: number | null = null;
+
+  private prefixSearchSpace = '';
+  private backwardsPrefixSearchSpace = '';
+  private suffixSearchSpace = '';
+
+  private startSearchSpace?: string;
+  private endSearchSpace?: string;
+  private backwardsEndSearchSpace?: string;
+  private sharedSearchSpace?: string;
+  private backwardsSharedSearchSpace?: string;
+  private exactTextMatch?: string;
+
+  private startSegments?: Intl.Segments;
+  private endSegments?: Intl.Segments;
+  private sharedSegments?: Intl.Segments;
+  private prefixSegments?: Intl.Segments;
+  private suffixSegments?: Intl.Segments;
+
+  private numIterations = 0;
+
+  /**
+   * Initializes the basic state of the factory. Users should then call exactly
+   * one of setStartAndEndSearchSpace, setSharedSearchSpace, or
+   * setExactTextMatch, and optionally setPrefixAndSuffixSearchSpace.
+   * @param doc - document to check uniqueness against.
+   * @param root - root element to check uniqueness against.
+   */
+  constructor(doc: Document, root: Element) {
+    this.doc = doc;
+    this.root = root;
+  }
+
+  /**
+   * Generates a fragment based on the current state, then tests it for
+   * uniqueness.
+   * @return a text fragment if the current state is uniquely identifying, or
+   *     undefined if the current state is ambiguous.
+   */
+  tryToMakeUniqueFragment(): TextFragment | undefined {
+    let fragment: TextFragment;
+    if (this.mode === this.Mode.CONTEXT_ONLY) {
+      fragment = {textStart: this.exactTextMatch!};
+    } else {
+      fragment = {
+        textStart:
+            this.getStartSearchSpace().substring(0, this.startOffset!).trim(),
+        textEnd: this.getEndSearchSpace().substring(this.endOffset!).trim(),
+      };
+    }
+    if (this.prefixOffset != null) {
+      const prefix =
+          this.getPrefixSearchSpace().substring(this.prefixOffset).trim();
+      if (prefix) {
+        fragment.prefix = prefix;
+      }
+    }
+    if (this.suffixOffset != null) {
+      const suffix =
+          this.getSuffixSearchSpace().substring(0, this.suffixOffset).trim();
+      if (suffix) {
+        fragment.suffix = suffix;
+      }
+    }
+    return isUniquelyIdentifying(fragment, this.doc, this.root) ? fragment :
+                                                                   undefined;
+  }
+
+  /**
+   * Shifts the current state such that the candidates for textStart and textEnd
+   * represent more of the possible search spaces.
+   * @return true if the desired expansion occurred; false if the entire search
+   *     space has been consumed and no further attempts can be made.
+   */
+  embiggen(): boolean {
+    let canExpandRange = true;
+
+    if (this.mode === this.Mode.SHARED_START_AND_END) {
+      if (this.startOffset! >= this.endOffset!) {
+        // If the search space is shared between textStart and textEnd, then
+        // stop expanding when textStart overlaps textEnd.
+        canExpandRange = false;
+      }
+    } else if (this.mode === this.Mode.ALL_PARTS) {
+      // Stop expanding if both start and end have already consumed their full
+      // search spaces.
+      if (this.startOffset === this.getStartSearchSpace().length &&
+          this.backwardsEndOffset() === this.getEndSearchSpace().length) {
+        canExpandRange = false;
+      }
+    } else if (this.mode === this.Mode.CONTEXT_ONLY) {
+      canExpandRange = false;
+    }
+
+    if (canExpandRange) {
+      const desiredIterations = this.getNumberOfRangeWordsToAdd();
+      if (this.startOffset! < this.getStartSearchSpace().length) {
+        let i = 0;
+        if (this.getStartSegments() != null) {
+          while (i < desiredIterations &&
+                 this.startOffset! < this.getStartSearchSpace().length) {
+            this.startOffset = this.getNextOffsetForwards(
+                this.getStartSegments()!, this.startOffset!,
+                this.getStartSearchSpace());
+            i++;
+          }
+        } else {
+          // We don't have a segmenter, so find the next boundary character
+          // instead. Shift to the next boundary char, and repeat until we've
+          // added a word char.
+          let oldStartOffset = this.startOffset!;
+          do {
+            checkTimeout();
+            const newStartOffset =
+                this.getStartSearchSpace()
+                    .substring(this.startOffset! + 1)
+                    .search(fragments.internal.BOUNDARY_CHARS);
+            if (newStartOffset === -1) {
+              this.startOffset = this.getStartSearchSpace().length;
+            } else {
+              this.startOffset = this.startOffset! + 1 + newStartOffset;
+            }
+            // Only count as an iteration if a word character was added.
+            if (this.getStartSearchSpace()
+                    .substring(oldStartOffset, this.startOffset)
+                    .search(fragments.internal.NON_BOUNDARY_CHARS) !== -1) {
+              oldStartOffset = this.startOffset;
+              i++;
+            }
+          } while (this.startOffset! < this.getStartSearchSpace().length &&
+                   i < desiredIterations);
+        }
+
+        // Ensure we don't have overlapping start and end offsets.
+        if (this.mode === this.Mode.SHARED_START_AND_END) {
+          this.startOffset = Math.min(this.startOffset!, this.endOffset!);
+        }
+      }
+
+      if (this.backwardsEndOffset() < this.getEndSearchSpace().length) {
+        let i = 0;
+        if (this.getEndSegments() != null) {
+          while (i < desiredIterations && this.endOffset! > 0) {
+            this.endOffset = this.getNextOffsetBackwards(
+                this.getEndSegments()!, this.endOffset!);
+            i++;
+          }
+        } else {
+          // No segmenter, so shift to the next boundary char, and repeat until
+          // we've added a word char.
+          let oldBackwardsEndOffset = this.backwardsEndOffset();
+          do {
+            checkTimeout();
+            const newBackwardsOffset =
+                this.getBackwardsEndSearchSpace()
+                    .substring(this.backwardsEndOffset() + 1)
+                    .search(fragments.internal.BOUNDARY_CHARS);
+            if (newBackwardsOffset === -1) {
+              this.setBackwardsEndOffset(this.getEndSearchSpace().length);
+            } else {
+              this.setBackwardsEndOffset(
+                  this.backwardsEndOffset() + 1 + newBackwardsOffset);
+            }
+            // Only count as an iteration if a word character was added.
+            if (this.getBackwardsEndSearchSpace()
+                    .substring(oldBackwardsEndOffset, this.backwardsEndOffset())
+                    .search(fragments.internal.NON_BOUNDARY_CHARS) !== -1) {
+              oldBackwardsEndOffset = this.backwardsEndOffset();
+              i++;
+            }
+          } while (this.backwardsEndOffset() <
+                       this.getEndSearchSpace().length &&
+                   i < desiredIterations);
+        }
+        // Ensure we don't have overlapping start and end offsets.
+        if (this.mode === this.Mode.SHARED_START_AND_END) {
+          this.endOffset = Math.max(this.startOffset!, this.endOffset!);
+        }
+      }
+    }
+
+    let canExpandContext = false;
+    if (!canExpandRange ||
+        this.startOffset! + this.backwardsEndOffset() <
+            MIN_LENGTH_WITHOUT_CONTEXT ||
+        this.numIterations >= ITERATIONS_BEFORE_ADDING_CONTEXT) {
+      // Check if there's any unused search space left.
+      if ((this.backwardsPrefixOffset() != null &&
+           this.backwardsPrefixOffset() !==
+               this.getPrefixSearchSpace().length) ||
+          (this.suffixOffset != null &&
+           this.suffixOffset !== this.getSuffixSearchSpace().length)) {
+        canExpandContext = true;
+      }
+    }
+
+    if (canExpandContext) {
+      const desiredIterations = this.getNumberOfContextWordsToAdd();
+      if (this.backwardsPrefixOffset()! < this.getPrefixSearchSpace().length) {
+        let i = 0;
+        if (this.getPrefixSegments() != null) {
+          while (i < desiredIterations && this.prefixOffset! > 0) {
+            this.prefixOffset = this.getNextOffsetBackwards(
+                this.getPrefixSegments()!, this.prefixOffset!);
+            i++;
+          }
+        } else {
+          // Shift to the next boundary char, and repeat until we've added a
+          // word char.
+          let oldBackwardsPrefixOffset = this.backwardsPrefixOffset()!;
+          do {
+            checkTimeout();
+            const newBackwardsPrefixOffset =
+                this.getBackwardsPrefixSearchSpace()
+                    .substring(this.backwardsPrefixOffset()! + 1)
+                    .search(fragments.internal.BOUNDARY_CHARS);
+            if (newBackwardsPrefixOffset === -1) {
+              this.setBackwardsPrefixOffset(
+                  this.getBackwardsPrefixSearchSpace().length);
+            } else {
+              this.setBackwardsPrefixOffset(
+                  this.backwardsPrefixOffset()! + 1 + newBackwardsPrefixOffset);
+            }
+            // Only count as an iteration if a word character was added.
+            if (this.getBackwardsPrefixSearchSpace()
+                    .substring(
+                        oldBackwardsPrefixOffset, this.backwardsPrefixOffset()!)
+                    .search(fragments.internal.NON_BOUNDARY_CHARS) !== -1) {
+              oldBackwardsPrefixOffset = this.backwardsPrefixOffset()!;
+              i++;
+            }
+          } while (this.backwardsPrefixOffset()! <
+                       this.getPrefixSearchSpace().length &&
+                   i < desiredIterations);
+        }
+      }
+      if (this.suffixOffset! < this.getSuffixSearchSpace().length) {
+        let i = 0;
+        if (this.getSuffixSegments() != null) {
+          while (i < desiredIterations &&
+                 this.suffixOffset! < this.getSuffixSearchSpace().length) {
+            this.suffixOffset = this.getNextOffsetForwards(
+                this.getSuffixSegments()!, this.suffixOffset!,
+                this.getSuffixSearchSpace());
+            i++;
+          }
+        } else {
+          let oldSuffixOffset = this.suffixOffset!;
+          do {
+            checkTimeout();
+            const newSuffixOffset =
+                this.getSuffixSearchSpace()
+                    .substring(this.suffixOffset! + 1)
+                    .search(fragments.internal.BOUNDARY_CHARS);
+            if (newSuffixOffset === -1) {
+              this.suffixOffset = this.getSuffixSearchSpace().length;
+            } else {
+              this.suffixOffset = this.suffixOffset! + 1 + newSuffixOffset;
+            }
+            // Only count as an iteration if a word character was added.
+            if (this.getSuffixSearchSpace()
+                    .substring(oldSuffixOffset, this.suffixOffset)
+                    .search(fragments.internal.NON_BOUNDARY_CHARS) !== -1) {
+              oldSuffixOffset = this.suffixOffset;
+              i++;
+            }
+          } while (this.suffixOffset! < this.getSuffixSearchSpace().length &&
+                   i < desiredIterations);
+        }
+      }
+    }
+    this.numIterations++;
+
+    // TODO: check if this exceeds the total length limit
+    return canExpandRange || canExpandContext;
+  }
+
+  /**
+   * Sets up the factory for a range-based match with a highlight that crosses
+   * block boundaries.
+   *
+   * Exactly one of this, setSharedSearchSpace, or setExactTextMatch should be
+   * called so the factory can identify the fragment.
+   *
+   * @param startSearchSpace - the maximum possible string which can be used to
+   *     identify the start of the fragment
+   * @param endSearchSpace - the maximum possible string which can be used to
+   *     identify the end of the fragment
+   * @return returns |this| to allow call chaining and assignment
+   */
+  setStartAndEndSearchSpace(startSearchSpace: string, endSearchSpace: string): this {
+    this.startSearchSpace = startSearchSpace;
+    this.endSearchSpace = endSearchSpace;
+    this.backwardsEndSearchSpace = reverseString(endSearchSpace);
+
+    this.startOffset = 0;
+    this.endOffset = endSearchSpace.length;
+
+    this.mode = this.Mode.ALL_PARTS;
+    return this;
+  }
+
+  /**
+   * Sets up the factory for a range-based match with a highlight that doesn't
+   * cross block boundaries.
+   *
+   * Exactly one of this, setStartAndEndSearchSpace, or setExactTextMatch should
+   * be called so the factory can identify the fragment.
+   *
+   * @param sharedSearchSpace - the full text of the highlight
+   * @return returns |this| to allow call chaining and assignment
+   */
+  setSharedSearchSpace(sharedSearchSpace: string): this {
+    this.sharedSearchSpace = sharedSearchSpace;
+    this.backwardsSharedSearchSpace = reverseString(sharedSearchSpace);
+
+    this.startOffset = 0;
+    this.endOffset = sharedSearchSpace.length;
+
+    this.mode = this.Mode.SHARED_START_AND_END;
+    return this;
+  }
+
+  /**
+   * Sets up the factory for an exact text match.
+   *
+   * Exactly one of this, setStartAndEndSearchSpace, or setSharedSearchSpace
+   * should be called so the factory can identify the fragment.
+   *
+   * @param exactTextMatch - the full text of the highlight
+   * @return returns |this| to allow call chaining and assignment
+   */
+  setExactTextMatch(exactTextMatch: string): this {
+    this.exactTextMatch = exactTextMatch;
+
+    this.mode = this.Mode.CONTEXT_ONLY;
+    return this;
+  }
+
+  /**
+   * Sets up the factory for context-based matches.
+   * @param prefixSearchSpace - the string to be used as the search space for
+   *     prefix
+   * @param suffixSearchSpace - the string to be used as the search space for
+   *     suffix
+   * @return returns |this| to allow call chaining and assignment
+   */
+  setPrefixAndSuffixSearchSpace(prefixSearchSpace: string | undefined, suffixSearchSpace: string | undefined): this {
+    if (prefixSearchSpace) {
+      this.prefixSearchSpace = prefixSearchSpace;
+      this.backwardsPrefixSearchSpace = reverseString(prefixSearchSpace);
+      this.prefixOffset = prefixSearchSpace.length;
+    }
+
+    if (suffixSearchSpace) {
+      this.suffixSearchSpace = suffixSearchSpace;
+      this.suffixOffset = 0;
+    }
+
+    return this;
+  }
+
+  /**
+   * Sets up the factory to use an instance of Intl.Segmenter when identifying
+   * the start/end of words. |segmenter| is not actually retained; instead it is
+   * used to create segment objects which are cached.
+   *
+   * This must be called AFTER any calls to setStartAndEndSearchSpace,
+   * setSharedSearchSpace, and/or setPrefixAndSuffixSearchSpace, as these search
+   * spaces will be segmented immediately.
+   */
+  useSegmenter(segmenter: Intl.Segmenter | undefined): this {
+    if (segmenter == null) {
+      return this;
+    }
+
+    if (this.mode === this.Mode.ALL_PARTS) {
+      this.startSegments = segmenter.segment(this.startSearchSpace!);
+      this.endSegments = segmenter.segment(this.endSearchSpace!);
+    } else if (this.mode === this.Mode.SHARED_START_AND_END) {
+      this.sharedSegments = segmenter.segment(this.sharedSearchSpace!);
+    }
+
+    if (this.prefixSearchSpace) {
+      this.prefixSegments = segmenter.segment(this.prefixSearchSpace);
+    }
+    if (this.suffixSearchSpace) {
+      this.suffixSegments = segmenter.segment(this.suffixSearchSpace);
+    }
+
+    return this;
+  }
+
+  /**
+   * @return how many words should be added to the prefix and suffix when
+   *     embiggening. This changes depending on the current state of the
+   *     prefix/suffix, so it should be invoked once per embiggen, before either
+   *     is modified.
+   */
+  private getNumberOfContextWordsToAdd(): number {
+    return (this.backwardsPrefixOffset() === 0 && this.suffixOffset === 0) ?
+        WORDS_TO_ADD_FIRST_ITERATION :
+        WORDS_TO_ADD_SUBSEQUENT_ITERATIONS;
+  }
+
+  /**
+   * @return how many words should be added to textStart and textEnd when
+   *     embiggening. This changes depending on the current state of
+   *     textStart/textEnd, so it should be invoked once per embiggen, before
+   *     either is modified.
+   */
+  private getNumberOfRangeWordsToAdd(): number {
+    return (this.startOffset === 0 && this.backwardsEndOffset() === 0) ?
+        WORDS_TO_ADD_FIRST_ITERATION :
+        WORDS_TO_ADD_SUBSEQUENT_ITERATIONS;
+  }
+
+  /**
+   * Helper method for embiggening using Intl.Segmenter. Finds the next offset
+   * to be tried in the forwards direction (i.e., a prefix of the search space).
+   */
+  private getNextOffsetForwards(segments: Intl.Segments, offset: number, searchSpace: string): number {
+    // Find the nearest wordlike segment and move to the end of it.
+    let currentSegment = segments.containing(offset);
+    while (currentSegment != null) {
+      checkTimeout();
+      const currentSegmentEnd =
+          currentSegment.index + currentSegment.segment.length;
+      if (currentSegment.isWordLike) {
+        return currentSegmentEnd;
+      }
+      currentSegment = segments.containing(currentSegmentEnd);
+    }
+    // If we didn't find a wordlike segment by the end of the string, set the
+    // offset to the full search space.
+    return searchSpace.length;
+  }
+
+  /**
+   * Helper method for embiggening using Intl.Segmenter. Finds the next offset
+   * to be tried in the backwards direction (i.e., a suffix of the search
+   * space).
+   */
+  private getNextOffsetBackwards(segments: Intl.Segments, offset: number): number {
+    // Find the nearest wordlike segment and move to the start of it.
+    let currentSegment = segments.containing(offset);
+
+    // Handle two edge cases:
+    //     1. |offset| is at the end of the search space, so |currentSegment|
+    //        is undefined
+    //     2. We're already at the start of a segment, so moving to the start of
+    //        |currentSegment| would be a no-op.
+    // In both cases, the solution is to grab the segment immediately
+    // prior to this offset.
+    if (!currentSegment || offset == currentSegment.index) {
+      // If offset is 0, this will return null, which is handled below.
+      currentSegment = segments.containing(offset - 1);
+    }
+
+    while (currentSegment != null) {
+      checkTimeout();
+      if (currentSegment.isWordLike) {
+        return currentSegment.index;
+      }
+      currentSegment = segments.containing(currentSegment.index - 1);
+    }
+    // If we didn't find a wordlike segment by the start of the string,
+    // set the offset to the full search space.
+    return 0;
+  }
+
+  /** @return the string to be used as the search space for textStart */
+  private getStartSearchSpace(): string {
+    return this.mode === this.Mode.SHARED_START_AND_END ?
+        this.sharedSearchSpace! :
+        this.startSearchSpace!;
+  }
+
+  /**
+   * @return the result of segmenting the start search space using
+   *     Intl.Segmenter, or undefined if a segmenter was not provided.
+   */
+  private getStartSegments(): Intl.Segments | undefined {
+    return this.mode === this.Mode.SHARED_START_AND_END ? this.sharedSegments :
+                                                          this.startSegments;
+  }
+
+  /** @return the string to be used as the search space for textEnd */
+  private getEndSearchSpace(): string {
+    return this.mode === this.Mode.SHARED_START_AND_END ?
+        this.sharedSearchSpace! :
+        this.endSearchSpace!;
+  }
+
+  /**
+   * @return the result of segmenting the end search space using
+   *     Intl.Segmenter, or undefined if a segmenter was not provided.
+   */
+  private getEndSegments(): Intl.Segments | undefined {
+    return this.mode === this.Mode.SHARED_START_AND_END ? this.sharedSegments :
+                                                          this.endSegments;
+  }
+
+  /** @return the string to be used as the search space for textEnd, backwards. */
+  private getBackwardsEndSearchSpace(): string {
+    return this.mode === this.Mode.SHARED_START_AND_END ?
+        this.backwardsSharedSearchSpace! :
+        this.backwardsEndSearchSpace!;
+  }
+
+  /** @return the string to be used as the search space for prefix */
+  private getPrefixSearchSpace(): string {
+    return this.prefixSearchSpace;
+  }
+
+  /**
+   * @return the result of segmenting the prefix search space using
+   *     Intl.Segmenter, or undefined if a segmenter was not provided.
+   */
+  private getPrefixSegments(): Intl.Segments | undefined {
+    return this.prefixSegments;
+  }
+
+  /** @return the string to be used as the search space for prefix, backwards. */
+  private getBackwardsPrefixSearchSpace(): string {
+    return this.backwardsPrefixSearchSpace;
+  }
+
+  /** @return the string to be used as the search space for suffix */
+  private getSuffixSearchSpace(): string {
+    return this.suffixSearchSpace;
+  }
+
+  /**
+   * @return the result of segmenting the suffix search space using
+   *     Intl.Segmenter, or undefined if a segmenter was not provided.
+   */
+  private getSuffixSegments(): Intl.Segments | undefined {
+    return this.suffixSegments;
+  }
+
+  /**
+   * Helper method for doing arithmetic in the backwards search space.
+   * @return the current end offset, as a start offset in the backwards search
+   *     space
+   */
+  private backwardsEndOffset(): number {
+    return this.getEndSearchSpace().length - this.endOffset!;
+  }
+
+  /**
+   * Helper method for doing arithmetic in the backwards search space.
+   * @param backwardsEndOffset - the desired new value of the start offset in
+   *     the backwards search space
+   */
+  private setBackwardsEndOffset(backwardsEndOffset: number): void {
+    this.endOffset = this.getEndSearchSpace().length - backwardsEndOffset;
+  }
+
+  /**
+   * Helper method for doing arithmetic in the backwards search space.
+   * @return the current prefix offset, as a start offset in the backwards
+   *     search space
+   */
+  private backwardsPrefixOffset(): number | null {
+    if (this.prefixOffset == null) return null;
+    return this.getPrefixSearchSpace().length - this.prefixOffset;
+  }
+
+  /**
+   * Helper method for doing arithmetic in the backwards search space.
+   * @param backwardsPrefixOffset - the desired new value of the prefix offset
+   *     in the backwards search space
+   */
+  private setBackwardsPrefixOffset(backwardsPrefixOffset: number): void {
+    if (this.prefixOffset == null) return;
+    this.prefixOffset =
+        this.getPrefixSearchSpace().length - backwardsPrefixOffset;
+  }
+}
+
+type TextNodeLike = Node | { textContent: string };
+
+/**
+ * Helper class to calculate visible text from the start or end of a range
+ * until a block boundary is reached or the range is exhausted.
+ */
+class BlockTextAccumulator {
+  private readonly searchRange: Range;
+  private readonly isForwardTraversal: boolean;
+  private textFound = false;
+  private textNodes: TextNodeLike[] = [];
+  textInBlock: string | null = null;
+
+  /**
+   * @param searchRange - the range for which the text in the last or first
+   *     non empty block boundary will be calculated
+   * @param isForwardTraversal - true if nodes in searchRange will be forward
+   *     traversed
+   */
+  constructor(searchRange: Range, isForwardTraversal: boolean) {
+    this.searchRange = searchRange;
+    this.isForwardTraversal = isForwardTraversal;
+  }
+
+  /**
+   * Adds the next node in the search space range traversal to the accumulator.
+   * The accumulator then will keep track of the text nodes in the range until a
+   * block boundary is found. Once a block boundary is found and the content of
+   * the text nodes in the boundary is non empty, the property textInBlock will
+   * be set with the content of the text nodes, trimmed of leading and trailing
+   * whitespaces.
+   * @param node - next node in the traversal of the searchRange
+   */
+  appendNode(node: Node): void {
+    // If we already calculated the text in the block boundary just ignore any
+    // calls to append nodes.
+    if (this.textInBlock !== null) {
+      return;
+    }
+    // We found a block boundary, check if there's text inside and set it to
+    // textInBlock or keep going to the next block boundary.
+    if (isBlock(node)) {
+      if (this.textFound) {
+        // When traversing backwards the nodes are pushed in reverse order.
+        // Reversing them to get them in the right order.
+        if (!this.isForwardTraversal) {
+          this.textNodes.reverse();
+        }
+        // Concatenate all the text nodes in the block boundary and trim any
+        // trailing and leading whitespaces.
+        this.textInBlock = this.textNodes.map(textNode => textNode.textContent)
+                               .join('')
+                               .trim();
+      } else {
+        // Discard the text nodes visited so far since they are empty and we'll
+        // continue searching in the next block boundary.
+        this.textNodes = [];
+      }
+      return;
+    }
+
+    // Ignore non text nodes.
+    if (!isText(node)) return;
+
+    // Get the part of node inside the search range. This is to avoid
+    // accumulating text that's not inside the range.
+    const nodeToInsert = this.getNodeIntersectionWithRange(node);
+
+    // Keep track of any text found in the block boundary.
+    this.textFound = this.textFound || (nodeToInsert.textContent ?? '').trim() !== '';
+
+    this.textNodes.push(nodeToInsert);
+  }
+
+  /**
+   * Calculates the intersection of a node with searchRange and returns a Text
+   * Node with the intersection
+   * @param node - the node to intercept with searchRange
+   * @return node if node is fully within searchRange or a Text Node with the
+   *     substring of the content of node inside the search range
+   */
+  private getNodeIntersectionWithRange(node: Node): TextNodeLike {
+    let startOffset: number | null = null;
+    let endOffset: number | null = null;
+
+    const textLength = (node.textContent ?? '').length;
+
+    if (node === this.searchRange.startContainer &&
+        this.searchRange.startOffset !== 0) {
+      startOffset = this.searchRange.startOffset;
+    }
+
+    if (node === this.searchRange.endContainer &&
+        this.searchRange.endOffset !== textLength) {
+      endOffset = this.searchRange.endOffset;
+    }
+    if (startOffset !== null || endOffset !== null) {
+      return {
+        textContent: (node.textContent ?? '').substring(
+            startOffset ?? 0, endOffset ?? textLength),
+      };
+    }
+
+    return node;
+  }
+}
+
+/**
+ * @param fragment - the candidate fragment
+ * @param doc - document to check uniqueness against.
+ * @param root - root element to check uniqueness against.
+ * @return true iff the candidate fragment identifies exactly one portion of
+ *     the document.
+ */
+const isUniquelyIdentifying = (fragment: TextFragment, doc: Document, root: Element): boolean => {
+  return fragments.processTextFragmentDirective(fragment, doc, root).length ===
+      1;
+};
+
+/**
+ * Reverses a string. Compound unicode characters are preserved.
+ * @param string - the string to reverse
+ * @return sdrawkcab |gnirts|
+ */
+const reverseString = (string: string): string => {
+  // Spread operator (...) splits full characters, rather than code points, to
+  // avoid breaking compound unicode characters upon reverse.
+  return [...(string || '')].reverse().join('');
+};
+
+/**
+ * Determines whether the conditions for an exact match are met.
+ * @param range - the range for which a fragment is being generated.
+ * @return true if exact matching (i.e., only textStart) can be used; false if
+ *     range matching (i.e., both textStart and textEnd) must be used.
+ */
+const canUseExactMatch = (range: Range): boolean => {
+  if (range.toString().length > MAX_EXACT_MATCH_LENGTH) return false;
+  return !containsBlockBoundary(range);
+};
+
+/**
+ * Finds the node at which a forward traversal through |range| should begin,
+ * based on the range's start container and offset values.
+ * @param range - the range which will be traversed
+ * @return the node where traversal should begin
+ */
+const getFirstNodeForBlockSearch = (range: Range): Node => {
+  // Get a handle on the first node inside the range. For text nodes, this
+  // is the start container; for element nodes, we use the offset to find
+  // where it actually starts.
+  let node: Node = range.startContainer;
+  if (node.nodeType == Node.ELEMENT_NODE &&
+      range.startOffset < node.childNodes.length) {
+    node = node.childNodes[range.startOffset]!;
+  }
+  return node;
+};
+
+/**
+ * Finds the node at which a backward traversal through |range| should begin,
+ * based on the range's end container and offset values.
+ * @param range - the range which will be traversed
+ * @return the node where traversal should begin
+ */
+const getLastNodeForBlockSearch = (range: Range): Node => {
+  // Get a handle on the last node inside the range. For text nodes, this
+  // is the end container; for element nodes, we use the offset to find
+  // where it actually ends. If the offset is 0, the node itself is returned.
+  let node: Node = range.endContainer;
+  if (node.nodeType == Node.ELEMENT_NODE && range.endOffset > 0) {
+    node = node.childNodes[range.endOffset - 1]!;
+  }
+  return node;
+};
+
+/**
+ * Finds the first visible text node within a given range.
+ * @param range - range in which to find the first visible text node
+ * @return first visible text node within |range| or null if there are no
+ *     visible text nodes within |range|
+ */
+const getFirstTextNode = (range: Range): Node | null => {
+  // Check if first node in the range is a visible text node.
+  const firstNode = getFirstNodeForBlockSearch(range);
+  if (isText(firstNode) && fragments.internal.isNodeVisible(firstNode)) {
+    return firstNode;
+  }
+
+  // First node is not visible text, use a tree walker to find the first visible
+  // text node.
+  const walker = fragments.internal.makeTextNodeWalker(range);
+  walker.currentNode = firstNode;
+
+  return walker.nextNode();
+};
+
+/**
+ * Finds the last visible text node within a given range.
+ * @param range - range in which to find the last visible text node
+ * @return last visible text node within |range| or null if there are no
+ *     visible text nodes within |range|
+ */
+const getLastTextNode = (range: Range): Node | null => {
+  // Check if last node in the range is a visible text node.
+  const lastNode = getLastNodeForBlockSearch(range);
+  if (isText(lastNode) && fragments.internal.isNodeVisible(lastNode)) {
+    return lastNode;
+  }
+
+  // Last node is not visible text, traverse the range backwards to find the
+  // last visible text node.
+  const walker = fragments.internal.makeTextNodeWalker(range);
+  walker.currentNode = lastNode;
+
+  return fragments.internal.backwardTraverse(walker, new Set());
+};
+
+/**
+ * Determines whether or not a range crosses a block boundary.
+ * @param range - the range to investigate
+ * @return true if a block boundary was found, false if no such boundary was
+ *     found.
+ */
+const containsBlockBoundary = (range: Range): boolean => {
+  const tempRange = range.cloneRange();
+  let node: Node | null = getFirstNodeForBlockSearch(tempRange);
+  const walker = makeWalkerForNode(node);
+  if (!walker) {
+    return false;
+  }
+  const finishedSubtrees = new Set<Node>();
+
+  while (!tempRange.collapsed && node != null) {
+    if (isBlock(node)) return true;
+    if (node != null) tempRange.setStartAfter(node);
+    node = fragments.internal.forwardTraverse(walker, finishedSubtrees);
+    checkTimeout();
+  }
+  return false;
+};
+
+/**
+ * Attempts to find a word start within the given text node, starting at
+ * |offset| and working backwards.
+ *
+ * @param node - a node to be searched
+ * @param startOffset - the character offset within |node| where the selected
+ *     text begins. If undefined, the entire node will be searched.
+ * @return the number indicating the offset to which a range should be set to
+ *     ensure it starts on a word bound. Returns -1 if the node is not a text
+ *     node, or if no word boundary character could be found.
+ */
+const findWordStartBoundInTextNode = (node: Node, startOffset?: number | null): number => {
+  if (node.nodeType !== Node.TEXT_NODE) return -1;
+  const textNode = node as Text;
+
+  const offset = startOffset != null ? startOffset : textNode.data.length;
+
+  // If the first character in the range is a boundary character, we don't
+  // need to do anything.
+  if (offset < textNode.data.length &&
+      fragments.internal.BOUNDARY_CHARS.test(textNode.data[offset]!))
+    return offset;
+
+  const precedingText = textNode.data.substring(0, offset);
+  const boundaryIndex =
+      reverseString(precedingText).search(fragments.internal.BOUNDARY_CHARS);
+
+  if (boundaryIndex !== -1) {
+    // Because we did a backwards search, the found index counts backwards
+    // from offset, so we subtract to find the start of the word.
+    return offset - boundaryIndex;
+  }
+  return -1;
+};
+
+/**
+ * Attempts to find a word end within the given text node, starting at |offset|.
+ *
+ * @param node - a node to be searched
+ * @param endOffset - the character offset within |node| where the selected
+ *     text end. If undefined, the entire node will be searched.
+ * @return the number indicating the offset to which a range should be set to
+ *     ensure it ends on a word bound. Returns -1 if the node is not a text
+ *     node, or if no word boundary character could be found.
+ */
+const findWordEndBoundInTextNode = (node: Node, endOffset?: number | null): number => {
+  if (node.nodeType !== Node.TEXT_NODE) return -1;
+  const textNode = node as Text;
+
+  const offset = endOffset != null ? endOffset : 0;
+
+  // If the last character in the range is a boundary character, we don't
+  // need to do anything.
+  if (offset < textNode.data.length && offset > 0 &&
+      fragments.internal.BOUNDARY_CHARS.test(textNode.data[offset - 1]!)) {
+    return offset;
+  }
+
+  const followingText = textNode.data.substring(offset);
+  const boundaryIndex = followingText.search(fragments.internal.BOUNDARY_CHARS);
+
+  if (boundaryIndex !== -1) {
+    return offset + boundaryIndex;
+  }
+  return -1;
+};
+
+/**
+ * Helper method to create a TreeWalker useful for finding a block boundary near
+ * a given node.
+ * @param node - the node where the search should start
+ * @param endNode - optional; if included, the root of the walker will be
+ *     chosen to ensure it can traverse at least as far as this node.
+ * @return a TreeWalker, rooted in a block ancestor of |node|, currently
+ *     pointing to |node|, which will traverse only visible text and element
+ *     nodes.
+ */
+const makeWalkerForNode = (node: Node | null, endNode?: Node): TreeWalker | undefined => {
+  if (!node) {
+    return undefined;
+  }
+
+  // Find a block-level ancestor of the node by walking up the tree. This
+  // will be used as the root of the tree walker.
+  let blockAncestor: Node = node;
+  const endNodeNotNull = endNode != null ? endNode : node;
+  while (!(blockAncestor as Element).contains?.(endNodeNotNull) || !isBlock(blockAncestor)) {
+    if (blockAncestor.parentNode) {
+      blockAncestor = blockAncestor.parentNode;
+    }
+  }
+
+  const doc = blockAncestor.ownerDocument ?? (blockAncestor as unknown as Document);
+  const walker = doc.createTreeWalker(
+      blockAncestor, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT, {
+        acceptNode: (node: Node) => fragments.internal.acceptNodeIfVisibleInRange(node),
+      });
+
+  walker.currentNode = node;
+  return walker;
+};
+
+/**
+ * Modifies the start of the range, if necessary, to ensure the selection text
+ * starts after a boundary char (whitespace, etc.) or a block boundary. Can only
+ * expand the range, not shrink it.
+ * @param range - the range to be modified
+ */
+const expandRangeStartToWordBound = (range: Range): void => {
+  const segmenter =
+      fragments.internal.makeNewSegmenter(range.startContainer.ownerDocument ?? undefined);
+  if (segmenter) {
+    // Find the starting text node and offset (since the range may start with a
+    // non-text node).
+    const startNode = getFirstNodeForBlockSearch(range);
+    if (startNode !== range.startContainer) {
+      range.setStartBefore(startNode);
+    }
+
+    expandToNearestWordBoundaryPointUsingSegments(
+        segmenter, /* isRangeEnd= */ false, range);
+  } else {
+    // Simplest case: If we're in a text node, try to find a boundary char in
+    // the same text node.
+    const newOffset =
+        findWordStartBoundInTextNode(range.startContainer, range.startOffset);
+    if (newOffset !== -1) {
+      range.setStart(range.startContainer, newOffset);
+      return;
+    }
+
+    // Also, skip doing any traversal if we're already at the inside edge of
+    // a block node.
+    if (isBlock(range.startContainer) && range.startOffset === 0) {
+      return;
+    }
+
+    const walker = makeWalkerForNode(range.startContainer);
+    if (!walker) {
+      return;
+    }
+    const finishedSubtrees = new Set<Node>();
+
+    let node = fragments.internal.backwardTraverse(walker, finishedSubtrees);
+    while (node != null) {
+      const newOffset = findWordStartBoundInTextNode(node);
+      if (newOffset !== -1) {
+        range.setStart(node, newOffset);
+        return;
+      }
+
+      // If |node| is a block node, then we've hit a block boundary, which
+      // counts as a word boundary.
+      if (isBlock(node)) {
+        if ((node as Element).contains?.(range.startContainer)) {
+          // If the selection starts inside |node|, then the correct range
+          // boundary is the *leading* edge of |node|.
+          range.setStart(node, 0);
+        } else {
+          // Otherwise, |node| is before the selection, so the correct boundary
+          // is the *trailing* edge of |node|.
+          range.setStartAfter(node);
+        }
+        return;
+      }
+
+      node = fragments.internal.backwardTraverse(walker, finishedSubtrees);
+      // We should never get here; the walker should eventually hit a block node
+      // or the root of the document. Collapse range so the caller can handle
+      // this as an error.
+      range.collapse();
+    }
+  }
+};
+
+/**
+ * Moves the range edges to the first and last visible text nodes inside of it.
+ * If there are no visible text nodes in the range then it is collapsed.
+ * @param range - the range to be modified
+ */
+const moveRangeEdgesToTextNodes = (range: Range): void => {
+  const firstTextNode = getFirstTextNode(range);
+  // No text nodes in range. Collapsing the range and early return.
+  if (firstTextNode == null) {
+    range.collapse();
+    return;
+  }
+
+  const firstNode = getFirstNodeForBlockSearch(range);
+
+  // Making sure the range starts with visible text.
+  if (firstNode !== firstTextNode) {
+    range.setStart(firstTextNode, 0);
+  }
+
+  const lastNode = getLastNodeForBlockSearch(range);
+  const lastTextNode = getLastTextNode(range)!;
+  // No need for no text node checks here because we know at there's at least
+  // firstTextNode in the range.
+
+  // Making sure the range ends with visible text.
+  if (lastNode !== lastTextNode) {
+    range.setEnd(lastTextNode, (lastTextNode.textContent ?? '').length);
+  }
+};
+
+/**
+ * Uses Intl.Segmenter to shift the start or end of a range to a word boundary.
+ * Helper method for expandWord*ToWordBound methods.
+ * @param segmenter - object to use for word segmenting
+ * @param isRangeEnd - true if the range end should be modified, false if the
+ *     range start should be modified
+ * @param range - the range to modify
+ */
+const expandToNearestWordBoundaryPointUsingSegments =
+    (segmenter: Intl.Segmenter, isRangeEnd: boolean, range: Range): void => {
+      // Find the index as an offset in the full text of the block in which
+      // boundary occurs.
+      const boundary = isRangeEnd ?
+          {node: range.endContainer, offset: range.endOffset} :
+          {node: range.startContainer, offset: range.startOffset};
+
+      const nodes = getTextNodesInSameBlock(boundary.node);
+      if (!nodes) return;
+      const preNodeText = nodes.preNodes.reduce((prev, cur) => {
+        return prev.concat(cur.textContent ?? '');
+      }, '');
+
+      const innerNodeText = nodes.innerNodes.reduce((prev, cur) => {
+        return prev.concat(cur.textContent ?? '');
+      }, '');
+
+      let offsetInText = preNodeText.length;
+      if (boundary.node.nodeType === Node.TEXT_NODE) {
+        offsetInText += boundary.offset;
+      } else if (isRangeEnd) {
+        offsetInText += innerNodeText.length;
+      }
+
+      // Find the segment of the full block text containing the range start.
+      const postNodeText = nodes.postNodes.reduce((prev, cur) => {
+        return prev.concat(cur.textContent ?? '');
+      }, '');
+
+      const allNodes =
+          [...nodes.preNodes, ...nodes.innerNodes, ...nodes.postNodes];
+
+      // Edge case: There's no text nodes in the block.
+      // In that case there's nothing to do because there is no word boundary
+      // to find.
+      if (allNodes.length == 0) {
+        return;
+      }
+
+      const text = preNodeText.concat(innerNodeText, postNodeText);
+
+      const segments = segmenter.segment(text);
+      const foundSegment = segments.containing(offsetInText);
+
+      if (!foundSegment) {
+        if (isRangeEnd) {
+          range.setEndAfter(allNodes[allNodes.length - 1]!);
+        } else {
+          range.setEndBefore(allNodes[0]!);
+        }
+        return;
+      }
+
+      // Easy case: if the segment is not word-like (i.e., contains whitespace,
+      // punctuation, etc.) then nothing needs to be done because this
+      // boundary point is between words.
+      if (!foundSegment.isWordLike) {
+        return;
+      }
+
+      // Another easy case: if we are at the first/last character of the
+      // segment, then we're done.
+      if (offsetInText === foundSegment.index ||
+          offsetInText === foundSegment.index + foundSegment.segment.length) {
+        return;
+      }
+
+      // We're inside a word. Based on |isRangeEnd|, the target offset will
+      // either be the start or the end of the found segment.
+      const desiredOffsetInText = isRangeEnd ?
+          foundSegment.index + foundSegment.segment.length :
+          foundSegment.index;
+      let newNodeIndexInText = 0;
+      for (const node of allNodes) {
+        const nodeTextLength = (node.textContent ?? '').length;
+        if (newNodeIndexInText <= desiredOffsetInText &&
+            desiredOffsetInText <
+                newNodeIndexInText + nodeTextLength) {
+          const offsetInNode = desiredOffsetInText - newNodeIndexInText;
+          if (isRangeEnd) {
+            if (offsetInNode >= nodeTextLength) {
+              range.setEndAfter(node);
+            } else {
+              range.setEnd(node, offsetInNode);
+            }
+          } else {
+            if (offsetInNode >= nodeTextLength) {
+              range.setStartAfter(node);
+            } else {
+              range.setStart(node, offsetInNode);
+            }
+          }
+          return;
+        }
+        newNodeIndexInText += nodeTextLength;
+      }
+
+      // If we got here, then somehow the offset didn't fall within a node. As a
+      // fallback, move the range to the start/end of the block.
+      if (isRangeEnd) {
+        range.setEndAfter(allNodes[allNodes.length - 1]!);
+      } else {
+        range.setStartBefore(allNodes[0]!);
+      }
+    };
+
+interface TextNodeLists {
+  preNodes: Text[];
+  innerNodes: Text[];
+  postNodes: Text[];
+}
+
+/**
+ * Traverses the DOM to extract all TextNodes appearing in the same block level
+ * as |node| (i.e., those that are descendents of a common ancestor of |node|
+ * with no other block elements in between.)
+ */
+const getTextNodesInSameBlock = (node: Node): TextNodeLists | undefined => {
+  const preNodes: Text[] = [];
+  // First, backtraverse to get to a block boundary
+  const backWalker = makeWalkerForNode(node);
+  if (!backWalker) {
+    return undefined;
+  }
+  const finishedSubtrees = new Set<Node>();
+  let backNode: Node | null =
+      fragments.internal.backwardTraverse(backWalker, finishedSubtrees);
+  while (backNode != null && !isBlock(backNode)) {
+    checkTimeout();
+    if (backNode.nodeType === Node.TEXT_NODE) {
+      preNodes.push(backNode as Text);
+    }
+    backNode =
+        fragments.internal.backwardTraverse(backWalker, finishedSubtrees);
+  }
+  preNodes.reverse();
+
+  const innerNodes: Text[] = [];
+  if (node.nodeType === Node.TEXT_NODE) {
+    innerNodes.push(node as Text);
+  } else {
+    const doc = node.ownerDocument ?? (node as unknown as Document);
+    const walker = doc.createTreeWalker(
+        node, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT, {
+          acceptNode: (n: Node) => fragments.internal.acceptNodeIfVisibleInRange(n),
+        });
+    walker.currentNode = node;
+    let child = walker.nextNode();
+    while (child != null) {
+      checkTimeout();
+      if (child.nodeType === Node.TEXT_NODE) {
+        innerNodes.push(child as Text);
+      }
+      child = walker.nextNode();
+    }
+  }
+
+  const postNodes: Text[] = [];
+  const forwardWalker = makeWalkerForNode(node);
+  if (!forwardWalker) {
+    return undefined;
+  }
+  // Forward traverse from node after having finished its subtree
+  // to get text nodes after it until we find a block boundary.
+  const finishedSubtreesForward = new Set<Node>([node]);
+  let forwardNode: Node | null = fragments.internal.forwardTraverse(
+      forwardWalker, finishedSubtreesForward);
+  while (forwardNode != null && !isBlock(forwardNode)) {
+    checkTimeout();
+    if (forwardNode.nodeType === Node.TEXT_NODE) {
+      postNodes.push(forwardNode as Text);
+    }
+    forwardNode = fragments.internal.forwardTraverse(
+        forwardWalker, finishedSubtreesForward);
+  }
+
+  return {preNodes, innerNodes, postNodes};
+};
+
+/**
+ * Modifies the end of the range, if necessary, to ensure the selection text
+ * ends before a boundary char (whitespace, etc.) or a block boundary. Can only
+ * expand the range, not shrink it.
+ * @param range - the range to be modified
+ */
+const expandRangeEndToWordBound = (range: Range): void => {
+  const segmenter =
+      fragments.internal.makeNewSegmenter(range.endContainer.ownerDocument ?? undefined);
+  if (segmenter) {
+    // Find the ending text node and offset (since the range may end with a
+    // non-text node).
+    const endNode = getLastNodeForBlockSearch(range);
+    if (endNode !== range.endContainer) {
+      range.setEndAfter(endNode);
+    }
+    expandToNearestWordBoundaryPointUsingSegments(
+        segmenter, /* isRangeEnd= */ true, range);
+  } else {
+    let initialOffset: number | null = range.endOffset;
+
+    let node: Node | null = range.endContainer;
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      if (range.endOffset < node.childNodes.length) {
+        node = node.childNodes[range.endOffset]!;
+      }
+    }
+
+    const walker = makeWalkerForNode(node);
+    if (!walker) {
+      return;
+    }
+    // We'll traverse the dom after node's subtree to try to find
+    // either a word or block boundary.
+    const finishedSubtrees = new Set<Node>([node]);
+
+    while (node != null) {
+      checkTimeout();
+
+      const newOffset = findWordEndBoundInTextNode(node, initialOffset);
+      // Future iterations should not use initialOffset; null it out so it is
+      // discarded.
+      initialOffset = null;
+
+      if (newOffset !== -1) {
+        range.setEnd(node, newOffset);
+        return;
+      }
+
+      // If |node| is a block node, then we've hit a block boundary, which
+      // counts as a word boundary.
+      if (isBlock(node)) {
+        if ((node as Element).contains?.(range.endContainer)) {
+          // If the selection starts inside |node|, then the correct range
+          // boundary is the *trailing* edge of |node|.
+          range.setEnd(node, node.childNodes.length);
+        } else {
+          // Otherwise, |node| is after the selection, so the correct boundary
+          // is the *leading* edge of |node|.
+          range.setEndBefore(node);
+        }
+        return;
+      }
+
+      node = fragments.internal.forwardTraverse(walker, finishedSubtrees);
+    }
+    // We should never get here; the walker should eventually hit a block node
+    // or the root of the document. Collapse range so the caller can handle this
+    // as an error.
+    range.collapse();
+  }
+};
+
+/**
+ * Helper to determine if a node is a block element or not.
+ * @param node - the node to evaluate
+ * @return true if the node is an element classified as block-level
+ */
+const isBlock = (node: Node): boolean => {
+  return node.nodeType === Node.ELEMENT_NODE &&
+      (fragments.internal.BLOCK_ELEMENTS.includes((node as Element).tagName.toUpperCase()) ||
+       (node as Element).tagName.toUpperCase() === 'HTML' ||
+       (node as Element).tagName.toUpperCase() === 'BODY');
+};
+
+/**
+ * Helper to determine if a node is a Text Node or not
+ * @param node - the node to evaluate
+ * @return true if the node is a Text Node
+ */
+const isText = (node: Node): boolean => {
+  return node.nodeType === Node.TEXT_NODE;
+};

--- a/helpers/src/vendor/text-fragments-polyfill/textFragmentMatcher.ts
+++ b/helpers/src/vendor/text-fragments-polyfill/textFragmentMatcher.ts
@@ -1,0 +1,883 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Ported from text-fragments-polyfill@6.7.0
+// (https://github.com/GoogleChromeLabs/text-fragments-polyfill), trimmed to
+// the directive-matching subset (dropped the live-highlighting/marking
+// exports) and converted from JSDoc-typed JavaScript to TypeScript. See
+// README.MD in this directory.
+
+export interface TextFragment {
+  textStart: string;
+  textEnd?: string;
+  prefix?: string;
+  suffix?: string;
+}
+
+interface BoundaryPoint {
+  node: Node;
+  offset: number;
+}
+
+type ElementFilterFunction = (node: Node) => number;
+
+// Block elements. elements of a text fragment cannot cross the boundaries of a
+// block element. Source for the list:
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements#Elements
+const BLOCK_ELEMENTS = [
+  'ADDRESS',    'ARTICLE',  'ASIDE',  'BLOCKQUOTE', 'BR',     'DETAILS',
+  'DIALOG',     'DD',       'DIV',    'DL',         'DT',     'FIELDSET',
+  'FIGCAPTION', 'FIGURE',   'FOOTER', 'FORM',       'H1',     'H2',
+  'H3',         'H4',       'H5',     'H6',         'HEADER', 'HGROUP',
+  'HR',         'LI',       'MAIN',   'NAV',        'OL',     'P',
+  'PRE',        'SECTION',  'TABLE',  'UL',         'TR',     'TH',
+  'TD',         'COLGROUP', 'COL',    'CAPTION',    'THEAD',  'TBODY',
+  'TFOOT',
+];
+
+// Characters that indicate a word boundary. Use the script
+// tools/generate-boundary-regex.js if it's necessary to modify or regenerate
+// this. Because it's a hefty regex, this should be used infrequently and only
+// on single-character strings.
+const BOUNDARY_CHARS =
+    /[\t-\r -#%-\*,-\/:;\?@\[-\]_\{\}\x85\xA0\xA1\xA7\xAB\xB6\xB7\xBB\xBF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u0AF0\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166D\u166E\u1680\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2000-\u200A\u2010-\u2029\u202F-\u2043\u2045-\u2051\u2053-\u205F\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E44\u3000-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]|\uD800[\uDD00-\uDD02\uDF9F\uDFD0]|\uD801\uDD6F|\uD802[\uDC57\uDD1F\uDD3F\uDE50-\uDE58\uDE7F\uDEF0-\uDEF6\uDF39-\uDF3F\uDF99-\uDF9C]|\uD804[\uDC47-\uDC4D\uDCBB\uDCBC\uDCBE-\uDCC1\uDD40-\uDD43\uDD74\uDD75\uDDC5-\uDDC9\uDDCD\uDDDB\uDDDD-\uDDDF\uDE38-\uDE3D\uDEA9]|\uD805[\uDC4B-\uDC4F\uDC5B\uDC5D\uDCC6\uDDC1-\uDDD7\uDE41-\uDE43\uDE60-\uDE6C\uDF3C-\uDF3E]|\uD807[\uDC41-\uDC45\uDC70\uDC71]|\uD809[\uDC70-\uDC74]|\uD81A[\uDE6E\uDE6F\uDEF5\uDF37-\uDF3B\uDF44]|\uD82F\uDC9F|\uD836[\uDE87-\uDE8B]|\uD83A[\uDD5E\uDD5F]/u;
+
+// The same thing, but with a ^.
+const NON_BOUNDARY_CHARS =
+    /[^\t-\r -#%-\*,-\/:;\?@\[-\]_\{\}\x85\xA0\xA1\xA7\xAB\xB6\xB7\xBB\xBF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u0AF0\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166D\u166E\u1680\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2000-\u200A\u2010-\u2029\u202F-\u2043\u2045-\u2051\u2053-\u205F\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E44\u3000-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]|\uD800[\uDD00-\uDD02\uDF9F\uDFD0]|\uD801\uDD6F|\uD802[\uDC57\uDD1F\uDD3F\uDE50-\uDE58\uDE7F\uDEF0-\uDEF6\uDF39-\uDF3F\uDF99-\uDF9C]|\uD804[\uDC47-\uDC4D\uDCBB\uDCBC\uDCBE-\uDCC1\uDD40-\uDD43\uDD74\uDD75\uDDC5-\uDDC9\uDDCD\uDDDB\uDDDD-\uDDDF\uDE38-\uDE3D\uDEA9]|\uD805[\uDC4B-\uDC4F\uDC5B\uDC5D\uDCC6\uDDC1-\uDDD7\uDE41-\uDE43\uDE60-\uDE6C\uDF3C-\uDF3E]|\uD807[\uDC41-\uDC45\uDC70\uDC71]|\uD809[\uDC70-\uDC74]|\uD81A[\uDE6E\uDE6F\uDEF5\uDF37-\uDF3B\uDF44]|\uD82F\uDC9F|\uD836[\uDE87-\uDE8B]|\uD83A[\uDD5E\uDD5F]/u;
+
+/**
+ * Searches the document for a given text fragment.
+ *
+ * @param textFragment - Text Fragment to highlight.
+ * @param documentToProcess - document where to extract and mark fragments in.
+ * @param root - the root element where to extract and mark fragments in.
+ * @return Zero or more ranges within the document corresponding to the
+ *     fragment. If the fragment corresponds to more than one location in the
+ *     document (i.e., is ambiguous) then the first two matches will be
+ *     returned (regardless of how many more matches there may be in the
+ *     document).
+ */
+export const processTextFragmentDirective =
+    (textFragment: TextFragment, documentToProcess: Document, root?: Node): Range[] => {
+      const results: Range[] = [];
+
+      const searchRange = documentToProcess.createRange();
+      searchRange.selectNodeContents(root ?? documentToProcess);
+
+      while (!searchRange.collapsed && results.length < 2) {
+        let potentialMatch: Range | undefined;
+        if (textFragment.prefix) {
+          const prefixMatch = findTextInRange(textFragment.prefix, searchRange);
+          if (prefixMatch == null) {
+            break;
+          }
+          // Future iterations, if necessary, should start after the first
+          // character of the prefix match.
+          advanceRangeStartPastOffset(
+              searchRange,
+              prefixMatch.startContainer,
+              prefixMatch.startOffset,
+          );
+
+          // The search space for textStart is everything after the prefix and
+          // before the end of the top-level search range, starting at the next
+          // non- whitespace position.
+          const matchRange = documentToProcess.createRange();
+          matchRange.setStart(prefixMatch.endContainer, prefixMatch.endOffset);
+          matchRange.setEnd(searchRange.endContainer, searchRange.endOffset);
+
+          advanceRangeStartToNonWhitespace(matchRange);
+          if (matchRange.collapsed) {
+            break;
+          }
+
+          potentialMatch = findTextInRange(textFragment.textStart, matchRange);
+          // If textStart wasn't found anywhere in the matchRange, then there's
+          // no possible match and we can stop early.
+          if (potentialMatch == null) {
+            break;
+          }
+
+          // If potentialMatch is immediately after the prefix (i.e., its start
+          // equals matchRange's start), this is a candidate and we should keep
+          // going with this iteration. Otherwise, we'll need to find the next
+          // instance (if any) of the prefix.
+          if (potentialMatch.compareBoundaryPoints(
+                  Range.START_TO_START,
+                  matchRange,
+                  ) !== 0) {
+            continue;
+          }
+        } else {
+          // With no prefix, just look directly for textStart.
+          potentialMatch = findTextInRange(textFragment.textStart, searchRange);
+          if (potentialMatch == null) {
+            break;
+          }
+          advanceRangeStartPastOffset(
+              searchRange,
+              potentialMatch.startContainer,
+              potentialMatch.startOffset,
+          );
+        }
+
+        if (textFragment.textEnd) {
+          const textEndRange = documentToProcess.createRange();
+          textEndRange.setStart(
+              potentialMatch.endContainer, potentialMatch.endOffset);
+          textEndRange.setEnd(searchRange.endContainer, searchRange.endOffset);
+
+          // Keep track of matches of the end term followed by suffix term
+          // (if needed).
+          // If no matches are found then there's no point in keeping looking
+          // for matches of the start term after the current start term
+          // occurrence.
+          let matchFound = false;
+
+          // Search through the rest of the document to find a textEnd match.
+          // This may take multiple iterations if a suffix needs to be found.
+          while (!textEndRange.collapsed && results.length < 2) {
+            const textEndMatch =
+                findTextInRange(textFragment.textEnd, textEndRange);
+            if (textEndMatch == null) {
+              break;
+            }
+
+            advanceRangeStartPastOffset(
+                textEndRange, textEndMatch.startContainer,
+                textEndMatch.startOffset);
+
+            potentialMatch.setEnd(
+                textEndMatch.endContainer, textEndMatch.endOffset);
+
+            if (textFragment.suffix) {
+              // If there's supposed to be a suffix, check if it appears after
+              // the textEnd we just found.
+              const suffixResult = checkSuffix(
+                  textFragment.suffix, potentialMatch, searchRange,
+                  documentToProcess);
+              if (suffixResult === CheckSuffixResult.NO_SUFFIX_MATCH) {
+                break;
+              } else if (suffixResult === CheckSuffixResult.SUFFIX_MATCH) {
+                matchFound = true;
+                results.push(potentialMatch.cloneRange());
+                continue;
+              } else if (suffixResult === CheckSuffixResult.MISPLACED_SUFFIX) {
+                continue;
+              }
+            } else {
+              // If we've found textEnd and there's no suffix, then it's a
+              // match!
+              matchFound = true;
+              results.push(potentialMatch.cloneRange());
+            }
+          }
+          // Stopping match search because suffix or textEnd are missing from
+          // the rest of the search space.
+          if (!matchFound) {
+            break;
+          }
+
+        } else if (textFragment.suffix) {
+          // If there's no textEnd but there is a suffix, search for the suffix
+          // after potentialMatch
+          const suffixResult = checkSuffix(
+              textFragment.suffix, potentialMatch, searchRange,
+              documentToProcess);
+          if (suffixResult === CheckSuffixResult.NO_SUFFIX_MATCH) {
+            break;
+          } else if (suffixResult === CheckSuffixResult.SUFFIX_MATCH) {
+            results.push(potentialMatch.cloneRange());
+            advanceRangeStartPastOffset(
+                searchRange, searchRange.startContainer,
+                searchRange.startOffset);
+            continue;
+          } else if (suffixResult === CheckSuffixResult.MISPLACED_SUFFIX) {
+            continue;
+          }
+        } else {
+          results.push(potentialMatch.cloneRange());
+        }
+      }
+      return results;
+    };
+
+/**
+ * Enum indicating the result of the checkSuffix function.
+ */
+const CheckSuffixResult = {
+  NO_SUFFIX_MATCH: 0,   // Suffix wasn't found at all. Search should halt.
+  SUFFIX_MATCH: 1,      // The suffix matches the expectation.
+  MISPLACED_SUFFIX: 2,  // The suffix was found, but not in the right place.
+} as const;
+
+/**
+ * Checks to see if potentialMatch satisfies the suffix conditions of this
+ * Text Fragment.
+ * @param suffix - the suffix text to find
+ * @param potentialMatch - the Range containing the match text.
+ * @param searchRange - the Range in which to search for |suffix|.
+ *     Regardless of the start boundary of this Range, nothing appearing before
+ *     |potentialMatch| will be considered.
+ * @param documentToProcess - document where to extract and mark fragments in.
+ * @return enum value indicating that potentialMatch should be accepted, that
+ *     the search should continue, or that the search should halt.
+ */
+const checkSuffix =
+    (suffix: string, potentialMatch: Range, searchRange: Range, documentToProcess: Document): number => {
+      const suffixRange = documentToProcess.createRange();
+      suffixRange.setStart(
+          potentialMatch.endContainer,
+          potentialMatch.endOffset,
+      );
+      suffixRange.setEnd(searchRange.endContainer, searchRange.endOffset);
+      advanceRangeStartToNonWhitespace(suffixRange);
+
+      const suffixMatch = findTextInRange(suffix, suffixRange);
+      // If suffix wasn't found anywhere in the suffixRange, then there's no
+      // possible match and we can stop early.
+      if (suffixMatch == null) {
+        return CheckSuffixResult.NO_SUFFIX_MATCH;
+      }
+
+      // If suffixMatch is immediately after potentialMatch (i.e., its start
+      // equals suffixRange's start), this is a match. If not, we have to
+      // start over from the beginning.
+      if (suffixMatch.compareBoundaryPoints(
+              Range.START_TO_START, suffixRange) !== 0) {
+        return CheckSuffixResult.MISPLACED_SUFFIX;
+      }
+
+      return CheckSuffixResult.SUFFIX_MATCH;
+    };
+
+/**
+ * Sets the start of |range| to be the first boundary point after |offset| in
+ * |node|--either at offset+1, or after the node.
+ * @param range - the range to mutate
+ * @param node - the node used to determine the new range start
+ * @param offset - the offset immediately before the desired new boundary point
+ */
+const advanceRangeStartPastOffset = (range: Range, node: Node, offset: number): void => {
+  try {
+    range.setStart(node, offset + 1);
+  } catch (err) {
+    range.setStartAfter(node);
+  }
+};
+
+/**
+ * Modifies |range| to start at the next non-whitespace position.
+ * @param range - the range to mutate
+ */
+const advanceRangeStartToNonWhitespace = (range: Range): void => {
+  const walker = makeTextNodeWalker(range);
+
+  let node = walker.nextNode() as Text | null;
+  while (!range.collapsed && node != null) {
+    if (node !== range.startContainer) {
+      range.setStart(node, 0);
+    }
+
+    if (node.textContent!.length > range.startOffset) {
+      const firstChar = node.textContent![range.startOffset];
+      if (!firstChar.match(/\s/)) {
+        return;
+      }
+    }
+
+    try {
+      range.setStart(node, range.startOffset + 1);
+    } catch (err) {
+      node = walker.nextNode() as Text | null;
+      if (node == null) {
+        range.collapse();
+      } else {
+        range.setStart(node, 0);
+      }
+    }
+  }
+};
+
+/**
+ * Creates a TreeWalker that traverses a range and emits visible text nodes in
+ * the range.
+ * @param range - Range to be traversed by the walker
+ */
+const makeTextNodeWalker = (range: Range): TreeWalker => {
+  const doc = range.commonAncestorContainer.ownerDocument ?? (range.commonAncestorContainer as unknown as Document);
+  return doc.createTreeWalker(
+      range.commonAncestorContainer,
+      NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT,
+      {
+        acceptNode: (node: Node) => acceptTextNodeIfVisibleInRange(node, range),
+      },
+  );
+};
+
+/**
+ * Helper function to check if the element has attribute `hidden="until-found"`.
+ * @param elt - the element to evaluate
+ * @return true if the element has attribute `hidden="until-found"`
+ */
+const isHiddenUntilFound = (elt: Element): boolean => {
+  if ((elt as unknown as { hidden: unknown }).hidden === 'until-found') {
+    return true;
+  }
+  // Workaround for WebKit. See https://bugs.webkit.org/show_bug.cgi?id=238266
+  const attributes = elt.attributes as unknown as Record<string, { value: string } | undefined>;
+  if (attributes && attributes['hidden']) {
+    const value = attributes['hidden']!.value;
+    if (value === 'until-found') {
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
+ * Helper function to calculate the visibility of a Node based on its CSS
+ * computed style. This function does not take into account the visibility of
+ * the node's ancestors so even if the node is visible according to its style
+ * it might not be visible on the page if one of its ancestors is not visible.
+ * @param node - the Node to evaluate
+ * @return true if the node is visible. A node will be visible if
+ * its computed style meets all of the following criteria:
+ *  - non zero height, width, height and opacity
+ *  - visibility not hidden
+ *  - display not none
+ */
+const isNodeVisible = (node: Node): boolean => {
+  // Find an HTMLElement (this node or an ancestor) so we can check
+  // visibility.
+  let elt: Node | null = node;
+  while (elt != null && !(elt instanceof HTMLElement)) elt = elt.parentNode;
+  // A document parsed via DOMParser (as opposed to one attached to a
+  // real browsing context) has no defaultView, and therefore no
+  // rendering/layout at all — nothing to check visibility against, so
+  // every node in it counts as visible.
+  const win = elt?.ownerDocument?.defaultView;
+  if (elt != null && win != null) {
+    if (isHiddenUntilFound(elt)) {
+      return true;
+    }
+    const nodeStyle = win.getComputedStyle(elt);
+    // If the node is not rendered, just skip it.
+    if (nodeStyle.visibility === 'hidden' || nodeStyle.display === 'none' ||
+        parseInt(nodeStyle.height, 10) === 0 &&
+            nodeStyle.overflowY != 'visible' ||
+        parseInt(nodeStyle.width, 10) === 0 &&
+            nodeStyle.overflowX != 'visible' ||
+        parseInt(nodeStyle.opacity, 10) === 0) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * Filter function for use with TreeWalkers. Rejects nodes that aren't in the
+ * given range or aren't visible.
+ * @param node - the Node to evaluate
+ * @param range - the range in which node must fall. Optional; if null, the
+ *     range check is skipped.
+ * @return FILTER_ACCEPT or FILTER_REJECT, to be passed along to a TreeWalker.
+ */
+const acceptNodeIfVisibleInRange = (node: Node, range?: Range): number => {
+  if (range != null && !range.intersectsNode(node))
+    return NodeFilter.FILTER_REJECT;
+
+  return isNodeVisible(node) ? NodeFilter.FILTER_ACCEPT :
+                               NodeFilter.FILTER_REJECT;
+};
+
+/**
+ * Filter function for use with TreeWalkers. Accepts only visible text nodes
+ * that are in the given range. Other types of nodes visible in the given range
+ * are skipped so a TreeWalker using this filter function still visits text
+ * nodes in the node's subtree.
+ * @param node - the Node to evaluate
+ * @param range - the range in which node must fall. Optional; if null, the
+ *     range check is skipped/
+ * @return NodeFilter value to be passed along to a TreeWalker.
+ * Values returned:
+ *  - FILTER_REJECT: Node not in range or not visible.
+ *  - FILTER_SKIP: Non Text Node visible and in range
+ *  - FILTER_ACCEPT: Text Node visible and in range
+ */
+const acceptTextNodeIfVisibleInRange = (node: Node, range?: Range): number => {
+  if (range != null && !range.intersectsNode(node))
+    return NodeFilter.FILTER_REJECT;
+
+  if (!isNodeVisible(node)) {
+    return NodeFilter.FILTER_REJECT;
+  }
+
+  return node.nodeType === Node.TEXT_NODE ? NodeFilter.FILTER_ACCEPT :
+                                            NodeFilter.FILTER_SKIP;
+};
+
+/**
+ * Extracts all the text nodes within the given range.
+ * @param root - the root node in which to search
+ * @param range - a range restricting the scope of extraction
+ * @return a list of lists of text nodes, in document order. Lists represent
+ *     block boundaries; i.e., two nodes appear in the same list iff there are
+ *     no block element starts or ends in between them.
+ */
+const getAllTextNodes = (root: Node, range?: Range): Text[][] => {
+  const blocks: Text[][] = [];
+  let tmp: Text[] = [];
+
+  const nodes = Array.from(
+      getElementsIn(
+          root,
+          (node) => {
+            return acceptNodeIfVisibleInRange(node, range);
+          }),
+  );
+
+  for (const node of nodes) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      tmp.push(node as Text);
+    } else if (
+        node instanceof HTMLElement &&
+        BLOCK_ELEMENTS.includes(node.tagName.toUpperCase()) && tmp.length > 0) {
+      // If this is a block element, the current set of text nodes in |tmp| is
+      // complete, and we need to move on to a new one.
+      blocks.push(tmp);
+      tmp = [];
+    }
+  }
+  if (tmp.length > 0) blocks.push(tmp);
+
+  return blocks;
+};
+
+/**
+ * Returns the textContent of all the textNodes and normalizes strings by
+ * replacing duplicated spaces with single space.
+ * @param nodes - TextNodes to get the textContent from.
+ * @param startOffset - Where to start in the first TextNode.
+ * @param endOffset - Where to end in the last TextNode.
+ * @return Entire text content of all the nodes, with spaces normalized.
+ */
+const getTextContent = (nodes: Text[], startOffset: number, endOffset?: number): string => {
+  let str = '';
+  if (nodes.length === 1) {
+    str = nodes[0]!.textContent!.substring(startOffset, endOffset);
+  } else {
+    str = nodes[0]!.textContent!.substring(startOffset) +
+        nodes.slice(1, -1).reduce((s, n) => s + n.textContent, '') +
+        nodes.slice(-1)[0]!.textContent!.substring(0, endOffset);
+  }
+  return str.replace(/[\t\n\r ]+/g, ' ');
+};
+
+/**
+ * Returns all nodes inside root using the provided filter.
+ * @param root - Node where to start the TreeWalker.
+ * @param filter - Filter provided to the TreeWalker's acceptNode filter.
+ * @yield All elements that were accepted by filter.
+ */
+function* getElementsIn(root: Node, filter: ElementFilterFunction): Generator<Node> {
+  const doc = root.ownerDocument ?? (root as unknown as Document);
+  const treeWalker = doc.createTreeWalker(
+      root,
+      NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
+      {acceptNode: filter},
+  );
+
+  const finishedSubtrees = new Set<Node>();
+  while (forwardTraverse(treeWalker, finishedSubtrees) !== null) {
+    yield treeWalker.currentNode;
+  }
+}
+
+/**
+ * Returns a range pointing to the first instance of |query| within |range|.
+ * @param query - the string to find
+ * @param range - the range in which to search
+ * @return The first found instance of |query| within |range|.
+ */
+const findTextInRange = (query: string, range: Range): Range | undefined => {
+  const textNodeLists = getAllTextNodes(range.commonAncestorContainer, range);
+  const segmenter = makeNewSegmenter(range.commonAncestorContainer.ownerDocument ?? undefined);
+
+  for (const list of textNodeLists) {
+    const found = findRangeFromNodeList(query, range, list, segmenter);
+    if (found !== undefined) return found;
+  }
+  return undefined;
+};
+
+/**
+ * Finds a range pointing to the first instance of |query| within |range|,
+ * searching over the text contained in a list |nodeList| of relevant textNodes.
+ * @param query - the string to find
+ * @param range - the range in which to search
+ * @param textNodes - the visible text nodes within |range|
+ * @param segmenter - a segmenter to be used for finding word boundaries, if
+ *     supported
+ * @return the found range, or undefined if no such range could be found
+ */
+const findRangeFromNodeList = (query: string, range: Range, textNodes: Text[], segmenter?: Intl.Segmenter): Range | undefined => {
+  if (!query || !range || !(textNodes || []).length) return undefined;
+  const startOffset =
+      textNodes[0] === range.startContainer ? range.startOffset : 0;
+  const data =
+      normalizeString(getTextContent(textNodes, startOffset, undefined));
+  const normalizedQuery = normalizeString(query);
+  let searchStart = 0;
+  let start: BoundaryPoint | undefined;
+  let end: BoundaryPoint | undefined;
+  while (searchStart < data.length) {
+    const matchIndex = data.indexOf(normalizedQuery, searchStart);
+    if (matchIndex === -1) return undefined;
+    if (isWordBounded(data, matchIndex, normalizedQuery.length, segmenter)) {
+      const normalizedStartOffset =
+          normalizeString(textNodes[0]!.data.slice(0, startOffset)).length;
+      start = getBoundaryPointAtIndex(
+          normalizedStartOffset + matchIndex, textNodes, /* isEnd=*/ false);
+      end = getBoundaryPointAtIndex(
+          normalizedStartOffset + matchIndex + normalizedQuery.length,
+          textNodes,
+          /* isEnd=*/ true,
+      );
+    }
+
+    if (start != null && end != null) {
+      const foundRange = new Range();
+      foundRange.setStart(start.node, start.offset);
+      foundRange.setEnd(end.node, end.offset);
+
+      // Verify that |foundRange| is a subrange of |range|
+      if (range.compareBoundaryPoints(Range.START_TO_START, foundRange) <= 0 &&
+          range.compareBoundaryPoints(Range.END_TO_END, foundRange) >= 0) {
+        return foundRange;
+      }
+    }
+    searchStart = matchIndex + 1;
+  }
+  return undefined;
+};
+
+/**
+ * Generates a boundary point pointing to the given text position.
+ * @param index - the text offset indicating the start/end of a substring of
+ *     the concatenated, normalized text in |textNodes|
+ * @param textNodes - the text Nodes whose contents make up the search space
+ * @param isEnd - indicates whether the offset is the start or end of the
+ *     substring
+ * @return a boundary point suitable for setting as the start or end of a
+ *     Range, or undefined if it couldn't be computed.
+ */
+const getBoundaryPointAtIndex = (index: number, textNodes: Text[], isEnd: boolean): BoundaryPoint | undefined => {
+  let counted = 0;
+  let normalizedData: string | undefined;
+  for (let i = 0; i < textNodes.length; i++) {
+    const node = textNodes[i]!;
+    if (!normalizedData) normalizedData = normalizeString(node.data);
+    let nodeEnd = counted + normalizedData.length;
+    if (isEnd) nodeEnd += 1;
+    if (nodeEnd > index) {
+      // |index| falls within this node, but we need to turn the offset in the
+      // normalized data into an offset in the real node data.
+      const normalizedOffset = index - counted;
+      let denormalizedOffset = Math.min(index - counted, node.data.length);
+
+      // Walk through the string until denormalizedOffset produces a substring
+      // that corresponds to the target from the normalized data.
+      const targetSubstring = isEnd ?
+          normalizedData.substring(0, normalizedOffset) :
+          normalizedData.substring(normalizedOffset);
+
+      let candidateSubstring = isEnd ?
+          normalizeString(node.data.substring(0, denormalizedOffset)) :
+          normalizeString(node.data.substring(denormalizedOffset));
+
+      // We will either lengthen or shrink the candidate string to approach the
+      // length of the target string. If we're looking for the start, adding 1
+      // makes the candidate shorter; if we're looking for the end, it makes the
+      // candidate longer.
+      const direction = (isEnd ? -1 : 1) *
+          (targetSubstring.length > candidateSubstring.length ? -1 : 1);
+
+      while (denormalizedOffset >= 0 &&
+             denormalizedOffset <= node.data.length) {
+        if (candidateSubstring.length === targetSubstring.length) {
+          return {node: node, offset: denormalizedOffset};
+        }
+
+        denormalizedOffset += direction;
+
+        candidateSubstring = isEnd ?
+            normalizeString(node.data.substring(0, denormalizedOffset)) :
+            normalizeString(node.data.substring(denormalizedOffset));
+      }
+    }
+    counted += normalizedData.length;
+
+    if (i + 1 < textNodes.length) {
+      // Edge case: if this node ends with a whitespace character and the next
+      // node starts with one, they'll be double-counted relative to the
+      // normalized version. Subtract 1 from |counted| to compensate.
+      const nextNormalizedData = normalizeString(textNodes[i + 1]!.data);
+      if (normalizedData.slice(-1) === ' ' &&
+          nextNormalizedData.slice(0, 1) === ' ') {
+        counted -= 1;
+      }
+      // Since we already normalized the next node's data, hold on to it for the
+      // next iteration.
+      normalizedData = nextNormalizedData;
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Checks if a substring is word-bounded in the context of a longer string.
+ *
+ * If an Intl.Segmenter is provided for locale-specific segmenting, it will be
+ * used for this check. This is the most desirable option, but not supported in
+ * all browsers.
+ *
+ * If one is not provided, a heuristic will be applied,
+ * returning true iff:
+ *  - startPos == 0 OR char before start is a boundary char, AND
+ *  - length indicates end of string OR char after end is a boundary char
+ * Where boundary chars are whitespace/punctuation defined in the const above.
+ * This causes the known issue that some languages, notably Japanese, only match
+ * at the level of roughly a full clause or sentence, rather than a word.
+ *
+ * @param text - the text to search
+ * @param startPos - the index of the start of the substring
+ * @param length - the length of the substring
+ * @param segmenter - a segmenter to be used for finding word boundaries, if
+ *     supported
+ * @return true iff startPos and length point to a word-bounded substring of
+ *     |text|.
+ */
+const isWordBounded = (text: string, startPos: number, length: number, segmenter?: Intl.Segmenter): boolean => {
+  if (startPos < 0 || startPos >= text.length || length <= 0 ||
+      startPos + length > text.length) {
+    return false;
+  }
+
+  if (segmenter) {
+    // If the Intl.Segmenter API is available on this client, use it for more
+    // reliable word boundary checking.
+
+    const segments = segmenter.segment(text);
+    const startSegment = segments.containing(startPos);
+    if (!startSegment) return false;
+    // If the start index is inside a word segment but not the first character
+    // in that segment, it's not word-bounded. If it's not a word segment, then
+    // it's punctuation, etc., so that counts for word bounding.
+    if (startSegment.isWordLike && startSegment.index != startPos) return false;
+
+    // |endPos| points to the first character outside the target substring.
+    const endPos = startPos + length;
+    const endSegment = segments.containing(endPos);
+
+    // If there's no end segment found, it's because we're at the end of the
+    // text, which is a valid boundary. (Because of the preconditions we
+    // checked above, we know we aren't out of range.)
+    // If there's an end segment found but it's non-word-like, that's also OK,
+    // since punctuation and whitespace are acceptable boundaries.
+    // Lastly, if there's an end segment and it is word-like, then |endPos|
+    // needs to point to the start of that new word, or |endSegment.index|.
+    if (endSegment && endSegment.isWordLike && endSegment.index != endPos)
+      return false;
+  } else {
+    // We don't have Intl.Segmenter support, so fall back to checking whether or
+    // not the substring is flanked by boundary characters.
+
+    // If the first character is already a boundary, move it once.
+    if (text[startPos]!.match(BOUNDARY_CHARS)) {
+      ++startPos;
+      --length;
+      if (!length) {
+        return false;
+      }
+    }
+
+    // If the last character is already a boundary, move it once.
+    if (text[startPos + length - 1]!.match(BOUNDARY_CHARS)) {
+      --length;
+      if (!length) {
+        return false;
+      }
+    }
+
+    if (startPos !== 0 && (!text[startPos - 1]!.match(BOUNDARY_CHARS)))
+      return false;
+
+    if (startPos + length !== text.length &&
+        !text[startPos + length]!.match(BOUNDARY_CHARS))
+      return false;
+  }
+
+  return true;
+};
+
+/**
+ * @param str - a string to be normalized
+ * @return a normalized version of |str| with all consecutive whitespace chars
+ *     converted to a single ' ' and all diacriticals removed (e.g., 'é' ->
+ *     'e').
+ */
+const normalizeString = (str?: string): string => {
+  // First, decompose any characters with diacriticals. Then, turn all
+  // consecutive whitespace characters into a standard " ", and strip out
+  // anything in the Unicode U+0300..U+036F (Combining Diacritical Marks) range.
+  // This may change the length of the string.
+  return (str || '')
+      .normalize('NFKD')
+      .replace(/\s+/g, ' ')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase();
+};
+
+/**
+ * @param doc - document whose language governs segmentation.
+ * @return a segmenter object suitable for finding word boundaries. Returns
+ *     undefined on browsers/platforms that do not yet support the
+ *     Intl.Segmenter API.
+ */
+const makeNewSegmenter = (doc?: Document): Intl.Segmenter | undefined => {
+  if (Intl.Segmenter) {
+    // Falls back to the runtime's default locale (undefined) rather than
+    // upstream's navigator.language — doc.defaultView is null for a
+    // detached, DOMParser-produced document, which is the common case here.
+    const lang = doc?.documentElement?.lang || doc?.defaultView?.navigator?.language || undefined;
+    return new Intl.Segmenter(lang, {granularity: 'word'});
+  }
+  return undefined;
+};
+
+/**
+ * Performs traversal on a TreeWalker, visiting each subtree in document order.
+ * When visiting a subtree not already visited (its root not in finishedSubtrees
+ * ), first the root is emitted then the subtree is traversed, then the root is
+ * emitted again and then the next subtree in document order is visited.
+ *
+ * Subtree's roots are emitted twice to signal the beginning and ending of
+ * element nodes. This is useful for ensuring the ends of block boundaries are
+ * found.
+ * @param walker - the TreeWalker to be traversed
+ * @param finishedSubtrees - set of subtree roots already visited
+ * @return next node in the traversal
+ */
+const forwardTraverse = (walker: TreeWalker, finishedSubtrees: Set<Node>): Node | null => {
+  // If current node's subtree is not already finished
+  // try to go first down the subtree.
+  if (!finishedSubtrees.has(walker.currentNode)) {
+    const firstChild = walker.firstChild();
+    if (firstChild !== null) {
+      return firstChild;
+    }
+  }
+
+  // If no subtree go to next sibling if any.
+  const nextSibling = walker.nextSibling();
+  if (nextSibling !== null) {
+    return nextSibling;
+  }
+
+  // If no sibling go back to parent and mark it as finished.
+  const parent = walker.parentNode();
+
+  if (parent !== null) {
+    finishedSubtrees.add(parent);
+  }
+
+  return parent;
+};
+
+/**
+ * Performs backwards traversal on a TreeWalker, visiting each subtree in
+ * backwards document order. When visiting a subtree not already visited (its
+ * root not in finishedSubtrees ), first the root is emitted then the subtree is
+ * backward traversed, then the root is emitted again and then the previous
+ * subtree in document order is visited.
+ *
+ * Subtree's roots are emitted twice to signal the beginning and ending of
+ * element nodes. This is useful for ensuring  block boundaries are found.
+ * @param walker - the TreeWalker to be traversed
+ * @param finishedSubtrees - set of subtree roots already visited
+ * @return next node in the backwards traversal
+ */
+const backwardTraverse = (walker: TreeWalker, finishedSubtrees: Set<Node>): Node | null => {
+  // If current node's subtree is not already finished
+  // try to go first down the subtree.
+  if (!finishedSubtrees.has(walker.currentNode)) {
+    const lastChild = walker.lastChild();
+    if (lastChild !== null) {
+      return lastChild;
+    }
+  }
+
+  // If no subtree go to previous sibling if any.
+  const previousSibling = walker.previousSibling();
+  if (previousSibling !== null) {
+    return previousSibling;
+  }
+
+  // If no sibling go back to parent and mark it as finished.
+  const parent = walker.parentNode();
+
+  if (parent !== null) {
+    finishedSubtrees.add(parent);
+  }
+
+  return parent;
+};
+
+/**
+ * Should not be referenced except in the /test directory.
+ */
+export const forTesting = {
+  advanceRangeStartPastOffset,
+  advanceRangeStartToNonWhitespace,
+  findRangeFromNodeList,
+  findTextInRange,
+  getBoundaryPointAtIndex,
+  isWordBounded,
+  makeNewSegmenter,
+  normalizeString,
+  forwardTraverse,
+  backwardTraverse,
+  getAllTextNodes,
+  acceptTextNodeIfVisibleInRange,
+};
+
+/**
+ * Should only be used by other files in this directory.
+ */
+export const internal = {
+  BLOCK_ELEMENTS,
+  BOUNDARY_CHARS,
+  NON_BOUNDARY_CHARS,
+  acceptNodeIfVisibleInRange,
+  normalizeString,
+  makeNewSegmenter,
+  forwardTraverse,
+  backwardTraverse,
+  makeTextNodeWalker,
+  isNodeVisible,
+};

--- a/navigator-html-injectables/CHANGELOG.MD
+++ b/navigator-html-injectables/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0] – 2026-09-08
+
+### Added
+
+- `rangeFromLocator` can now resolve a `Locator`'s `domRange` (an exact node/offset selection) or a WICG text-fragment directive found in `locations.fragments`, in addition to `text.highlight` and element/id fallbacks — trying each strategy in turn and falling through safely if one is invalid or unresolvable ([#249](https://github.com/readium/ts-toolkit/pull/249))
+
 ## [2.6.3] – 2026-07-23
 
 ### Changed

--- a/navigator-html-injectables/package.json
+++ b/navigator-html-injectables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator-html-injectables",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "type": "module",
   "description": "An embeddable solution for connecting frames of HTML publications with a Readium Navigator",
   "author": "readium",

--- a/navigator-html-injectables/src/helpers/locator.ts
+++ b/navigator-html-injectables/src/helpers/locator.ts
@@ -1,9 +1,18 @@
-import { DomRangePoint, getCssSelector, getDomRange, Locator } from "@readium/shared";
+import { DomRangePoint, getCssSelector, getDomRange, Locator, LocatorLocations } from "@readium/shared";
+import { decodeTextFragmentDirective, processTextFragmentDirective } from "@readium/helpers";
 import { TextQuoteAnchor } from "../vendor/hypothesis/anchoring/types.ts";
 
 function isReplacedLikeElement(element: Element): boolean {
     const tagName = element.tagName.toUpperCase();
     return tagName === "IMG" || tagName === "VIDEO" || tagName === "AUDIO" || tagName === "IFRAME" || tagName === "OBJECT" || tagName === "EMBED" || tagName === "CANVAS";
+}
+
+// Root used for text-based searches: the cssSelector-referenced element when
+// present and resolvable, otherwise the whole document body.
+function resolveTextSearchRoot(doc: Document, locations: LocatorLocations | undefined): Element {
+    const cssSelector = locations && getCssSelector(locations);
+    const root = cssSelector ? doc.querySelector(cssSelector) : null;
+    return root ?? doc.body;
 }
 
 function resolveDomRangePoint(doc: Document, point: DomRangePoint): { node: Text; offset?: number } | null {
@@ -61,14 +70,26 @@ export function rangeFromLocator(doc: Document, locator: Locator) {
             }
         }
 
+        // Tried before text.highlight for the same reason as domRange: a
+        // ":~:text=" fragment is a strict superset of what text.highlight can
+        // express (it also supports a textStart...textEnd range), so checking
+        // text.highlight first would mean this branch is rarely reached.
+        if (locations) {
+            const fragmentDirective = locations.fragments
+                ?.map((fragment) => decodeTextFragmentDirective(fragment))
+                .find((directive) => directive !== undefined);
+
+            if (fragmentDirective) {
+                const root = resolveTextSearchRoot(doc, locations);
+                const results = processTextFragmentDirective(fragmentDirective, doc, root);
+                if (results.length > 0) {
+                    return results[0]!;
+                }
+            }
+        }
+
         if (text && text.highlight) {
-            let root;
-            if (locations && getCssSelector(locations)) {
-                root = doc.querySelector(getCssSelector(locations)!);
-            }
-            if (!root) {
-                root = doc.body;
-            }
+            const root = resolveTextSearchRoot(doc, locations);
 
             const anchor = new TextQuoteAnchor(root, text.highlight, {
                 prefix: text.before,

--- a/navigator-html-injectables/src/helpers/locator.ts
+++ b/navigator-html-injectables/src/helpers/locator.ts
@@ -1,5 +1,5 @@
-import { DomRangePoint, getCssSelector, getDomRange, Locator, LocatorLocations } from "@readium/shared";
-import { decodeTextFragmentDirective, processTextFragmentDirective } from "@readium/helpers";
+import { DomRangePoint, getCssSelector, getDomRange, getTextFragment, Locator, LocatorLocations } from "@readium/shared";
+import { processTextFragmentDirective } from "@readium/helpers";
 import { TextQuoteAnchor } from "../vendor/hypothesis/anchoring/types.ts";
 
 function isReplacedLikeElement(element: Element): boolean {
@@ -75,9 +75,7 @@ export function rangeFromLocator(doc: Document, locator: Locator) {
         // express (it also supports a textStart...textEnd range), so checking
         // text.highlight first would mean this branch is rarely reached.
         if (locations) {
-            const fragmentDirective = locations.fragments
-                ?.map((fragment) => decodeTextFragmentDirective(fragment))
-                .find((directive) => directive !== undefined);
+            const fragmentDirective = getTextFragment(locations);
 
             if (fragmentDirective) {
                 const root = resolveTextSearchRoot(doc, locations);

--- a/navigator-html-injectables/src/helpers/locator.ts
+++ b/navigator-html-injectables/src/helpers/locator.ts
@@ -1,4 +1,4 @@
-import { getCssSelector, Locator } from "@readium/shared";
+import { DomRangePoint, getCssSelector, getDomRange, Locator } from "@readium/shared";
 import { TextQuoteAnchor } from "../vendor/hypothesis/anchoring/types.ts";
 
 function isReplacedLikeElement(element: Element): boolean {
@@ -6,11 +6,61 @@ function isReplacedLikeElement(element: Element): boolean {
     return tagName === "IMG" || tagName === "VIDEO" || tagName === "AUDIO" || tagName === "IFRAME" || tagName === "OBJECT" || tagName === "EMBED" || tagName === "CANVAS";
 }
 
+function resolveDomRangePoint(doc: Document, point: DomRangePoint): { node: Text; offset?: number } | null {
+    const container = doc.querySelector(point.cssSelector);
+    if (!container) {
+        console.error(`Can't resolve domRange cssSelector: ${point.cssSelector}`);
+        return null;
+    }
+
+    let index = 0;
+    for (const child of Array.from(container.childNodes)) {
+        if (child.nodeType === Node.TEXT_NODE) {
+            if (index === point.textNodeIndex) {
+                return { node: child as Text, offset: point.charOffset };
+            }
+            index++;
+        }
+    }
+
+    console.error(`Can't resolve domRange textNodeIndex ${point.textNodeIndex} for selector: ${point.cssSelector}`);
+    return null;
+}
+
 // Based on the kotlin-toolkit code
 export function rangeFromLocator(doc: Document, locator: Locator) {
     try {
         const locations = locator.locations;
         const text = locator.text;
+
+        // Tried before text.highlight: a domRange pinpoints an exact node/offset,
+        // which disambiguates between multiple occurrences of the same quote that
+        // a text-based search alone cannot tell apart.
+        if (locations) {
+            const domRange = getDomRange(locations);
+            if (domRange) {
+                const start = resolveDomRangePoint(doc, domRange.start);
+                const end = domRange.end ? resolveDomRangePoint(doc, domRange.end) : start;
+                if (start && end) {
+                    const range = doc.createRange();
+
+                    if (start.offset !== undefined) {
+                        range.setStart(start.node, start.offset);
+                    } else {
+                        range.setStartBefore(start.node);
+                    }
+
+                    if (end.offset !== undefined) {
+                        range.setEnd(end.node, end.offset);
+                    } else {
+                        range.setEndBefore(end.node);
+                    }
+
+                    return range;
+                }
+            }
+        }
+
         if (text && text.highlight) {
             let root;
             if (locations && getCssSelector(locations)) {

--- a/navigator-html-injectables/src/helpers/locator.ts
+++ b/navigator-html-injectables/src/helpers/locator.ts
@@ -51,21 +51,25 @@ export function rangeFromLocator(doc: Document, locator: Locator) {
                 const start = resolveDomRangePoint(doc, domRange.start);
                 const end = domRange.end ? resolveDomRangePoint(doc, domRange.end) : start;
                 if (start && end) {
-                    const range = doc.createRange();
+                    try {
+                        const range = doc.createRange();
 
-                    if (start.offset !== undefined) {
-                        range.setStart(start.node, start.offset);
-                    } else {
-                        range.setStartBefore(start.node);
+                        if (start.offset !== undefined) {
+                            range.setStart(start.node, start.offset);
+                        } else {
+                            range.setStartBefore(start.node);
+                        }
+
+                        if (end.offset !== undefined) {
+                            range.setEnd(end.node, end.offset);
+                        } else {
+                            range.setEndBefore(end.node);
+                        }
+
+                        return range;
+                    } catch (error) {
+                        console.warn("Invalid domRange, falling back:", error);
                     }
-
-                    if (end.offset !== undefined) {
-                        range.setEnd(end.node, end.offset);
-                    } else {
-                        range.setEndBefore(end.node);
-                    }
-
-                    return range;
                 }
             }
         }

--- a/navigator-html-injectables/src/helpers/locator.ts
+++ b/navigator-html-injectables/src/helpers/locator.ts
@@ -22,14 +22,14 @@ function resolveDomRangePoint(doc: Document, point: DomRangePoint): { node: Text
         return null;
     }
 
+    const walker = doc.createTreeWalker(container, NodeFilter.SHOW_TEXT);
     let index = 0;
-    for (const child of Array.from(container.childNodes)) {
-        if (child.nodeType === Node.TEXT_NODE) {
-            if (index === point.textNodeIndex) {
-                return { node: child as Text, offset: point.charOffset };
-            }
-            index++;
+    let node: Node | null;
+    while ((node = walker.nextNode())) {
+        if (index === point.textNodeIndex) {
+            return { node: node as Text, offset: point.charOffset };
         }
+        index++;
     }
 
     console.error(`Can't resolve domRange textNodeIndex ${point.textNodeIndex} for selector: ${point.cssSelector}`);

--- a/navigator-html-injectables/src/helpers/locator.ts
+++ b/navigator-html-injectables/src/helpers/locator.ts
@@ -11,12 +11,25 @@ function isReplacedLikeElement(element: Element): boolean {
 // present and resolvable, otherwise the whole document body.
 function resolveTextSearchRoot(doc: Document, locations: LocatorLocations | undefined): Element {
     const cssSelector = locations && getCssSelector(locations);
-    const root = cssSelector ? doc.querySelector(cssSelector) : null;
-    return root ?? doc.body;
+    let root: Element | null = null;
+    if (cssSelector) {
+        try {
+            root = doc.querySelector(cssSelector);
+        } catch (error) {
+            console.warn(`Invalid cssSelector: ${cssSelector}`, error);
+        }
+    }
+    return root ?? doc.body ?? doc.documentElement;
 }
 
 function resolveDomRangePoint(doc: Document, point: DomRangePoint): { node: Text; offset?: number } | null {
-    const container = doc.querySelector(point.cssSelector);
+    let container: Element | null;
+    try {
+        container = doc.querySelector(point.cssSelector);
+    } catch (error) {
+        console.error(`Invalid domRange cssSelector: ${point.cssSelector}`, error);
+        return null;
+    }
     if (!container) {
         console.error(`Can't resolve domRange cssSelector: ${point.cssSelector}`);
         return null;

--- a/navigator/CHANGELOG.MD
+++ b/navigator/CHANGELOG.MD
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.0] – 2026-09-08
+
+### Added
+
+- Decorations positioned by a `Locator`'s `domRange` or a WICG text-fragment directive are now resolved, in addition to `text.highlight`, via updated `@readium/decorator`/`@readium/navigator-html-injectables`/`@readium/shared` ([#249](https://github.com/readium/ts-toolkit/pull/249))
+
+### Changed
+
+- `@readium/helpers` is now bundled as an external dependency instead of being inlined into the build output ([#249](https://github.com/readium/ts-toolkit/pull/249))
+
 ## [2.8.2] – 2026-08-03
 
 ### Fixed

--- a/navigator/package.json
+++ b/navigator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "type": "module",
   "description": "Next generation SDK for publications in Web Apps",
   "author": "readium",

--- a/navigator/vite.config.js
+++ b/navigator/vite.config.js
@@ -6,7 +6,7 @@ export default defineConfig({
   build: {
     rollupOptions: {
       input: resolve(__dirname, "src/index.ts"),
-      external: [/^@readium\/shared(\/.*)?$/, "@readium/navigator-html-injectables", "@readium/decorator"],
+      external: [/^@readium\/shared(\/.*)?$/, "@readium/navigator-html-injectables", "@readium/decorator", "@readium/helpers"],
       preserveEntrySignatures: "strict",
       output: {
         format: "es",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,10 @@ importers:
         version: 7.3.1(@types/node@25.0.9)
 
   shared:
+    dependencies:
+      '@readium/helpers':
+        specifier: workspace:*
+        version: link:../helpers
     devDependencies:
       '@babel/core':
         specifier: ^7.28.6

--- a/shared/CHANGELOG.MD
+++ b/shared/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] – 2026-09-08
+
+### Added
+
+- `getTextFragment` resolves a WICG Text Fragment directive (`:~:text=...`) from `LocatorLocations.fragments`, via `@readium/helpers`'s new `decodeTextFragmentDirective` ([#249](https://github.com/readium/ts-toolkit/pull/249))
+
 ## [2.4.0] – 2026-07-23
 
 ### Changed

--- a/shared/jest.config.cjs
+++ b/shared/jest.config.cjs
@@ -4,7 +4,8 @@ module.exports = {
         "shared/src/**/*.ts"
     ],
     moduleNameMapper: {
-        "^src/(.*)$": "<rootDir>/src/$1"
+        "^src/(.*)$": "<rootDir>/src/$1",
+        "^@readium/helpers$": "<rootDir>/../helpers/src/index.ts"
     },
     extensionsToTreatAsEsm: [".ts"],
     transform: {

--- a/shared/package.json
+++ b/shared/package.json
@@ -55,6 +55,9 @@
     }
   },
   "sideEffects": false,
+  "dependencies": {
+    "@readium/helpers": "workspace:*"
+  },
   "files": [
     "dist",
     "src",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/shared",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "type": "module",
   "description": "Shared models to be used across other Readium projects and implementations in Typescript",
   "author": "readium",

--- a/shared/src/publication/html/Locations.ts
+++ b/shared/src/publication/html/Locations.ts
@@ -1,6 +1,7 @@
 import { LocatorLocations } from '../Locator.ts';
 import { DomRange } from './DomRange.ts';
 import { parseNptTime } from '../../util/npt.ts';
+import { decodeTextFragmentDirective, TextFragmentDirective } from '@readium/helpers';
 
 // HTML extensions for LocatorLocations.
 // https://github.com/readium/architecture/blob/master/models/locators/extensions/html.md
@@ -15,6 +16,16 @@ export function getPartialCfi(loc: LocatorLocations): string | undefined {
 
 export function getDomRange(loc: LocatorLocations): DomRange | undefined {
   return DomRange.deserialize(loc.otherLocations?.get('domRange'));
+}
+
+// A WICG text-fragment directive (":~:text=...") found among fragments, per
+// https://wicg.github.io/scroll-to-text-fragment/.
+export function getTextFragment(loc: LocatorLocations): TextFragmentDirective | undefined {
+  for (const fragment of loc.fragments) {
+    const directive = decodeTextFragmentDirective(fragment);
+    if (directive) return directive;
+  }
+  return undefined;
 }
 
 export function getFragmentParameters(loc: LocatorLocations): Map<string, string> {

--- a/shared/test/html/Locator.test.ts
+++ b/shared/test/html/Locator.test.ts
@@ -1,4 +1,4 @@
-import { DomRange, DomRangePoint, LocatorLocations, getCssSelector, getPartialCfi, getDomRange } from '../../src';
+import { DomRange, DomRangePoint, LocatorLocations, getCssSelector, getPartialCfi, getDomRange, getTextFragment } from '../../src';
 
 describe('Locator Html Extension Tests', () => {
   it('get Locations {cssSelector} when available', () => {
@@ -41,5 +41,54 @@ describe('Locator Html Extension Tests', () => {
 
   it('get Locations {domRange} when missing', () => {
     expect(getDomRange(new LocatorLocations({}))).toBeUndefined();
+  });
+
+  it('get Locations {textFragment} exact match, when available', () => {
+    expect(
+      getTextFragment(new LocatorLocations({
+        fragments: [':~:text=Hello'],
+      }))
+    ).toEqual({ textStart: 'Hello' });
+  });
+
+  it('get Locations {textFragment} range match with prefix/suffix, when available', () => {
+    expect(
+      getTextFragment(new LocatorLocations({
+        fragments: [':~:text=pre-,Hello,World,-post'],
+      }))
+    ).toEqual({
+      prefix: 'pre',
+      textStart: 'Hello',
+      textEnd: 'World',
+      suffix: 'post',
+    });
+  });
+
+  it('get Locations {textFragment} finds the directive among unrelated fragments', () => {
+    expect(
+      getTextFragment(new LocatorLocations({
+        fragments: ['chapter3', ':~:text=Hello'],
+      }))
+    ).toEqual({ textStart: 'Hello' });
+  });
+
+  it('get Locations {textFragment} finds the directive when glued onto another fragment in the same string', () => {
+    expect(
+      getTextFragment(new LocatorLocations({
+        fragments: ['css(p.chapter):~:text=Hello'],
+      }))
+    ).toEqual({ textStart: 'Hello' });
+  });
+
+  it('get Locations {textFragment} when missing', () => {
+    expect(getTextFragment(new LocatorLocations({}))).toBeUndefined();
+  });
+
+  it('get Locations {textFragment} ignores fragments without a directive', () => {
+    expect(
+      getTextFragment(new LocatorLocations({
+        fragments: ['chapter3', 'css=p.chapter', 'page=12'],
+      }))
+    ).toBeUndefined();
   });
 });

--- a/shared/vite.config.js
+++ b/shared/vite.config.js
@@ -12,6 +12,7 @@ export default defineConfig({
         resolve(__dirname, "src/publication/opds/index.ts"),
         resolve(__dirname, "src/publication/encryption/index.ts"),
       ],
+      external: ["@readium/helpers"],
       preserveEntrySignatures: "strict",
       output: {
         format: "es",


### PR DESCRIPTION
This adds support for `locations.domRange` and `locations.fragments` in `Decorator` module, as well as a helper to extract the text fragment in `shared.`

Note Google’s polyfill is vendored due to it assuming `document.body`, which is an issue with a detached DOM. 