### PR TITLE
Handle update of Decorations on scroll event

### DIFF
--- a/decorator/CHANGELOG.MD
+++ b/decorator/CHANGELOG.MD
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Decorations rendered via the DOM overlay path no longer stay frozen at their original position when the reader scrolls, and every group is now correctly relaid out on resize, including ones that only use the CSS Highlight API, via updated `@readium/navigator-html-injectables`
+- `Highlight` decorations with `layout: Bounds` no longer render as an opaque block hiding the underlying text on iPadOS Safari, via updated `@readium/navigator-html-injectables`
 
 ## [1.1.0] – 2026-09-08
 

--- a/decorator/CHANGELOG.MD
+++ b/decorator/CHANGELOG.MD
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Decorations rendered via the DOM overlay path no longer stay frozen at their original position when the reader scrolls, and are now correctly relaid out on resize when mixed into a group that also uses the CSS Highlight API, via updated `@readium/navigator-html-injectables`
+- Decorations rendered via the DOM overlay path no longer stay frozen at their original position when the reader scrolls, and every group is now correctly relaid out on resize, including ones that only use the CSS Highlight API, via updated `@readium/navigator-html-injectables`
 
 ## [1.1.0] – 2026-09-08
 

--- a/decorator/CHANGELOG.MD
+++ b/decorator/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] – 2026-09-09
+
+### Fixed
+
+- Decorations rendered via the DOM overlay path no longer stay frozen at their original position when the reader scrolls, and are now correctly relaid out on resize when mixed into a group that also uses the CSS Highlight API, via updated `@readium/navigator-html-injectables`
+
 ## [1.1.0] – 2026-09-08
 
 ### Added

--- a/decorator/package.json
+++ b/decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/decorator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "description": "Standalone decoration controller and renderer for HTML content",
   "author": "readium",

--- a/navigator-html-injectables/CHANGELOG.MD
+++ b/navigator-html-injectables/CHANGELOG.MD
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Decorations rendered via the DOM overlay path (`Outline`, `Template`, `Mask`, `Bounds`/`Viewport`/`Page` width, `expand`, or any style when the browser lacks `CSS.highlights` support) are now repositioned when the reader scrolls, instead of staying frozen at their original position. `Decorator` also now relayouts every group on resize, including ones that only use the CSS Highlight API — previously skipped entirely, leaving their hit-testing rects stale
 - `rangeFromLocator` now resolves a `domRange`'s `textNodeIndex` against direct-child text nodes only, matching the Locator spec; it previously walked every text-node descendant, so any container with a nested inline element (`<a>`, `<em>`, `<span>`, ...) resolved the wrong node and threw `IndexSizeError`
+- `Highlight` decorations with `layout: Bounds` no longer render as an opaque block hiding the underlying text on iPadOS Safari; `mix-blend-mode` was silently failing to blend there
 
 ## [2.7.0] – 2026-09-08
 

--- a/navigator-html-injectables/CHANGELOG.MD
+++ b/navigator-html-injectables/CHANGELOG.MD
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Decorations rendered via the DOM overlay path (`Outline`, `Template`, `Mask`, `Bounds`/`Viewport`/`Page` width, `expand`, or any style when the browser lacks `CSS.highlights` support) are now repositioned when the reader scrolls, instead of staying frozen at their original position. `Decorator` also now correctly relayouts DOM-overlay items on resize when they're mixed into a group that otherwise uses the CSS Highlight API — previously skipped entirely
+- Decorations rendered via the DOM overlay path (`Outline`, `Template`, `Mask`, `Bounds`/`Viewport`/`Page` width, `expand`, or any style when the browser lacks `CSS.highlights` support) are now repositioned when the reader scrolls, instead of staying frozen at their original position. `Decorator` also now relayouts every group on resize, including ones that only use the CSS Highlight API — previously skipped entirely, leaving their hit-testing rects stale
 - `rangeFromLocator` now resolves a `domRange`'s `textNodeIndex` against direct-child text nodes only, matching the Locator spec; it previously walked every text-node descendant, so any container with a nested inline element (`<a>`, `<em>`, `<span>`, ...) resolved the wrong node and threw `IndexSizeError`
 
 ## [2.7.0] – 2026-09-08

--- a/navigator-html-injectables/CHANGELOG.MD
+++ b/navigator-html-injectables/CHANGELOG.MD
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Decorations rendered via the DOM overlay path (`Outline`, `Template`, `Mask`, `Bounds`/`Viewport`/`Page` width, `expand`, or any style when the browser lacks `CSS.highlights` support) are now repositioned when the reader scrolls, instead of staying frozen at their original position. `Decorator` also now correctly relayouts DOM-overlay items on resize when they're mixed into a group that otherwise uses the CSS Highlight API — previously skipped entirely
+- `rangeFromLocator` now resolves a `domRange`'s `textNodeIndex` against direct-child text nodes only, matching the Locator spec; it previously walked every text-node descendant, so any container with a nested inline element (`<a>`, `<em>`, `<span>`, ...) resolved the wrong node and threw `IndexSizeError`
 
 ## [2.7.0] – 2026-09-08
 

--- a/navigator-html-injectables/CHANGELOG.MD
+++ b/navigator-html-injectables/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.1] – 2026-09-09
+
+### Fixed
+
+- Decorations rendered via the DOM overlay path (`Outline`, `Template`, `Mask`, `Bounds`/`Viewport`/`Page` width, `expand`, or any style when the browser lacks `CSS.highlights` support) are now repositioned when the reader scrolls, instead of staying frozen at their original position. `Decorator` also now correctly relayouts DOM-overlay items on resize when they're mixed into a group that otherwise uses the CSS Highlight API — previously skipped entirely
+
 ## [2.7.0] – 2026-09-08
 
 ### Added

--- a/navigator-html-injectables/package.json
+++ b/navigator-html-injectables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator-html-injectables",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "type": "module",
   "description": "An embeddable solution for connecting frames of HTML publications with a Readium Navigator",
   "author": "readium",

--- a/navigator-html-injectables/src/helpers/locator.ts
+++ b/navigator-html-injectables/src/helpers/locator.ts
@@ -35,14 +35,14 @@ function resolveDomRangePoint(doc: Document, point: DomRangePoint): { node: Text
         return null;
     }
 
-    const walker = doc.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+    // textNodeIndex counts only direct-child text nodes (spec: html.md "child Text node"),
+    // matching the generator in @readium/speech's domRangeGenerator.
     let index = 0;
-    let node: Node | null;
-    while ((node = walker.nextNode())) {
-        if (index === point.textNodeIndex) {
-            return { node: node as Text, offset: point.charOffset };
+    for (const child of container.childNodes) {
+        if (child.nodeType === Node.TEXT_NODE) {
+            if (index === point.textNodeIndex) return { node: child as Text, offset: point.charOffset };
+            index++;
         }
-        index++;
     }
 
     console.error(`Can't resolve domRange textNodeIndex ${point.textNodeIndex} for selector: ${point.cssSelector}`);

--- a/navigator-html-injectables/src/helpers/locator.ts
+++ b/navigator-html-injectables/src/helpers/locator.ts
@@ -35,8 +35,7 @@ function resolveDomRangePoint(doc: Document, point: DomRangePoint): { node: Text
         return null;
     }
 
-    // textNodeIndex counts only direct-child text nodes (spec: html.md "child Text node"),
-    // matching the generator in @readium/speech's domRangeGenerator.
+    // textNodeIndex counts only direct-child text nodes (spec: html.md "child Text node").
     let index = 0;
     for (const child of container.childNodes) {
         if (child.nodeType === Node.TEXT_NODE) {

--- a/navigator-html-injectables/src/modules/Decorator.ts
+++ b/navigator-html-injectables/src/modules/Decorator.ts
@@ -1239,9 +1239,7 @@ export class Decorator extends Module {
     private handleResize() {
         this.wnd.clearTimeout(this.resizeFrame);
         this.resizeFrame = this.wnd.setTimeout(() => {
-            this.groups.forEach(g => {
-                if(g.hasOverlayItems) g.requestLayout();
-            });
+            this.groups.forEach(g => g.requestLayout());
         }, 50);
     }
     private readonly handleResizer = this.handleResize.bind(this);

--- a/navigator-html-injectables/src/modules/Decorator.ts
+++ b/navigator-html-injectables/src/modules/Decorator.ts
@@ -6,7 +6,7 @@ import { ModuleName } from "./ModuleLibrary.ts";
 import { Rect, getClientRectsNoOverlap, getTextClientRects, rectContainsPoint } from "../helpers/rect.ts";
 import { getProperty } from "../helpers/css.ts";
 import { isDarkColor, getContrastingTextColor, adjustColorForContrast, colorToRgba } from "@readium/helpers";
-import { makeWritingContext } from "../helpers/document.ts";
+import { makeWritingContext, WritingContext } from "../helpers/document.ts";
 import { sML } from "@readium/helpers";
 import { sanitizeHTML } from "../helpers/sanitize.ts";
 
@@ -506,6 +506,25 @@ class DecorationGroup {
         });
     }
 
+    /**
+     * Cheap scroll-driven pass: repositions existing overlay elements in place instead of
+     * requestLayout()'s full destroy-and-rebuild, only falling back to a full layout()
+     * per item when geometry has genuinely changed shape (a real reflow).
+     */
+    repositionOverlays() {
+        let hasMaskItem = false;
+        this.items.forEach(item => {
+            if (this.experimentalHighlights && !this.notTextFlag?.has(item.id)) return;
+            if (item.decoration.style?.type === DecorationStyleType.Mask) {
+                hasMaskItem = true;
+                return;
+            }
+            if (!this.repositionItem(item)) this.layout(item);
+            item.hitRects = this.clientRectsToDocCoords(getClientRectsNoOverlap(item.range, false, false, ((item.decoration.style as BuiltinDecorationStyle).expand ?? 0) + this.hitGap()));
+        });
+        if (hasMaskItem) this.updateSharedMask();
+    }
+
     private experimentalLayout(item: DecorationItem) {
         const stylesheet = this.requireContainer(true) as HTMLStyleElement;
         const cssHighlights = (this.wnd as any).CSS.highlights as Map<string, any>;
@@ -661,6 +680,132 @@ class DecorationGroup {
     }
 
     /**
+     * Positions a single overlay element according to the decoration's width mode.
+     */
+    private positionElement(item: DecorationItem, ctx: WritingContext, iz: number, element: HTMLElement, rect: Rect, boundingRect: DOMRect, inlineInset = 0) {
+        const w = item.decoration?.style?.width;
+        const r = rect;
+        switch (w) {
+            case DecorationWidth.Viewport: {
+                const snap = Math.floor(ctx.inlineStart(r) / ctx.viewportInlineSize) * ctx.viewportInlineSize;
+                ctx.applyPosition(element, snap + ctx.inlineScrollOffset + inlineInset, ctx.blockStart(r) + ctx.blockScrollOffset, ctx.viewportInlineSize - 2 * inlineInset, ctx.blockSize(r), iz);
+                break;
+            }
+            case DecorationWidth.Page: {
+                const snap = Math.floor(ctx.inlineStart(r) / ctx.pageInlineSize) * ctx.pageInlineSize;
+                ctx.applyPosition(element, snap + ctx.inlineScrollOffset + inlineInset, ctx.blockStart(r) + ctx.blockScrollOffset, ctx.pageInlineSize - 2 * inlineInset, ctx.blockSize(r), iz);
+                break;
+            }
+            case DecorationWidth.Bounds: {
+                ctx.applyPosition(element, ctx.inlineStart(boundingRect) + ctx.inlineScrollOffset, ctx.blockStart(r) + ctx.blockScrollOffset, ctx.inlineSize(boundingRect), ctx.blockSize(r), iz);
+                break;
+            }
+            default: {
+                ctx.applyPosition(element, ctx.inlineStart(r) + ctx.inlineScrollOffset, ctx.blockStart(r) + ctx.blockScrollOffset, ctx.inlineSize(r), ctx.blockSize(r), iz);
+            }
+        }
+    }
+
+    /**
+     * Computes the ordered list of rects an overlay item's elements should occupy
+     * (one rect for Bounds layout, one per merged client rect for Boxes layout).
+     * Shared between the full build path (layout) and the cheap reposition path.
+     */
+    private computeOverlayRects(item: DecorationItem, ctx: WritingContext, boundingRect: DOMRect, expand: number): Rect[] {
+        if (item.decoration?.style?.layout === DecorationLayout.Bounds) {
+            const boundsRect: Rect = expand ? {
+                left:   boundingRect.left   - expand,
+                right:  boundingRect.right  + expand,
+                top:    boundingRect.top    - expand,
+                bottom: boundingRect.bottom + expand,
+                width:  boundingRect.width  + expand * 2,
+                height: boundingRect.height + expand * 2,
+            } : boundingRect;
+            return [boundsRect];
+        }
+
+        // Fall back to "boxes" value for layout.
+        // For underline/strikethrough, pre-filter to text-node rects only so Ruby
+        // (rt/rp) glyphs don't produce a separate decoration segment above the base text.
+        const decoStyle = item.decoration.style;
+        const decoType = (decoStyle as BuiltinDecorationStyle).type;
+        const isLineDecoration = decoType === DecorationStyleType.Underline
+            || decoType === DecorationStyleType.Strikethrough;
+        const isStrikethrough = decoType === DecorationStyleType.Strikethrough;
+        const rectSource = isLineDecoration
+            ? getTextClientRects(item.range, ["rt", "rp"])
+            : item.range;
+        // Line decorations (underline/strikethrough) don't expand in the block axis —
+        // expand extends endpoints along the inline axis only.
+        let clientRects = getClientRectsNoOverlap(
+            rectSource,
+            true,              // doNotMergeHorizontallyAlignedRects
+            ctx.isVertical,    // doNotMergeVerticallyAlignedRects
+            isLineDecoration ? 0 : expand
+        );
+
+        clientRects = clientRects.sort((r1, r2) => {
+            if (ctx.isVertical) {
+                // vertical-rl: rightmost column first; vertical-lr: leftmost first
+                const factor = ctx.isVertLR ? 1 : -1;
+                return factor * (r1.left - r2.left);
+            }
+            return r1.top - r2.top;
+        });
+
+        return clientRects.map(clientRect => {
+            let posRect: Rect = clientRect;
+            if (isStrikethrough) {
+                // Thin the rect to ~10% of block size, centred on the mid-line.
+                const thickness = ctx.blockSize(clientRect) * 0.1;
+                const blockMid  = ctx.blockStart(clientRect) + ctx.blockSize(clientRect) / 2;
+                const bs = blockMid - thickness / 2;
+                posRect = ctx.isVertical
+                    ? { left: bs, right: bs + thickness, top: clientRect.top,    bottom: clientRect.bottom, width: thickness,           height: clientRect.height }
+                    : { top:  bs, bottom: bs + thickness, left: clientRect.left, right: clientRect.right,   height: thickness,           width: clientRect.width  };
+            }
+            if (expand && isLineDecoration) {
+                posRect = ctx.isVertical
+                    ? { ...posRect, top: posRect.top - expand, bottom: posRect.bottom + expand, height: posRect.height + expand * 2 }
+                    : { ...posRect, left: posRect.left - expand, right: posRect.right + expand, width: posRect.width + expand * 2 };
+            }
+            return posRect;
+        });
+    }
+
+    /**
+     * Cheaply repositions an already-rendered overlay item's existing elements in place,
+     * without destroying and rebuilding them. Returns false if the element count no
+     * longer matches the current geometry (a genuine reflow happened), signalling the
+     * caller to fall back to a full layout().
+     */
+    private repositionItem(item: DecorationItem): boolean {
+        if (!item.container) return true;
+        const decoStyle = item.decoration.style;
+        if (decoStyle.type !== DecorationStyleType.Template) {
+            const type = (decoStyle as BuiltinDecorationStyle).type ?? DecorationStyleType.Highlight;
+            if (type === DecorationStyleType.TextColor || type === DecorationStyleType.Mask) return true;
+        }
+
+        const ctx = makeWritingContext(this.wnd);
+        const iz = 1 / this.effectiveZoom();
+        const expand = (decoStyle as BuiltinDecorationStyle).expand ?? 0;
+        const boundingRect = item.range.getBoundingClientRect();
+        const outlineInset = (() => {
+            if ((decoStyle as BuiltinDecorationStyle).type !== DecorationStyleType.Outline) return 0;
+            const w = (decoStyle as BuiltinDecorationStyle).width;
+            return (w === DecorationWidth.Page || w === DecorationWidth.Viewport) ? 3 : 0;
+        })();
+
+        const rects = this.computeOverlayRects(item, ctx, boundingRect, expand);
+        const children = Array.from(item.container.children) as HTMLElement[];
+        if (children.length !== rects.length) return false;
+
+        children.forEach((el, i) => this.positionElement(item, ctx, iz, el, rects[i], boundingRect, outlineInset));
+        return true;
+    }
+
+    /**
      * Layouts a single DecorationItem.
      * @param item
      */
@@ -682,29 +827,6 @@ class DecorationGroup {
         const iz = 1 / this.effectiveZoom();
 
         const expand = (item.decoration.style as BuiltinDecorationStyle).expand ?? 0;
-        const positionElement = (element: HTMLElement, rect: Rect, boundingRect: DOMRect, inlineInset = 0) => {
-            const w = item.decoration?.style?.width;
-            const r = rect;
-            switch (w) {
-                case DecorationWidth.Viewport: {
-                    const snap = Math.floor(ctx.inlineStart(r) / ctx.viewportInlineSize) * ctx.viewportInlineSize;
-                    ctx.applyPosition(element, snap + ctx.inlineScrollOffset + inlineInset, ctx.blockStart(r) + ctx.blockScrollOffset, ctx.viewportInlineSize - 2 * inlineInset, ctx.blockSize(r), iz);
-                    break;
-                }
-                case DecorationWidth.Page: {
-                    const snap = Math.floor(ctx.inlineStart(r) / ctx.pageInlineSize) * ctx.pageInlineSize;
-                    ctx.applyPosition(element, snap + ctx.inlineScrollOffset + inlineInset, ctx.blockStart(r) + ctx.blockScrollOffset, ctx.pageInlineSize - 2 * inlineInset, ctx.blockSize(r), iz);
-                    break;
-                }
-                case DecorationWidth.Bounds: {
-                    ctx.applyPosition(element, ctx.inlineStart(boundingRect) + ctx.inlineScrollOffset, ctx.blockStart(r) + ctx.blockScrollOffset, ctx.inlineSize(boundingRect), ctx.blockSize(r), iz);
-                    break;
-                }
-                default: {
-                    ctx.applyPosition(element, ctx.inlineStart(r) + ctx.inlineScrollOffset, ctx.blockStart(r) + ctx.blockScrollOffset, ctx.inlineSize(r), ctx.blockSize(r), iz);
-                }
-            }
-        }
         const boundingRect = item.range.getBoundingClientRect();
 
         const decoStyle = item.decoration.style;
@@ -832,70 +954,12 @@ class DecorationGroup {
             elementTemplate = template.content.firstElementChild!;
         }
 
-        if(item.decoration?.style?.layout === DecorationLayout.Bounds) {
-            const bounds = elementTemplate.cloneNode(true) as HTMLDivElement;
-            bounds.style.setProperty("pointer-events", "none");
-            const boundsRect: Rect = expand ? {
-                left:   boundingRect.left   - expand,
-                right:  boundingRect.right  + expand,
-                top:    boundingRect.top    - expand,
-                bottom: boundingRect.bottom + expand,
-                width:  boundingRect.width  + expand * 2,
-                height: boundingRect.height + expand * 2,
-            } : boundingRect;
-            positionElement(bounds, boundsRect, boundingRect, outlineInset);
-            itemContainer.append(bounds);
-        } else {
-            // Fall back to "boxes" value for layout.
-            // For underline/strikethrough, pre-filter to text-node rects only so Ruby
-            // (rt/rp) glyphs don't produce a separate decoration segment above the base text.
-            const decoType = (decoStyle as BuiltinDecorationStyle).type;
-            const isLineDecoration = decoType === DecorationStyleType.Underline
-                || decoType === DecorationStyleType.Strikethrough;
-            const isStrikethrough = decoType === DecorationStyleType.Strikethrough;
-            const rectSource = isLineDecoration
-                ? getTextClientRects(item.range, ["rt", "rp"])
-                : item.range;
-            // Line decorations (underline/strikethrough) don't expand in the block axis —
-            // expand extends endpoints along the inline axis only.
-            let clientRects = getClientRectsNoOverlap(
-              rectSource,
-              true,              // doNotMergeHorizontallyAlignedRects
-              ctx.isVertical,    // doNotMergeVerticallyAlignedRects
-              isLineDecoration ? 0 : expand
-            );
-
-            clientRects = clientRects.sort((r1, r2) => {
-              if (ctx.isVertical) {
-                // vertical-rl: rightmost column first; vertical-lr: leftmost first
-                const factor = ctx.isVertLR ? 1 : -1;
-                return factor * (r1.left - r2.left);
-              }
-              return r1.top - r2.top;
-            });
-
-            for (let clientRect of clientRects) {
-              const line = elementTemplate.cloneNode(true) as HTMLDivElement;
-              line.style.setProperty("pointer-events", "none");
-              let posRect: Rect = clientRect;
-              if (isStrikethrough) {
-                  // Thin the rect to ~10% of block size, centred on the mid-line.
-                  const thickness = ctx.blockSize(clientRect) * 0.1;
-                  const blockMid  = ctx.blockStart(clientRect) + ctx.blockSize(clientRect) / 2;
-                  const bs = blockMid - thickness / 2;
-                  posRect = ctx.isVertical
-                      ? { left: bs, right: bs + thickness, top: clientRect.top,    bottom: clientRect.bottom, width: thickness,           height: clientRect.height }
-                      : { top:  bs, bottom: bs + thickness, left: clientRect.left, right: clientRect.right,   height: thickness,           width: clientRect.width  };
-              }
-              // Expand line decorations along the inline axis only (extend endpoints, not block size).
-              if (expand && isLineDecoration) {
-                  posRect = ctx.isVertical
-                      ? { ...posRect, top: posRect.top - expand, bottom: posRect.bottom + expand, height: posRect.height + expand * 2 }
-                      : { ...posRect, left: posRect.left - expand, right: posRect.right + expand, width: posRect.width + expand * 2 };
-              }
-              positionElement(line, posRect, boundingRect, outlineInset);
-              itemContainer.append(line);
-            }
+        const rects = this.computeOverlayRects(item, ctx, boundingRect, expand);
+        for (const posRect of rects) {
+            const el = elementTemplate.cloneNode(true) as HTMLDivElement;
+            el.style.setProperty("pointer-events", "none");
+            this.positionElement(item, ctx, iz, el, posRect, boundingRect, outlineInset);
+            itemContainer.append(el);
         }
 
         item.container = itemContainer;
@@ -1152,7 +1216,6 @@ export class Decorator extends Module {
         height: 0
     };*/
     private resizeFrame = 0;
-    private scrollFrame = 0;
 
     private lastGroupId = 0;
     private groups = new Map<string, DecorationGroup>();
@@ -1178,13 +1241,17 @@ export class Decorator extends Module {
     }
     private readonly handleResizer = this.handleResize.bind(this);
 
+    private scrollScheduled = false;
     private handleScroll() {
-        this.wnd.clearTimeout(this.scrollFrame);
-        this.scrollFrame = this.wnd.setTimeout(() => {
+        // rAF-throttled, not debounced: overlays must track every frame, not just settle after scroll stops.
+        if (this.scrollScheduled) return;
+        this.scrollScheduled = true;
+        this.wnd.requestAnimationFrame(() => {
+            this.scrollScheduled = false;
             this.groups.forEach(g => {
-                if(g.hasOverlayItems) g.requestLayout();
+                if(g.hasOverlayItems) g.repositionOverlays();
             });
-        }, 50);
+        });
     }
     private readonly handleScroller = this.handleScroll.bind(this);
 
@@ -1247,7 +1314,10 @@ export class Decorator extends Module {
         this.resizeObserver.observe(wnd.document.documentElement);
         wnd.addEventListener("orientationchange", this.handleResizer);
         wnd.addEventListener("resize", this.handleResizer);
-        wnd.addEventListener("scroll", this.handleScroller, { passive: true });
+        // Capture phase: scroll events don't bubble, so a scrollable descendant
+        // (e.g. an app shell's own reading-pane container) would never reach a
+        // bubble-phase listener on wnd.
+        wnd.addEventListener("scroll", this.handleScroller, { passive: true, capture: true });
 
         // Watch for any style change on <html> — covers appearance, background color,
         // font size, line height, margins, and anything else that reflows text.
@@ -1273,7 +1343,7 @@ export class Decorator extends Module {
     unmount(wnd: Window, comms: IComms): boolean {
         wnd.removeEventListener("orientationchange", this.handleResizer);
         wnd.removeEventListener("resize", this.handleResizer);
-        wnd.removeEventListener("scroll", this.handleScroller);
+        wnd.removeEventListener("scroll", this.handleScroller, { capture: true });
 
         comms.unregisterAll(Decorator.moduleName);
         this.resizeObserver.disconnect();

--- a/navigator-html-injectables/src/modules/Decorator.ts
+++ b/navigator-html-injectables/src/modules/Decorator.ts
@@ -1152,6 +1152,7 @@ export class Decorator extends Module {
         height: 0
     };*/
     private resizeFrame = 0;
+    private scrollFrame = 0;
 
     private lastGroupId = 0;
     private groups = new Map<string, DecorationGroup>();
@@ -1176,6 +1177,16 @@ export class Decorator extends Module {
         }, 50);
     }
     private readonly handleResizer = this.handleResize.bind(this);
+
+    private handleScroll() {
+        this.wnd.clearTimeout(this.scrollFrame);
+        this.scrollFrame = this.wnd.setTimeout(() => {
+            this.groups.forEach(g => {
+                if(g.hasOverlayItems) g.requestLayout();
+            });
+        }, 50);
+    }
+    private readonly handleScroller = this.handleScroll.bind(this);
 
     mount(wnd: Window, comms: IComms): boolean {
         this.wnd = wnd;
@@ -1236,6 +1247,7 @@ export class Decorator extends Module {
         this.resizeObserver.observe(wnd.document.documentElement);
         wnd.addEventListener("orientationchange", this.handleResizer);
         wnd.addEventListener("resize", this.handleResizer);
+        wnd.addEventListener("scroll", this.handleScroller, { passive: true });
 
         // Watch for any style change on <html> — covers appearance, background color,
         // font size, line height, margins, and anything else that reflows text.
@@ -1261,6 +1273,7 @@ export class Decorator extends Module {
     unmount(wnd: Window, comms: IComms): boolean {
         wnd.removeEventListener("orientationchange", this.handleResizer);
         wnd.removeEventListener("resize", this.handleResizer);
+        wnd.removeEventListener("scroll", this.handleScroller);
 
         comms.unregisterAll(Decorator.moduleName);
         this.resizeObserver.disconnect();

--- a/navigator-html-injectables/src/modules/Decorator.ts
+++ b/navigator-html-injectables/src/modules/Decorator.ts
@@ -167,6 +167,11 @@ class DecorationGroup {
         return this._hoverable;
     }
 
+    /** True if this group has at least one item rendered via the DOM overlay path (not CSS Highlight API). */
+    get hasOverlayItems(): boolean {
+        return !this.experimentalHighlights || (this.notTextFlag?.size ?? 0) > 0;
+    }
+
     set hoverable(value: boolean) {
         this._hoverable = value;
         if (!value && this.hoveredItem) {
@@ -1166,7 +1171,7 @@ export class Decorator extends Module {
         this.wnd.clearTimeout(this.resizeFrame);
         this.resizeFrame = this.wnd.setTimeout(() => {
             this.groups.forEach(g => {
-                if(!g.experimentalHighlights) g.requestLayout();
+                if(g.hasOverlayItems) g.requestLayout();
             });
         }, 50);
     }

--- a/navigator-html-injectables/src/modules/Decorator.ts
+++ b/navigator-html-injectables/src/modules/Decorator.ts
@@ -342,8 +342,7 @@ class DecorationGroup {
         this.wnd.document.removeEventListener("pointermove", this.hoverHandler);
     }
 
-    private clientRectsToDocCoords(rects: Rect[]): Rect[] {
-        const ctx = makeWritingContext(this.wnd);
+    private clientRectsToDocCoords(rects: Rect[], ctx: WritingContext = makeWritingContext(this.wnd)): Rect[] {
         const dx = ctx.xDocOffset;
         const dy = ctx.yDocOffset;
         if (dx === 0 && dy === 0) return rects;
@@ -514,18 +513,19 @@ class DecorationGroup {
     repositionOverlays() {
         let hasMaskItem = false;
         const relaidOut: DecorationItem[] = [];
+        const ctx = makeWritingContext(this.wnd);
         this.items.forEach(item => {
             if (this.experimentalHighlights && !this.notTextFlag?.has(item.id)) return;
             if (item.decoration.style?.type === DecorationStyleType.Mask) {
                 hasMaskItem = true;
                 return;
             }
-            if (!this.repositionItem(item)) {
+            if (!this.repositionItem(item, ctx)) {
                 item.container?.remove();
                 this.layout(item);
                 relaidOut.push(item);
             }
-            item.hitRects = this.clientRectsToDocCoords(getClientRectsNoOverlap(item.range, false, false, ((item.decoration.style as BuiltinDecorationStyle).expand ?? 0) + this.hitGap()));
+            item.hitRects = this.clientRectsToDocCoords(getClientRectsNoOverlap(item.range, false, false, ((item.decoration.style as BuiltinDecorationStyle).expand ?? 0) + this.hitGap()), ctx);
         });
         if (relaidOut.length) this.renderLayout(relaidOut);
         if (hasMaskItem) this.updateSharedMask();
@@ -785,7 +785,7 @@ class DecorationGroup {
      * longer matches the current geometry (a genuine reflow happened), signalling the
      * caller to fall back to a full layout().
      */
-    private repositionItem(item: DecorationItem): boolean {
+    private repositionItem(item: DecorationItem, ctx: WritingContext): boolean {
         if (!item.container) return true;
         const decoStyle = item.decoration.style;
         if (decoStyle.type !== DecorationStyleType.Template) {
@@ -793,7 +793,6 @@ class DecorationGroup {
             if (type === DecorationStyleType.TextColor || type === DecorationStyleType.Mask) return true;
         }
 
-        const ctx = makeWritingContext(this.wnd);
         const iz = 1 / this.effectiveZoom();
         const expand = (decoStyle as BuiltinDecorationStyle).expand ?? 0;
         const boundingRect = item.range.getBoundingClientRect();

--- a/navigator-html-injectables/src/modules/Decorator.ts
+++ b/navigator-html-injectables/src/modules/Decorator.ts
@@ -513,15 +513,21 @@ class DecorationGroup {
      */
     repositionOverlays() {
         let hasMaskItem = false;
+        const relaidOut: DecorationItem[] = [];
         this.items.forEach(item => {
             if (this.experimentalHighlights && !this.notTextFlag?.has(item.id)) return;
             if (item.decoration.style?.type === DecorationStyleType.Mask) {
                 hasMaskItem = true;
                 return;
             }
-            if (!this.repositionItem(item)) this.layout(item);
+            if (!this.repositionItem(item)) {
+                item.container?.remove();
+                this.layout(item);
+                relaidOut.push(item);
+            }
             item.hitRects = this.clientRectsToDocCoords(getClientRectsNoOverlap(item.range, false, false, ((item.decoration.style as BuiltinDecorationStyle).expand ?? 0) + this.hitGap()));
         });
+        if (relaidOut.length) this.renderLayout(relaidOut);
         if (hasMaskItem) this.updateSharedMask();
     }
 

--- a/navigator-html-injectables/src/modules/Decorator.ts
+++ b/navigator-html-injectables/src/modules/Decorator.ts
@@ -949,6 +949,8 @@ class DecorationGroup {
                             `mix-blend-mode: ${isDarkMode ? "exclusion" : "multiply"} !important`,
                             "opacity: 1 !important",
                             "box-sizing: border-box !important",
+                            // Works around an iPadOS Safari bug where mix-blend-mode paints opaque instead of blending.
+                            "transform: translateZ(0) !important",
                         ].join("; ");
                     }
                 }

--- a/navigator/CHANGELOG.MD
+++ b/navigator/CHANGELOG.MD
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.9.1] – 2026-09-09
+
+### Fixed
+
+- Decorations rendered via the DOM overlay path no longer stay frozen at their original position when the reader scrolls, and are now correctly relaid out on resize when mixed into a group that also uses the CSS Highlight API, via updated `@readium/decorator`/`@readium/navigator-html-injectables`
+
 ## [2.9.0] – 2026-09-08
 
 ### Added

--- a/navigator/CHANGELOG.MD
+++ b/navigator/CHANGELOG.MD
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Decorations rendered via the DOM overlay path no longer stay frozen at their original position when the reader scrolls, and are now correctly relaid out on resize when mixed into a group that also uses the CSS Highlight API, via updated `@readium/decorator`/`@readium/navigator-html-injectables`
+- Decorations rendered via the DOM overlay path no longer stay frozen at their original position when the reader scrolls, and every group is now correctly relaid out on resize, including ones that only use the CSS Highlight API, via updated `@readium/decorator`/`@readium/navigator-html-injectables`
 
 ## [2.9.0] – 2026-09-08
 

--- a/navigator/CHANGELOG.MD
+++ b/navigator/CHANGELOG.MD
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Decorations rendered via the DOM overlay path no longer stay frozen at their original position when the reader scrolls, and every group is now correctly relaid out on resize, including ones that only use the CSS Highlight API, via updated `@readium/decorator`/`@readium/navigator-html-injectables`
+- `Highlight` decorations with `layout: Bounds` no longer render as an opaque block hiding the underlying text on iPadOS Safari, via updated `@readium/decorator`/`@readium/navigator-html-injectables`
 
 ## [2.9.0] – 2026-09-08
 

--- a/navigator/package.json
+++ b/navigator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "type": "module",
   "description": "Next generation SDK for publications in Web Apps",
   "author": "readium",


### PR DESCRIPTION
Previously `Decorator` module only listened to `resize` to update Decorations, it did not plug into `scroll`. 