### PR TITLE
Decorator bugs

### DIFF
--- a/decorator/CHANGELOG.MD
+++ b/decorator/CHANGELOG.MD
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] – 2026-09-10
+
+### Added
+
+- `DecorationController` can now watch additional elements for resize via `resizeWatchSelectors` (config) and `addDecorationResizeTarget`/`removeDecorationResizeTarget`, so decoration overlays relay out when an element resizes for reasons that don't affect the document's own size — e.g. a sidebar collapsing and the reading pane reflowing inside it, via updated `@readium/navigator-html-injectables`
+
+### Fixed
+
+- Removing the last `Mask` decoration no longer leaks an orphaned shadow-host element or removes other decorations sharing the same shadow root, via updated `@readium/navigator-html-injectables`
+
 ## [1.1.1] – 2026-09-09
 
 ### Fixed

--- a/decorator/README.md
+++ b/decorator/README.md
@@ -87,12 +87,22 @@ class DecorationController {
     registerDecorationObserver(group: string, observer: DecorationObserver): void
     unregisterDecorationObserver(observer: DecorationObserver): void
 
+    // Watches an additional element for resize, so decorations relay out when it resizes
+    // even if the document's own size doesn't change (e.g. a sidebar collapsing and the
+    // reading pane reflowing inside it). Selector is resolved against the Decorator's document.
+    observeElement(selector: string): void
+    unobserveElement(selector: string): void
+
     destroy(): void
 }
 
 interface DecorationControllerConfig {
     // Named style templates. Register a template here and reference it by ID in decoration styles.
     decorationTemplates?: Record<string, HTMLDecorationTemplate>;
+
+    // CSS selectors to watch for resize from construction, equivalent to calling
+    // observeElement() for each one right after construction.
+    resizeWatchSelectors?: string[];
 }
 ```
 
@@ -165,7 +175,7 @@ interface IComms {
 | `BuiltinDecorationStyle` | `{ type?, tint?, layout?, width?, enforceContrast?, expand? }` |
 | `HTMLDecorationTemplate` | `{ type: "template", layout, width, element, stylesheet? }` — `element` is a function `(decoration) => string`, resolved to HTML per decoration before rendering |
 | `NamedDecorationStyle` | `{ type: string }` — reference to a style registered in `DecoratorConfig.decorationTemplates` |
-| `DecoratorConfig` | `{ decorationTemplates? }` — same shape as `DecorationControllerConfig` (the latter is a type alias of this) |
+| `DecoratorConfig` | `{ decorationTemplates?, resizeWatchSelectors? }` — same shape as `DecorationControllerConfig` (the latter is a type alias of this) |
 | `DecorationStyleType` | `"highlight" \| "highlightUnderline" \| "underline" \| "strikethrough" \| "outline" \| "textColor" \| "mask" \| "template"` |
 | `DecorationLayout` | `"boxes" \| "bounds"` |
 | `DecorationWidth` | `"wrap" \| "viewport" \| "bounds" \| "page"` |

--- a/decorator/README.md
+++ b/decorator/README.md
@@ -90,8 +90,8 @@ class DecorationController {
     // Watches an additional element for resize, so decorations relay out when it resizes
     // even if the document's own size doesn't change (e.g. a sidebar collapsing and the
     // reading pane reflowing inside it). Selector is resolved against the Decorator's document.
-    observeElement(selector: string): void
-    unobserveElement(selector: string): void
+    addDecorationResizeTarget(selector: string): void
+    removeDecorationResizeTarget(selector: string): void
 
     destroy(): void
 }
@@ -101,7 +101,7 @@ interface DecorationControllerConfig {
     decorationTemplates?: Record<string, HTMLDecorationTemplate>;
 
     // CSS selectors to watch for resize from construction, equivalent to calling
-    // observeElement() for each one right after construction.
+    // addDecorationResizeTarget() for each one right after construction.
     resizeWatchSelectors?: string[];
 }
 ```

--- a/decorator/package.json
+++ b/decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/decorator",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "type": "module",
   "description": "Standalone decoration controller and renderer for HTML content",
   "author": "readium",

--- a/decorator/src/controller/DecorationController.ts
+++ b/decorator/src/controller/DecorationController.ts
@@ -16,6 +16,7 @@ export class DecorationController {
 
     constructor(private readonly host: DirectCommsHost, config: DecorationControllerConfig = {}) {
         this._config = config;
+        config.resizeWatchSelectors?.forEach(selector => this.observeElement(selector));
         host.on("decoration_activated", (raw) => {
             const ev = raw as DecorationActivatedEvent;
             const decoration = this._decorations.get(ev.group)?.find(d => d.id === ev.decorationId);
@@ -45,6 +46,14 @@ export class DecorationController {
                 obs.onDecorationPointerLeave?.({ group: ev.group, decoration, rect: ev.rect, point: ev.point })
             );
         });
+    }
+
+    observeElement(selector: string): void {
+        this.host.send("decoration_resize", { action: "watch", selector });
+    }
+
+    unobserveElement(selector: string): void {
+        this.host.send("decoration_resize", { action: "unwatch", selector });
     }
 
     supportsDecorationStyle(styleTypeId: string): boolean {

--- a/decorator/src/controller/DecorationController.ts
+++ b/decorator/src/controller/DecorationController.ts
@@ -16,7 +16,7 @@ export class DecorationController {
 
     constructor(private readonly host: DirectCommsHost, config: DecorationControllerConfig = {}) {
         this._config = config;
-        config.resizeWatchSelectors?.forEach(selector => this.observeElement(selector));
+        config.resizeWatchSelectors?.forEach(selector => this.addDecorationResizeTarget(selector));
         host.on("decoration_activated", (raw) => {
             const ev = raw as DecorationActivatedEvent;
             const decoration = this._decorations.get(ev.group)?.find(d => d.id === ev.decorationId);
@@ -48,11 +48,11 @@ export class DecorationController {
         });
     }
 
-    observeElement(selector: string): void {
+    addDecorationResizeTarget(selector: string): void {
         this.host.send("decoration_resize", { action: "watch", selector });
     }
 
-    unobserveElement(selector: string): void {
+    removeDecorationResizeTarget(selector: string): void {
         this.host.send("decoration_resize", { action: "unwatch", selector });
     }
 

--- a/decorator/src/styles.ts
+++ b/decorator/src/styles.ts
@@ -36,6 +36,13 @@ export interface DecoratorConfig {
      * Template-type decoration.
      */
     decorationTemplates?: Record<string, HTMLDecorationTemplate>;
+
+    /**
+     * CSS selectors of additional elements to watch for resize, so decoration overlays are
+     * relaid-out when they resize for reasons that don't affect the document's own size
+     * (e.g. a sidebar collapsing and the reading pane reflowing within a flex/grid layout).
+     */
+    resizeWatchSelectors?: string[];
 }
 
 export const BUILTIN_DECORATION_TYPES = new Set<string>(Object.values(DecorationStyleType));

--- a/navigator-html-injectables/CHANGELOG.MD
+++ b/navigator-html-injectables/CHANGELOG.MD
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.0] – 2026-09-10
+
+### Added
+
+- `Decorator` can now watch additional elements for resize via `resizeWatchSelectors` (config) and `addDecorationResizeTarget`/`removeDecorationResizeTarget`, so decoration overlays relay out when an element resizes for reasons that don't affect the document's own size — e.g. a sidebar collapsing and the reading pane reflowing inside it
+
+### Fixed
+
+- Removing the last `Mask` decoration in a group no longer leaves an orphaned, unreachable shadow-host element attached to the document, and no longer removes other decorations sharing the same shadow root along with it
+
 ## [2.7.1] – 2026-09-09
 
 ### Fixed

--- a/navigator-html-injectables/package.json
+++ b/navigator-html-injectables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator-html-injectables",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "type": "module",
   "description": "An embeddable solution for connecting frames of HTML publications with a Readium Navigator",
   "author": "readium",

--- a/navigator-html-injectables/src/comms/keys.ts
+++ b/navigator-html-injectables/src/comms/keys.ts
@@ -41,6 +41,7 @@ export type CommsCommandKey =
     // "exact_progress" |
     "first_visible_locator" |
     "decorate" |
+    "decoration_resize" |
     "decoration_activatable" |
     "decoration_hoverable" |
     "protect" |

--- a/navigator-html-injectables/src/modules/Decorator.ts
+++ b/navigator-html-injectables/src/modules/Decorator.ts
@@ -1225,6 +1225,7 @@ export class Decorator extends Module {
     private resizeObserver!: ResizeObserver;
     private styleObserver!: MutationObserver;
     private wnd!: Window;
+    private observedResizeTargets = new Map<string, Element>();
     /*private readonly lastSize = {
         width: 0,
         height: 0
@@ -1237,6 +1238,7 @@ export class Decorator extends Module {
     private cleanup() {
         this.groups.forEach(g => g.destroy());
         this.groups.clear();
+        this.observedResizeTargets.clear();
     }
 
     private updateHighlightStyles() {
@@ -1374,12 +1376,23 @@ export class Decorator extends Module {
     }
 
     private addDecorationResizeTarget(selector: string): void {
+        const existing = this.observedResizeTargets.get(selector);
+        if (existing) this.resizeObserver.unobserve(existing);
+
         const el = this.wnd.document.querySelector(selector);
-        if (el) this.resizeObserver.observe(el);
+        if (el) {
+            this.resizeObserver.observe(el);
+            this.observedResizeTargets.set(selector, el);
+        } else {
+            this.observedResizeTargets.delete(selector);
+        }
     }
 
     private removeDecorationResizeTarget(selector: string): void {
-        const el = this.wnd.document.querySelector(selector);
-        if (el) this.resizeObserver.unobserve(el);
+        const el = this.observedResizeTargets.get(selector);
+        if (el) {
+            this.resizeObserver.unobserve(el);
+            this.observedResizeTargets.delete(selector);
+        }
     }
 }

--- a/navigator-html-injectables/src/modules/Decorator.ts
+++ b/navigator-html-injectables/src/modules/Decorator.ts
@@ -1306,8 +1306,8 @@ export class Decorator extends Module {
 
         comms.register("decoration_resize", Decorator.moduleName, (data, ack) => {
             const req = data as DecorationResizeRequest;
-            if (req.action === "watch") this.observeElement(req.selector);
-            else this.unobserveElement(req.selector);
+            if (req.action === "watch") this.addDecorationResizeTarget(req.selector);
+            else this.removeDecorationResizeTarget(req.selector);
             ack(true);
         });
 
@@ -1373,12 +1373,12 @@ export class Decorator extends Module {
         return true;
     }
 
-    private observeElement(selector: string): void {
+    private addDecorationResizeTarget(selector: string): void {
         const el = this.wnd.document.querySelector(selector);
         if (el) this.resizeObserver.observe(el);
     }
 
-    private unobserveElement(selector: string): void {
+    private removeDecorationResizeTarget(selector: string): void {
         const el = this.wnd.document.querySelector(selector);
         if (el) this.resizeObserver.unobserve(el);
     }

--- a/navigator-html-injectables/src/modules/Decorator.ts
+++ b/navigator-html-injectables/src/modules/Decorator.ts
@@ -1373,12 +1373,12 @@ export class Decorator extends Module {
         return true;
     }
 
-    observeElement(selector: string): void {
+    private observeElement(selector: string): void {
         const el = this.wnd.document.querySelector(selector);
         if (el) this.resizeObserver.observe(el);
     }
 
-    unobserveElement(selector: string): void {
+    private unobserveElement(selector: string): void {
         const el = this.wnd.document.querySelector(selector);
         if (el) this.resizeObserver.unobserve(el);
     }

--- a/navigator-html-injectables/src/modules/Decorator.ts
+++ b/navigator-html-injectables/src/modules/Decorator.ts
@@ -103,6 +103,10 @@ export type DecoratorRequest =
     | { group: string; action: "remove"; decoration: Pick<Decoration, "id"> }
     | { group: string; action: "clear" };
 
+export type DecorationResizeRequest =
+    | { action: "watch"; selector: string }
+    | { action: "unwatch"; selector: string };
+
 interface DecorationItem {
     id: string;
     decoration: Decoration;
@@ -1300,6 +1304,13 @@ export class Decorator extends Module {
             ack(true);
         });
 
+        comms.register("decoration_resize", Decorator.moduleName, (data, ack) => {
+            const req = data as DecorationResizeRequest;
+            if (req.action === "watch") this.observeElement(req.selector);
+            else this.unobserveElement(req.selector);
+            ack(true);
+        });
+
         comms.register("decoration_activatable", Decorator.moduleName, (data, ack) => {
             const req = data as { group: string; activatable: boolean };
             const group = this.groups.get(req.group);
@@ -1360,5 +1371,15 @@ export class Decorator extends Module {
 
         comms.log("Decorator Unmounted");
         return true;
+    }
+
+    observeElement(selector: string): void {
+        const el = this.wnd.document.querySelector(selector);
+        if (el) this.resizeObserver.observe(el);
+    }
+
+    unobserveElement(selector: string): void {
+        const el = this.wnd.document.querySelector(selector);
+        if (el) this.resizeObserver.unobserve(el);
     }
 }

--- a/navigator-html-injectables/src/modules/Decorator.ts
+++ b/navigator-html-injectables/src/modules/Decorator.ts
@@ -1055,12 +1055,12 @@ class DecorationGroup {
                 this.maskSvg.remove();
                 this.maskSvg = undefined;
             }
-            if (this.shadowRoot) {
-                this.shadowRoot.innerHTML = '';
+            // Only tear down the shared shadow host if no other decorations use it
+            if (this.shadowHost && !this.container) {
+                this.shadowHost.remove();
+                this.shadowRoot = undefined;
+                this.shadowHost = undefined;
             }
-            this.container = undefined;
-            this.shadowRoot = undefined;
-            this.shadowHost = undefined;
             return;
         }
 

--- a/navigator-html-injectables/src/modules/Decorator.ts
+++ b/navigator-html-injectables/src/modules/Decorator.ts
@@ -1054,6 +1054,9 @@ class DecorationGroup {
             if (this.shadowRoot) {
                 this.shadowRoot.innerHTML = '';
             }
+            this.container = undefined;
+            this.shadowRoot = undefined;
+            this.shadowHost = undefined;
             return;
         }
 

--- a/navigator/CHANGELOG.MD
+++ b/navigator/CHANGELOG.MD
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.0] – 2026-09-10
+
+### Added
+
+- `EpubNavigator` and `WebPubNavigator` now expose `addDecorationResizeTarget`/`removeDecorationResizeTarget`, so decoration overlays relay out when a watched element within the current content document resizes for reasons that don't affect the document's own size — e.g. a sidebar collapsing and the reading pane reflowing inside it, via updated `@readium/decorator`/`@readium/navigator-html-injectables`
+
+### Fixed
+
+- Removing the last `Mask` decoration no longer leaks an orphaned shadow-host element or removes other decorations sharing the same shadow root, via updated `@readium/decorator`/`@readium/navigator-html-injectables`
+
 ## [2.9.1] – 2026-09-09
 
 ### Fixed

--- a/navigator/CHANGELOG.MD
+++ b/navigator/CHANGELOG.MD
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `EpubNavigator` and `WebPubNavigator` now expose `addDecorationResizeTarget`/`removeDecorationResizeTarget`, so decoration overlays relay out when a watched element within the current content document resizes for reasons that don't affect the document's own size — e.g. a sidebar collapsing and the reading pane reflowing inside it, via updated `@readium/decorator`/`@readium/navigator-html-injectables`
+- `EpubNavigator` and `WebPubNavigator` now accept `resizeWatchSelectors` (decorator config) and expose `addDecorationResizeTarget`/`removeDecorationResizeTarget`, so decoration overlays relay out when a watched element within the current content document resizes for reasons that don't affect the document's own size — e.g. a sidebar collapsing and the reading pane reflowing inside it, via updated `@readium/decorator`/`@readium/navigator-html-injectables`
 
 ### Fixed
 

--- a/navigator/package.json
+++ b/navigator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readium/navigator",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "type": "module",
   "description": "Next generation SDK for publications in Web Apps",
   "author": "readium",

--- a/navigator/src/decorations/index.ts
+++ b/navigator/src/decorations/index.ts
@@ -42,4 +42,14 @@ export interface DecorableNavigator {
 
     /** Unregisters a previously registered observer from all groups. */
     unregisterDecorationObserver(observer: DecorationObserver): void;
+
+    /**
+     * Watches an element within the current content document for resize, so decoration
+     * overlays relay out when it resizes even if the resource's own document size doesn't
+     * change (e.g. a sidebar collapsing and the reading pane reflowing inside it).
+     */
+    addDecorationResizeTarget(selector: string): void;
+
+    /** Stops watching an element previously registered with addDecorationResizeTarget. */
+    removeDecorationResizeTarget(selector: string): void;
 }

--- a/navigator/src/epub/EpubNavigator.ts
+++ b/navigator/src/epub/EpubNavigator.ts
@@ -114,6 +114,7 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
     private _decorationActivationState: Map<string, boolean> = new Map();
     private _decorationHoverState: Map<string, boolean> = new Map();
     private _decorationActivationConsumed = false;
+    private _decorationResizeSelectors: Set<string>;
 
     private reflowViewport: VisualNavigatorViewport = {
         readingOrder: [],
@@ -175,6 +176,7 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
 
         this._contentProtection = configuration.contentProtection || {};
         this._decoratorConfig = configuration.decoratorConfig || {};
+        this._decorationResizeSelectors = new Set(this._decoratorConfig.resizeWatchSelectors ?? []);
 
         // Merge keyboard peripherals
         this._keyboardPeripherals = this.mergeKeyboardPeripherals(
@@ -269,7 +271,8 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
                 this.pub,
                 this._injector,
                 this._contentProtection,
-                this._keyboardPeripherals
+                this._keyboardPeripherals,
+                [...this._decorationResizeSelectors]
             );
             this.framePool.listener = (key: CommsEventKey | ManagerEventKey, data: unknown) => {
                 this.eventListener(key, data);
@@ -287,7 +290,8 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
                 (href) => this.pub.timeline.segmentsForHref(href)
                     .flatMap(item => item.references)
                     .map(ref => { const h = ref.indexOf('#'); return h >= 0 ? ref.slice(h + 1) : ''; })
-                    .filter(Boolean)
+                    .filter(Boolean),
+                [...this._decorationResizeSelectors]
             );
         }
 
@@ -725,6 +729,21 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
         });
     }
 
+    // Watches an element within the current content document(s) for resize, so decoration
+    // overlays relay out when it resizes even if the resource's own document size doesn't
+    // change. Not resource-scoped: forwarded to every frame, current and future, via
+    // framePool the same way contentProtectionConfig/keyboardPeripheralsConfig are — applied
+    // on every frame show(), not just replayed reactively off decoration state.
+    public addDecorationResizeTarget(selector: string): void {
+        this._decorationResizeSelectors.add(selector);
+        this.framePool?.addResizeTarget(selector);
+    }
+
+    public removeDecorationResizeTarget(selector: string): void {
+        this._decorationResizeSelectors.delete(selector);
+        this.framePool?.removeResizeTarget(selector);
+    }
+
     public applyDecorations(decorations: Decoration[], group: string): void {
         const previous = this._decorations.get(group) ?? [];
         const prevById = new Map(previous.map(d => [d.id, d]));
@@ -869,6 +888,7 @@ export class EpubNavigator extends VisualNavigator implements Configurable<Confi
         this._decorationHoveredDecorations.clear();
         this._decorationActivationState.clear();
         this._decorationHoverState.clear();
+        this._decorationResizeSelectors.clear();
     }
 
     private async changeResource(relative: number): Promise<boolean> {

--- a/navigator/src/epub/frame/FrameManager.ts
+++ b/navigator/src/epub/frame/FrameManager.ts
@@ -15,6 +15,7 @@ export class FrameManager {
     private destroyed: boolean = false;
     private readonly contentProtectionConfig: IContentProtectionConfig;
     private readonly keyboardPeripheralsConfig: IKeyboardPeripheralsConfig;
+    private resizeWatchSelectors: string[];
     private conditionBridge?: KeyboardConditionBridge;
     private currModules: ModuleName[] = [];
 
@@ -22,7 +23,8 @@ export class FrameManager {
         source: string,
         contentProtectionConfig: IContentProtectionConfig = {},
         keyboardPeripheralsConfig: IKeyboardPeripheralsConfig = [],
-        private readonly timelineFragmentIds: string[] = []
+        private readonly timelineFragmentIds: string[] = [],
+        resizeWatchSelectors: string[] = []
     ) {
         this.frame = document.createElement("iframe");
         this.frame.sandbox.value = "allow-same-origin allow-scripts";
@@ -38,6 +40,7 @@ export class FrameManager {
         // Use the provided content protection config directly without overriding defaults
         this.contentProtectionConfig = { ...contentProtectionConfig };
         this.keyboardPeripheralsConfig = [...keyboardPeripheralsConfig];
+        this.resizeWatchSelectors = [...resizeWatchSelectors];
 
     }
 
@@ -99,6 +102,21 @@ export class FrameManager {
         if (this.contentProtectionConfig.protectPrinting?.disable) {
             this.comms!.send("print_protection", this.contentProtectionConfig.protectPrinting);
         }
+
+        // Send resize-watch targets
+        this.resizeWatchSelectors.forEach(selector => {
+            this.comms!.send("decoration_resize", { action: "watch", selector });
+        });
+    }
+
+    addResizeTarget(selector: string): void {
+        if (!this.resizeWatchSelectors.includes(selector)) this.resizeWatchSelectors.push(selector);
+        if (this.comms?.ready) this.comms.send("decoration_resize", { action: "watch", selector });
+    }
+
+    removeResizeTarget(selector: string): void {
+        this.resizeWatchSelectors = this.resizeWatchSelectors.filter(s => s !== selector);
+        if (this.comms?.ready) this.comms.send("decoration_resize", { action: "unwatch", selector });
     }
 
     async destroy() {

--- a/navigator/src/epub/frame/FrameManager.ts
+++ b/navigator/src/epub/frame/FrameManager.ts
@@ -16,6 +16,7 @@ export class FrameManager {
     private readonly contentProtectionConfig: IContentProtectionConfig;
     private readonly keyboardPeripheralsConfig: IKeyboardPeripheralsConfig;
     private resizeWatchSelectors: string[];
+    private pendingUnwatchSelectors: string[] = [];
     private conditionBridge?: KeyboardConditionBridge;
     private currModules: ModuleName[] = [];
 
@@ -107,16 +108,27 @@ export class FrameManager {
         this.resizeWatchSelectors.forEach(selector => {
             this.comms!.send("decoration_resize", { action: "watch", selector });
         });
+
+        // Flush unwatches that couldn't be sent while comms was halted
+        this.pendingUnwatchSelectors.forEach(selector => {
+            this.comms!.send("decoration_resize", { action: "unwatch", selector });
+        });
+        this.pendingUnwatchSelectors = [];
     }
 
     addResizeTarget(selector: string): void {
         if (!this.resizeWatchSelectors.includes(selector)) this.resizeWatchSelectors.push(selector);
+        this.pendingUnwatchSelectors = this.pendingUnwatchSelectors.filter(s => s !== selector);
         if (this.comms?.ready) this.comms.send("decoration_resize", { action: "watch", selector });
     }
 
     removeResizeTarget(selector: string): void {
         this.resizeWatchSelectors = this.resizeWatchSelectors.filter(s => s !== selector);
-        if (this.comms?.ready) this.comms.send("decoration_resize", { action: "unwatch", selector });
+        if (this.comms?.ready) {
+            this.comms.send("decoration_resize", { action: "unwatch", selector });
+        } else if (!this.pendingUnwatchSelectors.includes(selector)) {
+            this.pendingUnwatchSelectors.push(selector);
+        }
     }
 
     async destroy() {

--- a/navigator/src/epub/frame/FramePoolManager.ts
+++ b/navigator/src/epub/frame/FramePoolManager.ts
@@ -21,6 +21,7 @@ export class FramePoolManager {
     private readonly injector: Injector | null = null;
     private readonly contentProtectionConfig: IContentProtectionConfig;
     private readonly keyboardPeripheralsConfig: IKeyboardPeripheralsConfig;
+    private resizeWatchSelectors: string[];
     private readonly getFragmentIds: (href: string) => string[];
 
     constructor(
@@ -30,7 +31,8 @@ export class FramePoolManager {
         injector?: Injector | null,
         contentProtectionConfig?: IContentProtectionConfig,
         keyboardPeripheralsConfig?: IKeyboardPeripheralsConfig,
-        getFragmentIds?: (href: string) => string[]
+        getFragmentIds?: (href: string) => string[],
+        resizeWatchSelectors: string[] = []
     ) {
         this.container = container;
         this.positions = positions;
@@ -39,6 +41,20 @@ export class FramePoolManager {
         this.contentProtectionConfig = contentProtectionConfig || {};
         this.keyboardPeripheralsConfig = keyboardPeripheralsConfig || [];
         this.getFragmentIds = getFragmentIds ?? (() => []);
+        this.resizeWatchSelectors = [...resizeWatchSelectors];
+    }
+
+    addResizeTarget(selector: string): void {
+        if (!this.resizeWatchSelectors.includes(selector)) this.resizeWatchSelectors.push(selector);
+        // Forward to the whole pool, not just currentFrames: off-screen cached frames
+        // (preloaded within the pool's boundary window) must not keep stale state that
+        // resurfaces if they're shown again later without being recreated.
+        this.pool.forEach(f => f.addResizeTarget(selector));
+    }
+
+    removeResizeTarget(selector: string): void {
+        this.resizeWatchSelectors = this.resizeWatchSelectors.filter(s => s !== selector);
+        this.pool.forEach(f => f.removeResizeTarget(selector));
     }
 
     async destroy() {
@@ -174,7 +190,7 @@ export class FramePoolManager {
                 }
 
                 // Create <iframe>
-                const fm = new FrameManager(this.blobs.get(href)!, this.contentProtectionConfig, this.keyboardPeripheralsConfig, this.getFragmentIds(href));
+                const fm = new FrameManager(this.blobs.get(href)!, this.contentProtectionConfig, this.keyboardPeripheralsConfig, this.getFragmentIds(href), this.resizeWatchSelectors);
                 if(href !== newHref) await fm.hide(); // Avoid unecessary hide
                 this.container.appendChild(fm.iframe);
                 await fm.load(modules);

--- a/navigator/src/epub/fxl/FXLFrameManager.ts
+++ b/navigator/src/epub/fxl/FXLFrameManager.ts
@@ -14,6 +14,7 @@ export class FXLFrameManager {
     private readonly peripherals: FXLPeripherals;
     private readonly contentProtectionConfig: IContentProtectionConfig;
     private readonly keyboardPeripheralsConfig: IKeyboardPeripheralsConfig;
+    private resizeWatchSelectors: string[];
     private conditionBridge?: KeyboardConditionBridge;
     private currModules: ModuleName[] = [];
 
@@ -28,13 +29,15 @@ export class FXLFrameManager {
         direction: ReadingProgression,
         debugHref: string,
         contentProtectionConfig: IContentProtectionConfig = {},
-        keyboardPeripheralsConfig: IKeyboardPeripheralsConfig = []
+        keyboardPeripheralsConfig: IKeyboardPeripheralsConfig = [],
+        resizeWatchSelectors: string[] = []
     ) {
         this.peripherals = peripherals;
         this.debugHref = debugHref;
         // Use the provided content protection config directly without overriding defaults
         this.contentProtectionConfig = { ...contentProtectionConfig };
         this.keyboardPeripheralsConfig = [...keyboardPeripheralsConfig];
+        this.resizeWatchSelectors = [...resizeWatchSelectors];
         this.frame = document.createElement("iframe");
         this.frame.sandbox.value = "allow-same-origin allow-scripts";
         this.frame.classList.add("readium-navigator-iframe");
@@ -236,6 +239,21 @@ export class FXLFrameManager {
         if (this.contentProtectionConfig.protectPrinting?.disable) {
             this.comms!.send("print_protection", this.contentProtectionConfig.protectPrinting);
         }
+
+        // Send resize-watch targets
+        this.resizeWatchSelectors.forEach(selector => {
+            this.comms!.send("decoration_resize", { action: "watch", selector });
+        });
+    }
+
+    addResizeTarget(selector: string): void {
+        if (!this.resizeWatchSelectors.includes(selector)) this.resizeWatchSelectors.push(selector);
+        if (this.comms?.ready) this.comms.send("decoration_resize", { action: "watch", selector });
+    }
+
+    removeResizeTarget(selector: string): void {
+        this.resizeWatchSelectors = this.resizeWatchSelectors.filter(s => s !== selector);
+        if (this.comms?.ready) this.comms.send("decoration_resize", { action: "unwatch", selector });
     }
 
     private cachedPage: Page | undefined = undefined;

--- a/navigator/src/epub/fxl/FXLFrameManager.ts
+++ b/navigator/src/epub/fxl/FXLFrameManager.ts
@@ -15,6 +15,7 @@ export class FXLFrameManager {
     private readonly contentProtectionConfig: IContentProtectionConfig;
     private readonly keyboardPeripheralsConfig: IKeyboardPeripheralsConfig;
     private resizeWatchSelectors: string[];
+    private pendingUnwatchSelectors: string[] = [];
     private conditionBridge?: KeyboardConditionBridge;
     private currModules: ModuleName[] = [];
 
@@ -244,16 +245,27 @@ export class FXLFrameManager {
         this.resizeWatchSelectors.forEach(selector => {
             this.comms!.send("decoration_resize", { action: "watch", selector });
         });
+
+        // Flush unwatches that couldn't be sent while comms was halted
+        this.pendingUnwatchSelectors.forEach(selector => {
+            this.comms!.send("decoration_resize", { action: "unwatch", selector });
+        });
+        this.pendingUnwatchSelectors = [];
     }
 
     addResizeTarget(selector: string): void {
         if (!this.resizeWatchSelectors.includes(selector)) this.resizeWatchSelectors.push(selector);
+        this.pendingUnwatchSelectors = this.pendingUnwatchSelectors.filter(s => s !== selector);
         if (this.comms?.ready) this.comms.send("decoration_resize", { action: "watch", selector });
     }
 
     removeResizeTarget(selector: string): void {
         this.resizeWatchSelectors = this.resizeWatchSelectors.filter(s => s !== selector);
-        if (this.comms?.ready) this.comms.send("decoration_resize", { action: "unwatch", selector });
+        if (this.comms?.ready) {
+            this.comms.send("decoration_resize", { action: "unwatch", selector });
+        } else if (!this.pendingUnwatchSelectors.includes(selector)) {
+            this.pendingUnwatchSelectors.push(selector);
+        }
     }
 
     private cachedPage: Page | undefined = undefined;

--- a/navigator/src/epub/fxl/FXLFramePoolManager.ts
+++ b/navigator/src/epub/fxl/FXLFramePoolManager.ts
@@ -30,6 +30,7 @@ export class FXLFramePoolManager {
     private readonly injector: Injector | null = null;
     private readonly contentProtectionConfig: IContentProtectionConfig;
     private readonly keyboardPeripheralsConfig: IKeyboardPeripheralsConfig;
+    private resizeWatchSelectors: string[];
 
     // NEW
     private readonly bookElement: HTMLDivElement;
@@ -55,6 +56,7 @@ export class FXLFramePoolManager {
         injector?: Injector | null,
         contentProtectionConfig?: IContentProtectionConfig,
         keyboardPeripheralsConfig?: IKeyboardPeripheralsConfig,
+        resizeWatchSelectors: string[] = [],
     ) {
         this.container = container;
         this.positions = positions;
@@ -62,6 +64,7 @@ export class FXLFramePoolManager {
         this.injector = injector ?? null;
         this.contentProtectionConfig = contentProtectionConfig || {};
         this.keyboardPeripheralsConfig = keyboardPeripheralsConfig || [];
+        this.resizeWatchSelectors = [...resizeWatchSelectors];
         this.spreadPresentation = pub.metadata.otherMetadata?.spread || Spread.auto;
 
         if(this.pub.metadata.effectiveReadingProgression !== ReadingProgression.rtl && this.pub.metadata.effectiveReadingProgression !== ReadingProgression.ltr)
@@ -88,7 +91,7 @@ export class FXLFramePoolManager {
 
         this.pub.readingOrder.items.forEach((link) => {
             // Create <iframe>
-            const fm = new FXLFrameManager(this.peripherals, this.pub.metadata.effectiveReadingProgression, link.href, this.contentProtectionConfig, this.keyboardPeripheralsConfig);
+            const fm = new FXLFrameManager(this.peripherals, this.pub.metadata.effectiveReadingProgression, link.href, this.contentProtectionConfig, this.keyboardPeripheralsConfig, this.resizeWatchSelectors);
             this.spineElement.appendChild(fm.element);
 
             // this.pages.push(fm);
@@ -593,6 +596,16 @@ export class FXLFramePoolManager {
         for (const s of spread) {
             this.inprogress.delete(s.href); // Delete it from the in progress map!
         }
+    }
+
+    addResizeTarget(selector: string): void {
+        if (!this.resizeWatchSelectors.includes(selector)) this.resizeWatchSelectors.push(selector);
+        this.pool.forEach(f => f.addResizeTarget(selector));
+    }
+
+    removeResizeTarget(selector: string): void {
+        this.resizeWatchSelectors = this.resizeWatchSelectors.filter(s => s !== selector);
+        this.pool.forEach(f => f.removeResizeTarget(selector));
     }
 
     get currentFrames(): (FXLFrameManager | undefined)[] {

--- a/navigator/src/webpub/WebPubFrameManager.ts
+++ b/navigator/src/webpub/WebPubFrameManager.ts
@@ -15,6 +15,7 @@ export class WebPubFrameManager {
     private readonly contentProtectionConfig: IContentProtectionConfig;
     private readonly keyboardPeripheralsConfig: IKeyboardPeripheralsConfig;
     private resizeWatchSelectors: string[];
+    private pendingUnwatchSelectors: string[] = [];
     private conditionBridge?: KeyboardConditionBridge;
     private currModules: ModuleName[] = [];
 
@@ -105,16 +106,27 @@ export class WebPubFrameManager {
         this.resizeWatchSelectors.forEach(selector => {
             this.comms!.send("decoration_resize", { action: "watch", selector });
         });
+
+        // Flush unwatches that couldn't be sent while comms was halted
+        this.pendingUnwatchSelectors.forEach(selector => {
+            this.comms!.send("decoration_resize", { action: "unwatch", selector });
+        });
+        this.pendingUnwatchSelectors = [];
     }
 
     addResizeTarget(selector: string): void {
         if (!this.resizeWatchSelectors.includes(selector)) this.resizeWatchSelectors.push(selector);
+        this.pendingUnwatchSelectors = this.pendingUnwatchSelectors.filter(s => s !== selector);
         if (this.comms?.ready) this.comms.send("decoration_resize", { action: "watch", selector });
     }
 
     removeResizeTarget(selector: string): void {
         this.resizeWatchSelectors = this.resizeWatchSelectors.filter(s => s !== selector);
-        if (this.comms?.ready) this.comms.send("decoration_resize", { action: "unwatch", selector });
+        if (this.comms?.ready) {
+            this.comms.send("decoration_resize", { action: "unwatch", selector });
+        } else if (!this.pendingUnwatchSelectors.includes(selector)) {
+            this.pendingUnwatchSelectors.push(selector);
+        }
     }
 
     async destroy() {

--- a/navigator/src/webpub/WebPubFrameManager.ts
+++ b/navigator/src/webpub/WebPubFrameManager.ts
@@ -14,6 +14,7 @@ export class WebPubFrameManager {
     private destroyed: boolean = false;
     private readonly contentProtectionConfig: IContentProtectionConfig;
     private readonly keyboardPeripheralsConfig: IKeyboardPeripheralsConfig;
+    private resizeWatchSelectors: string[];
     private conditionBridge?: KeyboardConditionBridge;
     private currModules: ModuleName[] = [];
 
@@ -21,7 +22,8 @@ export class WebPubFrameManager {
         source: string,
         contentProtectionConfig: IContentProtectionConfig = {},
         keyboardPeripheralsConfig: IKeyboardPeripheralsConfig = [],
-        private readonly timelineFragmentIds: string[] = []
+        private readonly timelineFragmentIds: string[] = [],
+        resizeWatchSelectors: string[] = []
     ) {
         this.frame = document.createElement("iframe");
         this.frame.classList.add("readium-navigator-iframe");
@@ -38,6 +40,7 @@ export class WebPubFrameManager {
         // Use the provided content protection config directly without overriding defaults
         this.contentProtectionConfig = { ...contentProtectionConfig };
         this.keyboardPeripheralsConfig = [...keyboardPeripheralsConfig];
+        this.resizeWatchSelectors = [...resizeWatchSelectors];
     }
 
     async load(modules: ModuleName[] = []): Promise<Window> {
@@ -97,6 +100,21 @@ export class WebPubFrameManager {
         if (this.contentProtectionConfig.protectPrinting?.disable) {
             this.comms!.send("print_protection", this.contentProtectionConfig.protectPrinting);
         }
+
+        // Send resize-watch targets
+        this.resizeWatchSelectors.forEach(selector => {
+            this.comms!.send("decoration_resize", { action: "watch", selector });
+        });
+    }
+
+    addResizeTarget(selector: string): void {
+        if (!this.resizeWatchSelectors.includes(selector)) this.resizeWatchSelectors.push(selector);
+        if (this.comms?.ready) this.comms.send("decoration_resize", { action: "watch", selector });
+    }
+
+    removeResizeTarget(selector: string): void {
+        this.resizeWatchSelectors = this.resizeWatchSelectors.filter(s => s !== selector);
+        if (this.comms?.ready) this.comms.send("decoration_resize", { action: "unwatch", selector });
     }
 
     async destroy() {

--- a/navigator/src/webpub/WebPubFramePoolManager.ts
+++ b/navigator/src/webpub/WebPubFramePoolManager.ts
@@ -17,6 +17,7 @@ export class WebPubFramePoolManager {
     private readonly injector?: Injector | null = null;
     private readonly contentProtectionConfig: IContentProtectionConfig;
     private readonly keyboardPeripheralsConfig: IKeyboardPeripheralsConfig;
+    private resizeWatchSelectors: string[];
     private readonly getFragmentIds: (href: string) => string[];
 
     constructor(
@@ -25,7 +26,8 @@ export class WebPubFramePoolManager {
         injector?: Injector | null,
         contentProtectionConfig: IContentProtectionConfig = {},
         keyboardPeripheralsConfig: IKeyboardPeripheralsConfig = [],
-        getFragmentIds?: (href: string) => string[]
+        getFragmentIds?: (href: string) => string[],
+        resizeWatchSelectors: string[] = []
     ) {
         this.container = container;
         this.currentCssProperties = cssProperties;
@@ -33,6 +35,20 @@ export class WebPubFramePoolManager {
         this.contentProtectionConfig = contentProtectionConfig;
         this.keyboardPeripheralsConfig = [...keyboardPeripheralsConfig];
         this.getFragmentIds = getFragmentIds ?? (() => []);
+        this.resizeWatchSelectors = [...resizeWatchSelectors];
+    }
+
+    addResizeTarget(selector: string): void {
+        if (!this.resizeWatchSelectors.includes(selector)) this.resizeWatchSelectors.push(selector);
+        // Forward to the whole pool, not just currentFrames: off-screen cached frames
+        // (preloaded within the pool's boundary window) must not keep stale state that
+        // resurfaces if they're shown again later without being recreated.
+        this.pool.forEach(f => f.addResizeTarget(selector));
+    }
+
+    removeResizeTarget(selector: string): void {
+        this.resizeWatchSelectors = this.resizeWatchSelectors.filter(s => s !== selector);
+        this.pool.forEach(f => f.removeResizeTarget(selector));
     }
 
     async destroy() {
@@ -157,7 +173,7 @@ export class WebPubFramePoolManager {
                     this.blobs.set(href, blobURL);
                 }
 
-                const fm = new WebPubFrameManager(this.blobs.get(href)!, this.contentProtectionConfig, this.keyboardPeripheralsConfig, this.getFragmentIds(href));
+                const fm = new WebPubFrameManager(this.blobs.get(href)!, this.contentProtectionConfig, this.keyboardPeripheralsConfig, this.getFragmentIds(href), this.resizeWatchSelectors);
                 if(href !== newHref) await fm.hide();
                 this.container.appendChild(fm.iframe);
                 await fm.load(modules);

--- a/navigator/src/webpub/WebPubNavigator.ts
+++ b/navigator/src/webpub/WebPubNavigator.ts
@@ -100,6 +100,7 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
     private _decorationActivationState: Map<string, boolean> = new Map();
     private _decorationHoverState: Map<string, boolean> = new Map();
     private _decorationActivationConsumed = false;
+    private _decorationResizeSelectors: Set<string>;
 
     private webViewport: VisualNavigatorViewport = {
         readingOrder: [],
@@ -134,6 +135,7 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
         // Initialize content protection with provided config or default values
         this._contentProtection = configuration.contentProtection || {};
         this._decoratorConfig = configuration.decoratorConfig || {};
+        this._decorationResizeSelectors = new Set(this._decoratorConfig.resizeWatchSelectors ?? []);
 
         // Merge keyboard peripherals
         this._keyboardPeripherals = this.mergeKeyboardPeripherals(
@@ -200,7 +202,8 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
             (href) => this.pub.timeline.segmentsForHref(href)
                 .flatMap(item => item.references)
                 .map(ref => { const h = ref.indexOf('#'); return h >= 0 ? ref.slice(h + 1) : ''; })
-                .filter(Boolean)
+                .filter(Boolean),
+            [...this._decorationResizeSelectors]
         );
 
         await this.apply();
@@ -467,6 +470,7 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
         this._decorationHoveredDecorations.clear();
         this._decorationActivationState.clear();
         this._decorationHoverState.clear();
+        this._decorationResizeSelectors.clear();
     }
 
     // DecorableNavigator
@@ -518,6 +522,21 @@ export class WebPubNavigator extends VisualNavigator implements Configurable<Web
     private _sendDecorationHoverable(group: string, hoverable: boolean): void {
         const frame = this.framePool?.currentFrames[0];
         if (frame?.msg) frame.msg.send("decoration_hoverable", { group, hoverable });
+    }
+
+    // Watches an element within the current content document for resize, so decoration
+    // overlays relay out when it resizes even if the resource's own document size doesn't
+    // change. Forwarded to framePool the same way contentProtectionConfig/
+    // keyboardPeripheralsConfig are — applied on every frame show(), not replayed
+    // reactively off decoration state.
+    public addDecorationResizeTarget(selector: string): void {
+        this._decorationResizeSelectors.add(selector);
+        this.framePool?.addResizeTarget(selector);
+    }
+
+    public removeDecorationResizeTarget(selector: string): void {
+        this._decorationResizeSelectors.delete(selector);
+        this.framePool?.removeResizeTarget(selector);
     }
 
     public applyDecorations(decorations: Decoration[], group: string): void {


### PR DESCRIPTION
This addresses ab additional bug in Decorator: option `mask` did not clean things up properly, so switching to another style failed as it was tied to a now detached context/node. 

It also adds the ability to observe a list of elements through CSS Selectors. Since Decorator is tied to a window, it was not possible to observe resize events for an element. So if you have collapsible panels for instance, and a `div` where your content is highlighted being resized as a result, the decorations would not previously be repositioned properly.  